### PR TITLE
Allows legacy oximeter data to show up in dashboard 

### DIFF
--- a/main/oximeter_legacy.c
+++ b/main/oximeter_legacy.c
@@ -131,6 +131,9 @@ static uint8_t legacy_crc8(const uint8_t *data, int len)
     return crc;
 }
 
+/* Forward declaration for legacy_set_time (called from do_connect_and_discover) */
+static esp_err_t legacy_set_time(void);
+
 /* ── Frame codec ───────────────────────────────────────────────────── */
 /* Encode a Legacy request frame into buf.  Returns total frame length.
  * Request: 0xAA | cmd | cmd^0xFF | block(LE16) | len(LE16) | data | crc8 */
@@ -609,6 +612,10 @@ static esp_err_t do_connect_and_discover(ble_addr_t *target)
         set_error("enable notify failed"); return ESP_FAIL;
     }
     ESP_LOGI(TAG, "notifications enabled (cccd=%d)", s_cccd_handle);
+
+    /* Sync ring clock so future recordings have valid header timestamps */
+    if (legacy_set_time() != ESP_OK)
+        ESP_LOGW(TAG, "time sync failed after connect — continuing");
     return ESP_OK;
 }
 
@@ -1160,9 +1167,9 @@ static bool do_pull_and_mark(bool *pulled_any)
 
         ESP_LOGI(TAG, "pulling file %d/%d: '%s'", i + 1, count, names[i]);
         if (legacy_pull_file(names[i]) != ESP_OK) {
-            ESP_LOGW(TAG, "pull failed for '%s'", names[i]);
+            ESP_LOGW(TAG, "pull failed for '%s' — continuing with next file", names[i]);
             pull_ok = false;
-            break;
+            continue;
         }
         if (pulled_any) *pulled_any = true;
     }

--- a/main/oximeter_oxyii.c
+++ b/main/oximeter_oxyii.c
@@ -241,7 +241,9 @@ static int64_t oxyii_filename_epoch_ms(const char *name)
 static void oxyii_file_start_payload(uint8_t *out20, const char *name)
 {
     memset(out20, 0, 20);
-    strncpy((char *)out20, name, 16);
+    size_t n = strlen(name);
+    if (n > 16) n = 16;
+    memcpy(out20, name, n);
     /* bytes 16..19: file type = 0 */
 }
 
@@ -1238,10 +1240,10 @@ static bool do_pull_and_mark(bool *pulled_any)
 
         ESP_LOGI(TAG, "pulling file %d/%d: '%s'", i + 1, count, names[i]);
         if (oxyii_pull_file(names[i]) != ESP_OK) {
-            ESP_LOGW(TAG, "pull failed for '%s'", names[i]);
+            ESP_LOGW(TAG, "pull failed for '%s' — continuing with next file", names[i]);
             if (sd_storage_is_ready()) oximetry_canonical_migrate_legacy(s_serial);
             pull_ok = false;
-            break;
+            continue;
         }
         if (pulled_any) *pulled_any = true;
     }

--- a/main/oximeter_store.c
+++ b/main/oximeter_store.c
@@ -32,6 +32,7 @@
 #include <sys/stat.h>
 #include <dirent.h>
 #include <unistd.h>
+#include <errno.h>
 
 #include "esp_log.h"
 #include "esp_heap_caps.h"
