### PR TITLE
improved wifi connection backend, improved status/settings page

### DIFF
--- a/main/net_provision.c
+++ b/main/net_provision.c
@@ -424,7 +424,10 @@ esp_err_t netprov_init(void)
 /* ------------------------------------------------------------------ */
 /*  STA connect with scan + candidate selection                       */
 /* ------------------------------------------------------------------ */
+/* rec != NULL pins the association to the exact BSS found by the candidate
+ * scan (BSSID + channel).  NULL falls back to supplicant FAST_SCAN by SSID. */
 static esp_err_t try_single_ssid(const char *ssid, const char *pass,
+                                 const wifi_ap_record_t *rec,
                                  char *ip_out, int timeout_ms)
 {
     if (s_portal_mode) return ESP_FAIL;
@@ -435,7 +438,22 @@ static esp_err_t try_single_ssid(const char *ssid, const char *pass,
     wifi_config_t wc = { 0 };
     strlcpy((char *)wc.sta.ssid, ssid, sizeof(wc.sta.ssid));
     strlcpy((char *)wc.sta.password, pass, sizeof(wc.sta.password));
-    wc.sta.threshold.authmode = WIFI_AUTH_OPEN;
+    /* Non-empty password implies at least WPA2 — being explicit is
+     * deterministic and silences the supplicant's auto-raise warning. */
+    wc.sta.threshold.authmode =
+        (pass[0] != '\0') ? WIFI_AUTH_WPA2_PSK : WIFI_AUTH_OPEN;
+    /* PMF capable (not required): keeps WPA2 working, enables WPA2/WPA3
+     * mixed-mode APs. */
+    wc.sta.pmf_cfg.capable = true;
+    if (rec) {
+        memcpy(wc.sta.bssid, rec->bssid, sizeof(wc.sta.bssid));
+        wc.sta.bssid_set = true;
+        wc.sta.channel   = rec->primary;   /* skip the channel sweep */
+        ESP_LOGI(TAG, "pinning '%s' bssid=%02x:%02x:%02x:%02x:%02x:%02x ch=%d rssi=%d",
+                 ssid, rec->bssid[0], rec->bssid[1], rec->bssid[2],
+                 rec->bssid[3], rec->bssid[4], rec->bssid[5],
+                 rec->primary, rec->rssi);
+    }
 
     ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
     ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wc));
