### PR TITLE
fix: pin STA association to the strongest scanned BSS

### DIFF
--- a/main/net_provision.c
+++ b/main/net_provision.c
@@ -425,6 +425,7 @@ esp_err_t netprov_init(void)
 /*  STA connect with scan + candidate selection                       */
 /* ------------------------------------------------------------------ */
 static esp_err_t try_single_ssid(const char *ssid, const char *pass,
+                                 const wifi_ap_record_t *rec,
                                  char *ip_out, int timeout_ms)
 {
     if (s_portal_mode) return ESP_FAIL;
@@ -436,6 +437,11 @@ static esp_err_t try_single_ssid(const char *ssid, const char *pass,
     strlcpy((char *)wc.sta.ssid, ssid, sizeof(wc.sta.ssid));
     strlcpy((char *)wc.sta.password, pass, sizeof(wc.sta.password));
     wc.sta.threshold.authmode = WIFI_AUTH_OPEN;
+    if (rec) {
+        memcpy(wc.sta.bssid, rec->bssid, sizeof(wc.sta.bssid));
+        wc.sta.bssid_set = true;
+        wc.sta.channel   = rec->primary;
+    }
 
     ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
     ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wc));
@@ -580,8 +586,9 @@ esp_err_t netprov_try_connect(const struct netprov_config *cfg,
 
         for (int attempt = 1; attempt <= MAX_STA_RETRY; attempt++) {
             esp_err_t err = try_single_ssid(cfg->wifi[slot].ssid,
-                                            cfg->wifi[slot].pass, ip_out,
-                                            timeout_ms);
+                                            cfg->wifi[slot].pass,
+                                            &cands[i].rec,
+                                            ip_out, timeout_ms);
             if (err == ESP_OK) return ESP_OK;
             if (attempt < MAX_STA_RETRY) {
                 ESP_LOGI(TAG, "waiting 5 s before retry %d/%d",


### PR DESCRIPTION
## Problem

Where multiple access points broadcast the same SSID (mesh systems, extenders),
SomnoTrace could associate with an arbitrary one. The candidate scan measures
every visible BSS and keeps the strongest record per configured network
(`cands[i].rec`) — but `try_single_ssid()` received only the SSID string. The
supplicant's FAST_SCAN then swept channels and grabbed the *first* beacon
answering with that name, which on a multi-AP setup can be a distant BSS
(observed at -94 dBm while a strong sibling was metres away). The weak link
stalls TCP and surfaces as slow or failing page loads.

**Root cause:** the scan result was measured and ranked, then discarded —
`bssid`/`channel` never reached `esp_wifi_set_config()`.

## Change (9 lines)

Hand the winning record to the connect helper and lock the association to it:

```c
static esp_err_t try_single_ssid(const char *ssid, const char *pass,
                                 const wifi_ap_record_t *rec,
                                 char *ip_out, int timeout_ms)
{
    ...
    wc.sta.threshold.authmode = WIFI_AUTH_OPEN;
    if (rec) {
        memcpy(wc.sta.bssid, rec->bssid, sizeof(wc.sta.bssid));
        wc.sta.bssid_set = true;
        wc.sta.channel   = rec->primary;
    }
```

The single call site passes `&cands[i].rec`.

Deliberately unchanged, per review feedback:

- authmode threshold stays `WIFI_AUTH_OPEN` (accepts WPA/WPA2/WPA3-SAE;
  the supplicant's auto-raise behaviour is untouched)
- cross-slot candidate ordering stays RSSI-sorted (a backup Network # 2 still
  wins whenever Network # 1 is absent or unreachable — no slot-priority policy)
- scan result cap stays 32
- retry/failover logic untouched: if a pinned BSS dies mid-retry, the remaining
  attempts fail fast and the candidate loop moves on; periodic rescan re-pins
  afterwards


## Optional follow-ups (found during this investigation)

None of these are part of this PR; listing them so the findings don't get lost.

1. **PMF capable** — `wc.sta.pmf_cfg.capable = true`: keeps WPA2 working and
   enables WPA2/WPA3 mixed-mode APs. One liner.
2. **Connection diagnostics** — decode authmode and disconnect reason codes
   (`NO_AP_FOUND` vs `4WAY_HANDSHAKE_TIMEOUT` vs beacon loss...), log
   STA_CONNECTED/DISCONNECTED events, add per-BSS scan log lines, and expose
   `bssid` in the `/api/wifi` scan JSON. Purely additive logging; makes field
   reports actionable instead of guesswork.
3. **NimBLE host task stack 3584 -> 6144** — the host-task stack canary
   overflowed after a long reconnect storm; GAP/GATT callbacks (AES +
   hex-dump logging in the send path) run in that task. IDF default is 5120.
4. **LWIP TCP accept mbox 4 -> 8** — a browser page-load burst (~7 concurrent
   SYNs) overflowed the accept queue while the single httpd worker was busy,
   resetting surplus connections (ERR_CONNECTION_RESET in the console).
5. **FreeRTOS/ringbuf functions into flash** — returns ~15 KB of IRAM; no
   hot-path impact observed.
6. **Scan cap 32 -> 60** — only worth doing once confirmed against IDF v5.5
   internals whether the driver-side result buffer is the real bound;
   otherwise it is a silent no-op.
7. **Weak-signal resilience heuristics** (rescan when the best candidate is
   below -75 dBm, directed per-SSID probes for APs missed by wildcard sweeps,
   sub--80 dBm last-resort tiering) — prototyped but parked pending agreement
   on connection-behaviour policy; code preserved on `feature/wifi`
   (commit cb1fd52).


## Checklist
- [X ] I have read and agree to the [Contributor License Agreement (CLA)](CLA/individual-cla.md) (or [Corporate CLA](CLA/corporate-cla.md)).
- [X ] This change is a clean-room implementation; no third-party copyrighted code has been copied without approval and notice in `THIRD-PARTY-NOTICES.md`.
- [X ] Any new source files include the standard license header from `docs/source-header.txt`.
- [X ] The code compiles and builds cleanly (`./scripts/build-dist.sh`).
- [X ] No real patient / medical data is included in test fixtures, commits, or descriptions.