@@ -531,6 +532,7 @@ bool ox_store_finalize_native(const char *serial, const char *name,
     int n = fread(data, 1, fsize, f);
     fclose(f);
     if (n != fsize) {
+        ESP_LOGE(TAG, "native promote: read %d/%ld bytes for '%s'", n, fsize, name);
         free(data);
         return false;
     }
@@ -538,8 +540,16 @@ bool ox_store_finalize_native(const char *serial, const char *name,
     /* Create files/<serial>/ directory */
     char serial_dir[160];
     snprintf(serial_dir, sizeof(serial_dir), "%s/%s", OXY_FILES, serial);
-    mkdir(OXY_FILES, 0775);
-    mkdir(serial_dir, 0775);
+    if (mkdir(OXY_FILES, 0775) != 0 && errno != EEXIST) {
+        ESP_LOGE(TAG, "native promote: mkdir %s failed: %s", OXY_FILES, strerror(errno));
+        free(data);
+        return false;
+    }
+    if (mkdir(serial_dir, 0775) != 0 && errno != EEXIST) {
+        ESP_LOGE(TAG, "native promote: mkdir %s failed: %s", serial_dir, strerror(errno));
+        free(data);
+        return false;
+    }
 
     /* Write the final file atomically (no .bin or .vld suffix — preserve
      * the original filename from the ring) */
@@ -549,7 +559,7 @@ bool ox_store_finalize_native(const char *serial, const char *name,
     snprintf(tmp_path, sizeof(tmp_path), "%s.tmp", out_path);
     f = fopen(tmp_path, "wb");
     if (!f) {
-        ESP_LOGE(TAG, "native promote: cannot create %s", tmp_path);
+        ESP_LOGE(TAG, "native promote: cannot create %s: %s", tmp_path, strerror(errno));
         free(data);
         return false;
     }
@@ -557,7 +567,16 @@ bool ox_store_finalize_native(const char *serial, const char *name,
                    fflush(f) == 0 && fsync(fileno(f)) == 0;
     fclose(f);
     free(data);
-    if (!written || rename(tmp_path, out_path) != 0) {
+    if (!written) {
+        ESP_LOGE(TAG, "native promote: write/flush/sync failed for %s", tmp_path);
+        unlink(tmp_path);
+        return false;
+    }
+    /* FATFS does not support rename-over-existing (returns EEXIST),
+     * so unlink the destination first. */
+    unlink(out_path);
+    if (rename(tmp_path, out_path) != 0) {
+        ESP_LOGE(TAG, "native promote: rename %s -> %s failed: %s", tmp_path, out_path, strerror(errno));
         unlink(tmp_path);
         return false;
     }

--- a/main/oximetry_canonical.c
+++ b/main/oximetry_canonical.c
@@ -714,8 +714,12 @@ esp_err_t oximetry_canonical_convert_vld3(const char *device_id,
 
     int64_t start_ms = vld3_start_epoch_ms(source_path);
     if (!start_ms) {
-        ESP_LOGW(TAG, "vld3 convert: cannot extract start time from header");
-        return ESP_ERR_INVALID_ARG;
+        start_ms = filename_epoch_ms(recording_id);
+        if (!start_ms) {
+            ESP_LOGW(TAG, "vld3 convert: cannot extract start time from header or filename");
+            return ESP_ERR_INVALID_ARG;
+        }
+        ESP_LOGI(TAG, "vld3 convert: start time from file name: %lld", (long long)start_ms);
     }
 
     uint32_t period_us = vld3_period_us(source_path);


### PR DESCRIPTION
## What is the problem

Two independent failures prevented Legacyy\Gen1 O2 Ring SpO2 data from reaching the dashboard:

1. **Finalization failed** — `rename()` on FATFS fails if destination exists. Files stuck as `.part`.
2. **Conversion failed** — VLD3 header timestamp was garbage (ring RTC never synced). `vld3_start_epoch_ms()` returned 0.

## Fixes 

(Consider this a proof of concept, feel free to use it as you please)

| File | Change | Why |
|------|--------|-----|
| `oximetry_canonical.c` | Fallback to filename timestamp (`YYYYMMDDHHMMSS`) when header invalid | Ring RTC often wrong; filename is reliable |
| `oximeter_legacy.c` | Call `legacy_set_time()` on GATT connect (after notifications enabled) | Syncs ring RTC *before* recording so future headers are valid |
| `oximeter_store.c` | `unlink(out_path)` before `rename()` + full error logging | FATFS requires this; logs now show exact failure point |
| `oximeter_legacy.c` / `oximeter_oxyii.c` | `break` → `continue` on pull failure | One bad file no longer blocks entire sync window 

## Proof (from device logs)

**Finalization now succeeds:**
```
I ox_store: native promoted .../files/22012C5328/20260828190635 (285 bytes)
I ox_legacy: pulled '20260828190635': 285 bytes, finalised=1
I ox_store: native promoted .../files/22012C5328/20260829014354 (31895 bytes)
I ox_legacy: pulled '20260829014354': 31895 bytes, finalised=1
... (all 4 files finalised=1)
```

**Conversion uses filename fallback:**
```
I ox_canon: vld3 convert: start time from file name: 1787969195000
I ox_canon: vld3 convert: start time from file name: 1787993034000
I ox_canon: vld3 convert: start time from file name: 1788025627000
I ox_canon: vld3 convert: start time from file name: 1788043765000
```

**Dashboard data created & uploaded:**
```
upload_shq: uploaded 20260828190635 (285 bytes)
upload_shq: uploaded 20260829014354 (31895 bytes)
```



## Checklist

- [x] I have read and agree to the [Contributor License Agreement (CLA)](CLA/individual-cla.md) (or [Corporate CLA](CLA/corporate-cla.md)).
- [x] This change is a clean-room implementation; no third-party copyrighted code has been copied without approval and notice in `THIRD-PARTY-NOTICES.md`.
- [x] Any new source files include the standard license header from `docs/source-header.txt`.
- [x] The code compiles and builds cleanly (`./scripts/build-dist.sh`).
- [x] No real patient / medical data is included in test fixtures, commits, or descriptions.