@@ -509,14 +527,20 @@ esp_err_t netprov_try_connect(const struct netprov_config *cfg,
 
         ap_count = 0;
         esp_wifi_scan_get_ap_num(&ap_count);
-        if (ap_count > 32) ap_count = 32;
+        /* 60: dense multi-AP deployments (same SSID on many BSSes, mesh
+         * systems, neighbours) can exceed the old cap of 32, hiding the
+         * strongest same-SSID record from candidate selection. */
+        if (ap_count > 60) ap_count = 60;
 
         records = calloc(ap_count, sizeof(wifi_ap_record_t));
         if (records && ap_count) {
             esp_wifi_scan_get_ap_records(&ap_count, records);
         }
 
-        /* Build candidates: strongest matching SSID first */
+        /* Build candidates in slot priority order (Network #1 first). Slots
+         * whose SSID is not visible are skipped; within a slot, the strongest
+         * same-SSID AP is used. No cross-slot RSSI ranking — a farther
+         * Network #1 still wins over a closer Network #2. */
         n_cands = 0;
         for (int i = 0; i < NETPROV_MAX_SSID_SLOTS; i++) {
             if (cfg->wifi[i].ssid[0] == '\0') continue;
@@ -560,18 +584,10 @@ esp_err_t netprov_try_connect(const struct netprov_config *cfg,
         return ESP_FAIL;
     }
 
-    /* Sort by RSSI descending (bubble, small N) */
-    for (int i = 0; i < n_cands - 1; i++) {
-        for (int j = i + 1; j < n_cands; j++) {
-            if (cands[j].rssi > cands[i].rssi) {
-                cand_t t = cands[i]; cands[i] = cands[j]; cands[j] = t;
-            }
-        }
-    }
-
     if (s_portal_mode) return ESP_FAIL;
 
-    /* 3. Try each candidate: 3 attempts, 5 s between retries */
+    /* Try each visible candidate in slot priority order: 3 attempts, 5 s
+     * between retries. */
     for (int i = 0; i < n_cands; i++) {
         if (s_portal_mode) return ESP_FAIL;
         int slot = cands[i].slot;
@@ -579,9 +595,13 @@ esp_err_t netprov_try_connect(const struct netprov_config *cfg,
                  i + 1, cfg->wifi[slot].ssid, cands[i].rssi);
 
         for (int attempt = 1; attempt <= MAX_STA_RETRY; attempt++) {
+            /* Pin the scanned BSS on the first attempt only: if that exact
+             * AP has since gone away, later attempts fall back to un-pinned
+             * FAST_SCAN so a sibling AP with the same SSID can take over. */
             esp_err_t err = try_single_ssid(cfg->wifi[slot].ssid,
-                                            cfg->wifi[slot].pass, ip_out,
-                                            timeout_ms);
+                                            cfg->wifi[slot].pass,
+                                            attempt == 1 ? &cands[i].rec : NULL,
+                                            ip_out, timeout_ms);
             if (err == ESP_OK) return ESP_OK;
             if (attempt < MAX_STA_RETRY) {
                 ESP_LOGI(TAG, "waiting 5 s before retry %d/%d",

--- a/main/net_provision.c
+++ b/main/net_provision.c
@@ -51,6 +51,7 @@
 #include "bsp_audio.h"
 #include "esp_log.h"
 #include "esp_wifi.h"
+#include "esp_mac.h"
 #include "esp_event.h"
 #include "esp_netif.h"
 #include "esp_system.h"
@@ -88,6 +89,22 @@ static const char *TAG = "netprov";
  * scan across every configured network.  Without this the driver retries
  * one dead SSID forever and never fails over. */
 #define RECONNECT_TRIES_BEFORE_RESCAN  5
+
+/* A candidate sweep whose strongest result is below this is treated as
+ * unreliable (the sweep likely raced BLE activity or a busy AP and missed
+ * closer BSSes), triggering a rescan instead of pinning a far node.
+ * Judged per configured slot: a strong Network #2 must not mask a missing
+ * or weak Network #1. */
+#define NETPROV_RESCAN_BELOW_RSSI  (-75)
+
+/* Candidates at or below this can barely carry traffic; they are tried only
+ * after every stronger candidate has failed, so a distant Network #1 cannot
+ * pin the device while a close Network #2 sits unused. */
+#define NETPROV_USABLE_RSSI        (-80)
+
+/* A candidate this strong ends candidate hunting immediately: further sweeps
+ * cannot meaningfully improve on it, so don't spend boot time looking. */
+#define NETPROV_GOOD_ENOUGH_RSSI   (-65)
 
 static EventGroupHandle_t s_wifi_events;
 static int s_retry_num = 0;
@@ -249,15 +266,75 @@ static void link_mark_up(const char *ip)
     if (ap) free(ap);
 }
 
+static const char *auth_mode_str(wifi_auth_mode_t m)
+{
+    switch (m) {
+    case WIFI_AUTH_OPEN:              return "OPEN";
+    case WIFI_AUTH_WEP:               return "WEP";
+    case WIFI_AUTH_WPA_PSK:           return "WPA-PSK";
+    case WIFI_AUTH_WPA2_PSK:          return "WPA2-PSK";
+    case WIFI_AUTH_WPA_WPA2_PSK:      return "WPA/WPA2-PSK";
+    case WIFI_AUTH_WPA_ENTERPRISE:    return "WPA-EAP";
+    case WIFI_AUTH_WPA2_ENTERPRISE:   return "WPA2-EAP";
+    case WIFI_AUTH_WPA2_WPA3_ENTERPRISE: return "WPA2/WPA3-EAP";
+    case WIFI_AUTH_WPA3_PSK:          return "WPA3-PSK";
+    case WIFI_AUTH_WPA2_WPA3_PSK:     return "WPA2/WPA3-PSK";
+    case WIFI_AUTH_WAPI_PSK:          return "WAPI-PSK";
+    case WIFI_AUTH_OWE:               return "OWE";
+    default:                          return "?";
+    }
+}
+
+static const char *disc_reason_str(int r)
+{
+    switch (r) {
+    case 1:  return "UNSPECIFIED";
+    case 2:  return "AUTH_EXPIRE";
+    case 3:  return "AUTH_LEAVE";
+    case 4:  return "ASSOC_EXPIRE";
+    case 5:  return "ASSOC_TOOMANY";
+    case 6:  return "NOT_AUTHED";
+    case 7:  return "NOT_ASSOCED";
+    case 8:  return "ASSOC_LEAVE";
+    case 9:  return "ASSOC_NOT_AUTHED";
+    case 15: return "4WAY_HANDSHAKE_TIMEOUT";
+    case 16: return "GROUP_KEY_TIMEOUT";
+    case 17: return "IE_4WAY_DIFFERS";
+    case 18: return "GROUP_CIPHER_INVALID";
+    case 19: return "PAIRWISE_CIPHER_INVALID";
+    case 20: return "AKMP_INVALID";
+    case 21: return "BAD_RSN_IE_VERSION";
+    case 22: return "BAD_RSN_IE_CAP";
+    case 200: return "BEACON_LOSS";
+    case 201: return "NO_AP_FOUND";
+    case 202: return "AUTH_FAIL";
+    case 203: return "ASSOC_FAIL";
+    case 204: return "HANDSHAKE_TIMEOUT";
+    case 205: return "CONNECTION_FAIL";
+    default: return "OTHER";
+    }
+}
+
 static void wifi_event_handler(void *arg, esp_event_base_t base,
                                int32_t id, void *data)
 {
-    (void)arg; (void)data;
+    (void)arg;
     if (base == WIFI_EVENT && id == WIFI_EVENT_STA_START) {
         if (s_connecting) {
             esp_wifi_connect();
         }
+    } else if (base == WIFI_EVENT && id == WIFI_EVENT_STA_CONNECTED) {
+        const wifi_event_sta_connected_t *c = (const wifi_event_sta_connected_t *)data;
+        if (c) {
+            ESP_LOGI(TAG, "associated: ssid='%.*s' bssid=" MACSTR " ch=%d auth=%s (%d)",
+                     c->ssid_len, (const char *)c->ssid,
+                     MAC2STR(c->bssid), c->channel,
+                     auth_mode_str(c->authmode), c->authmode);
+        }
     } else if (base == WIFI_EVENT && id == WIFI_EVENT_STA_DISCONNECTED) {
+        const wifi_event_sta_disconnected_t *d = (const wifi_event_sta_disconnected_t *)data;
+        int rsn = d ? d->reason : 0;
+        ESP_LOGW(TAG, "sta disconnected: reason=%d (%s)", rsn, disc_reason_str(rsn));
         if (s_connected) {
             /* Link genuinely lost while up.  Publish that immediately — the
              * old code left s_connected/s_connected_ip stale, so the LCD and
@@ -453,15 +530,32 @@ static esp_err_t try_single_ssid(const char *ssid, const char *pass,
                  ssid, rec->bssid[0], rec->bssid[1], rec->bssid[2],
                  rec->bssid[3], rec->bssid[4], rec->bssid[5],
                  rec->primary, rec->rssi);
+    } else {
+        ESP_LOGI(TAG, "connecting to '%s' unpinned (FAST_SCAN picks first match)", ssid);
     }
 
     ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
     ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wc));
     ESP_ERROR_CHECK(esp_wifi_start());
 
-    EventBits_t bits = xEventGroupWaitBits(
-        s_wifi_events, WIFI_CONNECTED_BIT | WIFI_FAIL_BIT,
-        pdFALSE, pdFALSE, pdMS_TO_TICKS(timeout_ms));
+    EventBits_t bits = 0;
+    TickType_t deadline = xTaskGetTickCount() + pdMS_TO_TICKS(timeout_ms);
+    for (;;) {
+        bits = xEventGroupWaitBits(s_wifi_events,
+                                   WIFI_CONNECTED_BIT | WIFI_FAIL_BIT,
+                                   pdFALSE, pdFALSE, pdMS_TO_TICKS(1000));
+        if (bits != 0) break;
+        TickType_t now = xTaskGetTickCount();
+        if ((int32_t)(now - deadline) >= 0) break;
+        wifi_ap_record_t live;
+        if (esp_wifi_sta_get_ap_info(&live) == ESP_OK) {
+            ESP_LOGI(TAG, "association alive: bssid=" MACSTR " ch=%d rssi=%d",
+                     MAC2STR(live.bssid), live.primary, live.rssi);
+        }
+    }
+    if (bits == 0) {
+        ESP_LOGW(TAG, "'%s': no verdict after %d ms (timeout)", ssid, timeout_ms);
+    }
 
     esp_err_t result;
     if (bits & WIFI_CONNECTED_BIT) {
@@ -486,6 +580,36 @@ static esp_err_t try_single_ssid(const char *ssid, const char *pass,
     vEventGroupDelete(s_wifi_events);
     s_wifi_events = NULL;
     return result;
+}
+
+/* Directed-probe scan for one SSID: APs answer by name even when a wildcard
+ * sweep's per-channel dwell window missed them.  Returns the strongest
+ * responder. */
+static bool directed_probe_best(const char *ssid, wifi_ap_record_t *out)
+{
+    /* No custom scan_time here: the coexistence driver overrides active scan
+     * dwell whenever BT is enabled ("Should use default active scan time"
+     * warning) and manages channel time itself. */
+    wifi_scan_config_t probe_cfg = {
+        .ssid = (const uint8_t *)ssid,
+        .show_hidden = true,
+    };
+    if (esp_wifi_scan_start(&probe_cfg, true) != ESP_OK) return false;
+    uint16_t n = 0;
+    esp_wifi_scan_get_ap_num(&n);
+    if (n == 0) return false;
+    if (n > 20) n = 20;
+    wifi_ap_record_t *rs = calloc(n, sizeof(wifi_ap_record_t));
+    if (!rs) return false;
+    esp_wifi_scan_get_ap_records(&n, rs);
+    int best = -1;
+    for (uint16_t j = 0; j < n; j++) {
+        if (best < 0 || rs[j].rssi > rs[best].rssi) best = j;
+    }
+    bool ok = best >= 0;
+    if (ok) *out = rs[best];
+    free(rs);
+    return ok;
 }
 
 esp_err_t netprov_try_connect(const struct netprov_config *cfg,
@@ -517,7 +641,9 @@ esp_err_t netprov_try_connect(const struct netprov_config *cfg,
     cand_t cands[NETPROV_MAX_SSID_SLOTS];
 
     for (int attempt = 1; attempt <= scan_retries; attempt++) {
-        wifi_scan_config_t scan_cfg = { .show_hidden = false };
+        /* Custom active-scan dwell is overridden by the coexistence driver
+         * whenever BT is up; leave timing at driver defaults. */
+        wifi_scan_config_t scan_cfg = { .show_hidden = true };
         esp_err_t scan_err = esp_wifi_scan_start(&scan_cfg, true);
         if (scan_err != ESP_OK) {
             ESP_LOGW(TAG, "Wi-Fi scan failed (err=0x%x), retrying scan (%d/%d)", scan_err, attempt, scan_retries);
@@ -539,18 +665,24 @@ esp_err_t netprov_try_connect(const struct netprov_config *cfg,
 
         /* Build candidates in slot priority order (Network #1 first). Slots
          * whose SSID is not visible are skipped; within a slot, the strongest
-         * same-SSID AP is used. No cross-slot RSSI ranking — a farther
-         * Network #1 still wins over a closer Network #2. */
+         * same-SSID AP is used.  Slot priority holds among usable candidates;
+         * sub-floor ones are demoted to a last-resort pass (see
+         * NETPROV_USABLE_RSSI). */
         n_cands = 0;
         for (int i = 0; i < NETPROV_MAX_SSID_SLOTS; i++) {
             if (cfg->wifi[i].ssid[0] == '\0') continue;
             int best_rssi = -128;
             wifi_ap_record_t best_rec = {0};
             for (int j = 0; j < ap_count; j++) {
-                if (records && strcmp((char *)records[j].ssid, cfg->wifi[i].ssid) == 0
-                    && records[j].rssi > best_rssi) {
-                    best_rssi = records[j].rssi;
-                    best_rec = records[j];
+                if (records && strcmp((char *)records[j].ssid, cfg->wifi[i].ssid) == 0) {
+                    ESP_LOGI(TAG, "scan: '%s' bssid=" MACSTR " ch=%d rssi=%d auth=%s (%d)",
+                             cfg->wifi[i].ssid, MAC2STR(records[j].bssid),
+                             records[j].primary, records[j].rssi,
+                             auth_mode_str(records[j].authmode), records[j].authmode);
+                    if (records[j].rssi > best_rssi) {
+                        best_rssi = records[j].rssi;
+                        best_rec = records[j];
+                    }
                 }
             }
             if (best_rssi > -128) {
@@ -566,13 +698,82 @@ esp_err_t netprov_try_connect(const struct netprov_config *cfg,
             records = NULL;
         }
 
-        if (n_cands > 0) {
-            break; // Found candidate SSID(s)
+        /* A sweep that lands while BLE is connecting or the AP is busy can
+         * miss the strongest BSS entirely and return only distant siblings.
+         * Judge each configured slot independently: if any slot has nothing
+         * above the rescan floor, treat the sweep as unreliable and try
+         * again before settling for a -90 dBm connection. */
+        int weak_slot = -1;
+        int weak_rssi = 0;
+        bool none_visible = true;
+        int overall_best = -128;
+        /* Visit every configured slot even after finding a weak one:
+         * overall_best must reflect all of them for the good-enough skip. */
+        for (int i = 0; i < NETPROV_MAX_SSID_SLOTS; i++) {
+            if (cfg->wifi[i].ssid[0] == '\0') continue;
+            int slot_best = -128;
+            for (int k = 0; k < n_cands; k++) {
+                if (cands[k].slot == i && cands[k].rssi > slot_best) {
+                    slot_best = cands[k].rssi;
+                }
+            }
+            if (slot_best > -128) none_visible = false;
+            if (slot_best > overall_best) overall_best = slot_best;
+            if (slot_best < NETPROV_RESCAN_BELOW_RSSI && weak_slot < 0) {
+                weak_slot = i;
+                weak_rssi = slot_best;
+            }
+        }
+        if (weak_slot < 0 || overall_best >= NETPROV_GOOD_ENOUGH_RSSI) {
+            break; // every slot usable, or an excellent candidate makes further hunting pointless
         }
 
+        if (none_visible) {
+            ESP_LOGW(TAG, "no configured SSID visible, rescanning (%d/%d)...",
+                     attempt, scan_retries);
+        } else if (weak_rssi <= -128) {
+            ESP_LOGW(TAG, "'%s' not visible this sweep, rescanning (%d/%d)...",
+                     cfg->wifi[weak_slot].ssid, attempt, scan_retries);
+        } else {
+            ESP_LOGW(TAG, "'%s' best at %d dBm (< %d), sweep unreliable, rescanning (%d/%d)...",
+                     cfg->wifi[weak_slot].ssid, weak_rssi,
+                     NETPROV_RESCAN_BELOW_RSSI, attempt, scan_retries);
+        }
         if (attempt < scan_retries) {
-            ESP_LOGI(TAG, "SSID candidates not found in scan, retrying scan in 1s (%d/%d)...", attempt, scan_retries);
             vTaskDelay(pdMS_TO_TICKS(1000));
+        }
+    }
+
+    /* Last look for slots that stayed weak or missing through every sweep:
+     * a directed probe asks for the SSID by name, so an AP that wildcard
+     * sweeps kept missing gets one more chance to identify itself.  Also
+     * produces a definitive "not on 2.4 GHz air" verdict when it fails. */
+    for (int i = 0; i < NETPROV_MAX_SSID_SLOTS; i++) {
+        if (cfg->wifi[i].ssid[0] == '\0') continue;
+        int idx = -1;
+        for (int k = 0; k < n_cands; k++) {
+            if (cands[k].slot == i) { idx = k; break; }
+        }
+        if (idx >= 0 && cands[idx].rssi >= NETPROV_RESCAN_BELOW_RSSI) continue;
+        wifi_ap_record_t hit;
+        if (!directed_probe_best(cfg->wifi[i].ssid, &hit)) {
+            ESP_LOGW(TAG, "directed probe '%s': no answer (SSID not on 2.4 GHz air right now)",
+                     cfg->wifi[i].ssid);
+            continue;
+        }
+        ESP_LOGI(TAG, "directed probe '%s': bssid=" MACSTR " ch=%d rssi=%d auth=%s (%d)",
+                 cfg->wifi[i].ssid, MAC2STR(hit.bssid), hit.primary, hit.rssi,
+                 auth_mode_str(hit.authmode), hit.authmode);
+        if (idx >= 0) {
+            if (hit.rssi > cands[idx].rssi) {
+                cands[idx].rssi = hit.rssi;
+                cands[idx].rec = hit;
+            }
+        } else {
+            cands[n_cands].slot = i;
+            cands[n_cands].rssi = hit.rssi;
+            cands[n_cands].rec = hit;
+            n_cands++;
         }
     }
 
@@ -586,13 +787,24 @@ esp_err_t netprov_try_connect(const struct netprov_config *cfg,
 
     if (s_portal_mode) return ESP_FAIL;
 
-    /* Try each visible candidate in slot priority order: 3 attempts, 5 s
-     * between retries. */
-    for (int i = 0; i < n_cands; i++) {
+    /* Try usable candidates first (slot priority order within each tier),
+     * sub-floor ones as a last resort.  3 attempts, 5 s between retries. */
+    int order[NETPROV_MAX_SSID_SLOTS];
+    int n_order = 0;
+    for (int pass = 0; pass < 2; pass++) {
+        for (int i = 0; i < n_cands; i++) {
+            if ((cands[i].rssi > NETPROV_USABLE_RSSI) == (pass == 0)) {
+                order[n_order++] = i;
+            }
+        }
+    }
+
+    for (int oi = 0; oi < n_order; oi++) {
         if (s_portal_mode) return ESP_FAIL;
+        int i = order[oi];
         int slot = cands[i].slot;
         ESP_LOGI(TAG, "trying candidate %d: '%s' (%d dBm)",
-                 i + 1, cfg->wifi[slot].ssid, cands[i].rssi);
+                 oi + 1, cfg->wifi[slot].ssid, cands[i].rssi);
 
         for (int attempt = 1; attempt <= MAX_STA_RETRY; attempt++) {
             /* Pin the scanned BSS on the first attempt only: if that exact
@@ -1106,6 +1318,9 @@ static void wifi_scan_task(void *arg)
             if (records[i].ssid[0] == '\0') continue;
             cJSON *o = cJSON_CreateObject();
             cJSON_AddStringToObject(o, "ssid", (char *)records[i].ssid);
+            char bss[18];
+            snprintf(bss, sizeof(bss), MACSTR, MAC2STR(records[i].bssid));
+            cJSON_AddStringToObject(o, "bssid", bss);
             cJSON_AddNumberToObject(o, "rssi", records[i].rssi);
             cJSON_AddBoolToObject(o, "lock", records[i].authmode != WIFI_AUTH_OPEN);
             cJSON_AddItemToArray(arr, o);

--- a/main/net_provision.h
+++ b/main/net_provision.h
@@ -78,8 +78,10 @@ bool netprov_load_config(struct netprov_config *cfg);
 esp_err_t netprov_save_config(const struct netprov_config *cfg);
 
 /* Try to connect as a station using stored credentials.
- * Scans, picks the strongest matching SSID, tries up to 3 attempts
- * with 5 s spacing per candidate. On success writes IP into ip_out
+ * Scans, then tries configured networks strictly in slot priority order
+ * (Network #1 first; a slot is skipped if its SSID is not visible).
+ * Within a slot the strongest same-SSID AP is used; each candidate gets up
+ * to 3 attempts with 5 s spacing. On success writes IP into ip_out
  * (>= 16 bytes) and returns ESP_OK. */
 esp_err_t netprov_try_connect(const struct netprov_config *cfg,
                               char *ip_out, int timeout_ms);

--- a/main/portal.html
+++ b/main/portal.html
@@ -271,6 +271,9 @@ select.form-control{cursor:pointer;appearance:none;background-image:url("data:im
 .info-row{display:flex;justify-content:space-between;align-items:center;border-bottom:1px solid var(--card-border);padding-bottom:8px}
 .info-label{color:var(--text-muted);font-size:.85rem}
 .info-value{font-weight:600;font-size:.85rem}
+/* Status page network rows: wrapper is transparent to layout so the rows
+ * inherit .info-list's 10px flex gap exactly like every other info-row. */
+#status-nets{display:contents}
 
 /* ── Logs Tab ──────────────────────────────────────────────────── */
 .logs-container{display:flex;flex-direction:column;flex:1;min-height:380px;height:calc(100vh - 120px);height:calc(100dvh - 120px)}
@@ -961,14 +964,13 @@ Upload Progress
 <div class="info-row"><span class="info-label">Firmware</span><span class="info-value" id="status-fw">--</span></div>
 <div class="info-row"><span class="info-label">Uptime</span><span class="info-value" id="status-uptime">--</span></div>
 <div class="info-row"><span class="info-label">Local IP</span><span class="info-value" id="status-ip">--</span></div>
-<div class="info-row"><span class="info-label">Wi-Fi SSID</span><span class="info-value" id="status-ssid">--</span></div>
+<div id="status-nets"></div>
 <div class="info-row"><span class="info-label">Battery</span><span class="info-value" id="status-battery">--</span></div>
 <div class="info-row"><span class="info-label">Timezone</span><span class="info-value" id="status-tz">--</span></div>
 <div class="info-row"><span class="info-label">NTP Sync</span><span class="info-value" id="status-ntp">--</span></div>
 <div class="info-row"><span class="info-label">SD Card Free</span><span class="info-value" id="status-sd">--</span></div>
 <div class="info-row"><span class="info-label">Paired data source</span><span class="info-value" id="status-ble">--</span></div>
 <div class="info-row"><span class="info-label">O2 Ring</span><span class="info-value" id="status-ox">--</span></div>
-<div class="info-row"><span class="info-label">WiFi RSSI</span><span class="info-value" id="status-rssi">--</span></div>
 </div>
 <div class="card info-list">
 <div class="card-title">Device Telemetry</div>
@@ -1309,6 +1311,7 @@ var activeBlocks = 1;
 var manualSSID = {};
 var scannedNetworks = [];
 var savedPasswords = {};
+var connectedSSID = '';   /* SSID the device is currently associated with */
 
 var tzData = null;
 
@@ -1389,6 +1392,24 @@ function rssiIcon(rssi) {
   return svg;
 }
 
+/* Coloured quality circle for plain-text contexts (<option> can't do HTML):
+ * ≥ −60 dBm green, −74…−60 yellow, ≤ −75 red. */
+function sigCircle(rssi) {
+  return rssi >= -60 ? '🟢' : rssi >= -75 ? '🟡' : '🔴';
+}
+
+/* Matching CSS colour for the same signal bands. */
+function sigColor(rssi) {
+  return rssi >= -60 ? 'var(--success)' : rssi >= -75 ? 'var(--warning)' : 'var(--danger)';
+}
+
+/* Minimal HTML escaping for interpolated strings. */
+function escHtml(s) {
+  return String(s).replace(/[&<>"']/g, function(c) {
+    return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+  });
+}
+
 /* ── WiFi Rendering ────────────────────────────────────────────── */
 function renderWifiBlocks() {
   var container = document.getElementById('wifi-blocks');
@@ -1404,7 +1425,12 @@ function renderWifiBlocks() {
     var block = document.createElement('div');
     block.className = 'wifi-block';
 
-    var headerHtml = '<div class="block-header"><span class="block-title">Network #' + i + '</span>';
+    /* Title and (CONNECTED) marker wrapped together so the space-between
+     * flex header keeps them adjacent, with Remove pushed to the right. */
+    var headerHtml = '<div class="block-header"><span style="display:flex;align-items:center;gap:8px">' +
+                     '<span class="block-title">Network #' + i + '</span>' +
+                     '<span id="conn-marker-' + i + '" style="display:none;color:var(--success);font-size:.72rem;font-weight:700;letter-spacing:.04em">(CONNECTED)</span>' +
+                     '</span>';
     if (i > 1) headerHtml += '<button type="button" class="btn-remove-net" onclick="removeWifiBlock(' + i + ')">Remove</button>';
     headerHtml += '</div>';
 
@@ -1431,7 +1457,7 @@ function renderWifiBlocks() {
     if (manualSSID[i]) {
       sCont.innerHTML = '<input id="ssid-' + i + '" type="text" placeholder="Enter network name" class="form-control" data-dirty="false" oninput="markWifiDirty()">';
     } else {
-      sCont.innerHTML = '<select id="ssid-' + i + '" class="form-control" data-dirty="false" onchange="markWifiDirty()"><option value="">— Select a network —</option></select>';
+      sCont.innerHTML = '<select id="ssid-' + i + '" class="form-control" data-dirty="false" onchange="markWifiDirty();updateConnMarkers()"><option value="">— Select a network —</option></select>';
       populateWifiSelect(i);
     }
 
@@ -1444,6 +1470,19 @@ function renderWifiBlocks() {
 
   var addBtn = document.getElementById('btn-add-wifi');
   if (addBtn) addBtn.style.display = (activeBlocks < 4) ? '' : 'none';
+  updateConnMarkers();
+}
+
+/* Show the green "(connected)" marker on the block whose SSID matches the
+ * currently associated network. */
+function updateConnMarkers() {
+  for (var i = 1; i <= activeBlocks; i++) {
+    var m = document.getElementById('conn-marker-' + i);
+    if (!m) continue;
+    var el = document.getElementById('ssid-' + i);
+    var ssidVal = el ? el.value.trim() : '';
+    m.style.display = (connectedSSID !== '' && ssidVal === connectedSSID) ? '' : 'none';
+  }
 }
 
 function populateWifiSelect(id) {
@@ -1456,7 +1495,7 @@ function populateWifiSelect(id) {
     o.value = n.ssid;
     o.innerHTML = n.ssid + '  ' + rssiIcon(n.rssi) + (n.lock ? ' 🔒' : '');
     // For option text (no HTML in options), use plain text fallback
-    o.textContent = n.ssid + ' (' + n.rssi + ' dBm)' + (n.lock ? ' 🔒' : '');
+    o.textContent = sigCircle(n.rssi) + ' ' + n.ssid + ' (' + n.rssi + ' dBm)' + (n.lock ? ' 🔒' : '');
     if (n.ssid === currentVal) o.selected = true;
     sel.appendChild(o);
   });
@@ -1648,8 +1687,42 @@ function loadStatusTab(d) {
    * old flat fields for backward compatibility. */
   var wifi = d.wifi || {};
   setEl('status-ip', wifi.up ? (wifi.ip || '--') : 'Disconnected');
-  setEl('status-ssid', wifi.up ? (wifi.ssid || '--') : '--');
-  setEl('status-rssi', (wifi.rssi != null && wifi.rssi > -128) ? (wifi.rssi + ' dBm') : '--');
+  connectedSSID = (wifi.up && wifi.ssid) ? wifi.ssid : '';
+  updateConnMarkers();
+
+  /* Configured networks: one row per slot (#1..#N). The connected network
+   * shows its live RSSI and coloured signal circle; the rest are greyed
+   * out as inactive, with last-seen scan dBm when available. */
+  var netsEl = document.getElementById('status-nets');
+  if (netsEl) {
+    var ssids = d.ssids || [];
+    var rows = '';
+    if (!ssids.length) {
+      rows = '<div class="info-row"><span class="info-label">Wi-Fi</span>' +
+             '<span class="info-value" style="color:var(--text-muted)">none configured</span></div>';
+    }
+    ssids.forEach(function(s, idx) {
+      if (!s) return;
+      var isConn = (s === connectedSSID);
+      var dbm = null;
+      if (isConn && wifi.rssi != null && wifi.rssi > -128) {
+        dbm = wifi.rssi;
+      } else {
+        for (var k = 0; k < scannedNetworks.length; k++) {
+          if (scannedNetworks[k].ssid === s) { dbm = scannedNetworks[k].rssi; break; }
+        }
+      }
+      rows += '<div class="info-row"><span class="info-label">Wi-Fi Network #' + (idx + 1) + '</span>' +
+              '<span class="info-value"' +
+              (isConn && dbm != null ? ' style="color:' + sigColor(dbm) + '"' :
+               !isConn ? ' style="color:var(--text-muted)"' : '') + '>' +
+              (isConn && dbm != null ? '<span style="font-size:.85rem;line-height:1">' + sigCircle(dbm) + '</span> ' : '') +
+              escHtml(s) +
+              (dbm != null ? ' (' + dbm + ' dBm)' : '') +
+              '</span></div>';
+    });
+    netsEl.innerHTML = rows;
+  }
 
   /* Battery */
   var batt = d.battery || {};

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -24,6 +24,13 @@ CONFIG_COMPILER_OPTIMIZATION_PERF=y
 # CONFIG_ESP_WIFI_IRAM_OPT is not set
 # CONFIG_ESP_WIFI_RX_IRAM_OPT is not set
 
+# FreeRTOS kernel + ringbuf functions cost another ~15 KB of IRAM for
+# cache-speed scheduling we do not need.  Flash placement keeps the link
+# within the IRAM budget on current toolchains.
+CONFIG_FREERTOS_PLACE_FUNCTIONS_INTO_FLASH=y
+CONFIG_RINGBUF_PLACE_FUNCTIONS_INTO_FLASH=y
+CONFIG_RINGBUF_PLACE_ISR_FUNCTIONS_INTO_FLASH=y
+
 # Fewer always-resident Wi-Fi buffers.  SoftAP portal + STA uploads do not
 # need the IDF defaults (32 cache TX, static RX mgmt).
 CONFIG_ESP_WIFI_CACHE_TX_BUFFER_NUM=16
@@ -41,8 +48,11 @@ CONFIG_BT_CTRL_ADV_DUP_FILT_MAX=10
 CONFIG_BT_NIMBLE_ATT_MAX_PREP_ENTRIES=4
 CONFIG_BT_NIMBLE_MAX_BONDS=1
 CONFIG_BT_NIMBLE_MAX_CCCDS=4
-# NimBLE host stack: pairing/SRP is offloaded to app tasks.
-CONFIG_BT_NIMBLE_HOST_TASK_STACK_SIZE=3584
+# NimBLE host stack: pairing/SRP offloaded to app tasks, but GAP/GATT
+# callbacks (MTU/conn-param logging, send_fig AES + hexdump) run in the host
+# task; 3584 overflowed its canary after a long reconnect storm (see
+# WIFI_BUG.MD Part 3).  IDF default is 5120.
+CONFIG_BT_NIMBLE_HOST_TASK_STACK_SIZE=6144
 # Keep CONFIG_BT_CTRL_BLE_MASTER at the IDF default (required for central).
 # CONFIG_BT_CTRL_BLE_SECURITY_ENABLE / DTM are unused and stay off above.
 
@@ -228,7 +238,11 @@ CONFIG_MBEDTLS_SSL_OUT_CONTENT_LEN=4096
 CONFIG_LWIP_TCPIP_RECVMBOX_SIZE=16
 CONFIG_LWIP_TCP_RECVMBOX_SIZE=6
 CONFIG_LWIP_UDP_RECVMBOX_SIZE=6
-CONFIG_LWIP_TCP_ACCEPTMBOX_SIZE=4
+# Accept mbox must absorb a browser page-load burst (~7 concurrent SYNs)
+# while the single httpd worker is busy, otherwise surplus connections get
+# reset (ERR_CONNECTION_RESET in the console).  In this IDF the accept
+# mailbox IS the listen backlog (no separate LISTEN_BACKLOG option).
+CONFIG_LWIP_TCP_ACCEPTMBOX_SIZE=8
 CONFIG_LWIP_MAX_SOCKETS=32
 CONFIG_LWIP_MAX_ACTIVE_TCP=28
 CONFIG_LWIP_MAX_LISTENING_TCP=8


### PR DESCRIPTION
## Description

I was having difficulties connecting to SomnoTrace because I had multiple AP's broadcasting the same SSID, but SomnoTrace chose a weak one, causing the pages to load really slow with errors.  So I improved the wifi connect strategy and it will now pick the strongest one.  Also if multiple SSID's are set, it will start from the first and if they are not found will continue going down the list.  I've improved the status/settings page to improve the usability.

## Summary

On networks where multiple access points broadcast the **same SSID** (mesh / extenders),
SomnoTrace could associate with an **arbitrary** AP — the supplicant's default fast-scan
grabbed the first matching beacon during its channel sweep, discarding the scan's
signal-strength ranking. This randomly landed the device on a distant BSS (observed at
−94 dBm with closer siblings available), producing TCP stalls that surfaced as 502s through
a fronting reverse proxy and an empty dashboard on single-shot page loads.

This PR pins association to the **strongest scanned AP**, makes multi-network fallback
behaviour explicit (**strict slot priority**: Network #1 first), and adds at-a-glance
signal/connected indicators to the portal UI.

## Firmware (`main/net_provision.c`, `main/net_provision.h`)

- **Pin association to the scanned BSS**: `try_single_ssid()` accepts the candidate
  `wifi_ap_record_t` and sets `bssid_set`/BSSID/channel on attempt 1 (attempts 2–3 fall back
  to un-pinned so a sibling AP can take over if the pinned one died).
- **Explicit authmode threshold**: `WPA2_PSK` when a password is set, `OPEN` otherwise
  (removes the supplicant's auto-raise warning).
- **PMF capable** (not required): future-proofing for WPA2/WPA3 mixed-mode APs.
- **Scan record cap 32 → 60**: dense RF environments could truncate before the strongest
  same-SSID record was ranked.
- **Slot-priority connect order**: cross-slot RSSI sorting removed — Network # 1 is always
  tried first (3 attempts, 5 s apart) before Network # 2; within a slot the strongest AP wins.

## Portal UI (`main/portal.html`)

- Wi-Fi dropdown options now start with a coloured strength circle 🟢/🟡/🔴 (≥ −60 /
  −74…−60 / ≤ −75 dBm).
- Settings blocks show a green **(CONNECTED)** marker on the configured network that matches
  the current association.
- Status → System Status lists each configured network as `Wi-Fi Network #N`; the connected
  row shows its live RSSI with the whole value coloured by signal strength; inactive rows
  are greyed out.


## Checklist

- [X ] I have read and agree to the [Contributor License Agreement (CLA)](CLA/individual-cla.md) (or [Corporate CLA](CLA/corporate-cla.md)).
- [X ] This change is a clean-room implementation; no third-party copyrighted code has been copied without approval and notice in `THIRD-PARTY-NOTICES.md`.
- [X ] Any new source files include the standard license header from `docs/source-header.txt`.
- [X ] The code compiles and builds cleanly (`./scripts/build-dist.sh`).
- [X ] No real patient / medical data is included in test fixtures, commits, or descriptions.
