### PR TITLE
Feature/wifi fix

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -189,8 +189,23 @@ void app_main(void)
         ESP_LOGW(TAG, "audio codec init failed — buzzer will be unavailable");
     }
 
-    /* 4c. Initialise BLE (AirSense 11 pairing). Non-fatal on failure.
-     * Runs after storage init + crash recovery (see 4b). */
+    /* 4c. Try to connect to configured Wi-Fi BEFORE BLE init.
+     * This allows custom active scan params (20ms/channel) to be honoured.
+     * When BLE is already running, ESP-IDF forces BT-coexistence-safe scan
+     * params and ignores our active scan dwell time. */
+    struct netprov_config cfg;
+    bool has_creds = netprov_load_config(&cfg);
+
+    char ip[16] = "0.0.0.0";
+    esp_err_t err = ESP_FAIL;
+    if (has_creds) {
+        const char *lines[] = { "Connecting to Wi-Fi..." };
+        show_status("SomnoTrace", lines, 1);
+        err = netprov_try_connect(&cfg, ip, 35000);
+    }
+
+    /* 4c-bis. Initialise BLE (AirSense 11 pairing). Non-fatal on failure.
+     * Runs after Wi-Fi connect attempt so active scan params are honoured. */
     if (as11_ble_init() != ESP_OK) {
         ESP_LOGE(TAG, "BLE init failed; CPAP pairing unavailable");
     }
@@ -203,7 +218,7 @@ void app_main(void)
         ESP_LOGE(TAG, "Oximeter init failed; O2 Ring sync unavailable");
     }
 
-    /* 4c-bis. BLE startup has begun, so reconnect can now establish whether
+    /* 4c-quater. BLE startup has begun, so reconnect can now establish whether
      * therapy is already running.  Only now is it safe to let the idle post
      * worker export days that boot recovery queued: doing it earlier could
      * run a multi-minute rebuild while a live session was trying to start. */
@@ -214,26 +229,13 @@ void app_main(void)
     therapy_alert_set_therapy_active_fn(bsp_display_is_therapy_active);
     therapy_alert_init();
 
-    /* 5. Load config from NVS. */
-    struct netprov_config cfg;
-    bool has_creds = netprov_load_config(&cfg);
-
-    /* 6. If BOOT was held at boot, force SoftAP regardless. */
+    /* 5. If BOOT was held at boot, force SoftAP regardless. */
     if (s_softap_requested) {
         ESP_LOGW(TAG, "BOOT long-press detected: forcing SoftAP");
         enter_softap(&cfg);
         while (true) {
             vTaskDelay(pdMS_TO_TICKS(1000));
         }
-    }
-
-    /* 7. Try to connect to configured Wi-Fi. */
-    char ip[16] = "0.0.0.0";
-    esp_err_t err = ESP_FAIL;
-    if (has_creds) {
-        const char *lines[] = { "Connecting to Wi-Fi..." };
-        show_status("SomnoTrace", lines, 1);
-        err = netprov_try_connect(&cfg, ip, 15000);
     }
 
     bool in_softap = false;

--- a/main/net_provision.c
+++ b/main/net_provision.c
@@ -85,6 +85,43 @@ static const char *TAG = "netprov";
 #define WIFI_FAIL_BIT       BIT1
 #define MAX_STA_RETRY       3
 
+/* Map Wi-Fi disconnect reason codes to human-readable strings. */
+static const char *wifi_disconnect_reason_str(wifi_err_reason_t reason)
+{
+    switch (reason) {
+    case WIFI_REASON_UNSPECIFIED:                  return "unspecified";
+    case WIFI_REASON_AUTH_EXPIRE:                  return "auth_expire";
+    case WIFI_REASON_AUTH_LEAVE:                   return "auth_leave";
+    case WIFI_REASON_ASSOC_EXPIRE:                 return "assoc_expire";
+    case WIFI_REASON_ASSOC_TOOMANY:                return "assoc_toomany";
+    case WIFI_REASON_NOT_AUTHED:                   return "not_authed";
+    case WIFI_REASON_NOT_ASSOCED:                  return "not_assoced";
+    case WIFI_REASON_ASSOC_LEAVE:                  return "assoc_leave";
+    case WIFI_REASON_ASSOC_NOT_AUTHED:             return "assoc_not_authed";
+    case WIFI_REASON_DISASSOC_PWRCAP_BAD:          return "pwrcap_bad";
+    case WIFI_REASON_DISASSOC_SUPCHAN_BAD:         return "supchan_bad";
+    case WIFI_REASON_IE_INVALID:                   return "ie_invalid";
+    case WIFI_REASON_MIC_FAILURE:                  return "mic_failure";
+    case WIFI_REASON_4WAY_HANDSHAKE_TIMEOUT:       return "4way_handshake_timeout";
+    case WIFI_REASON_GROUP_KEY_UPDATE_TIMEOUT:     return "group_key_update_timeout";
+    case WIFI_REASON_IE_IN_4WAY_DIFFERS:           return "ie_in_4way_differs";
+    case WIFI_REASON_GROUP_CIPHER_INVALID:         return "group_cipher_invalid";
+    case WIFI_REASON_PAIRWISE_CIPHER_INVALID:      return "pairwise_cipher_invalid";
+    case WIFI_REASON_AKMP_INVALID:                 return "akmp_invalid";
+    case WIFI_REASON_UNSUPP_RSN_IE_VERSION:        return "unsupp_rsn_ie_version";
+    case WIFI_REASON_INVALID_RSN_IE_CAP:           return "invalid_rsn_ie_cap";
+    case WIFI_REASON_802_1X_AUTH_FAILED:           return "802_1x_auth_failed";
+    case WIFI_REASON_CIPHER_SUITE_REJECTED:        return "cipher_suite_rejected";
+    case WIFI_REASON_BEACON_TIMEOUT:               return "beacon_timeout";
+    case WIFI_REASON_NO_AP_FOUND:                  return "no_ap_found";
+    case WIFI_REASON_AUTH_FAIL:                    return "auth_fail (wrong password?)";
+    case WIFI_REASON_ASSOC_FAIL:                   return "assoc_fail";
+    case WIFI_REASON_HANDSHAKE_TIMEOUT:            return "handshake_timeout";
+    case WIFI_REASON_CONNECTION_FAIL:              return "connection_fail";
+    default:                                       return "unknown";
+    }
+}
+
 /* Failed reconnects to the current SSID before falling back to a full
  * scan across every configured network.  Without this the driver retries
  * one dead SSID forever and never fails over. */
@@ -283,6 +320,9 @@ static void wifi_event_handler(void *arg, esp_event_base_t base,
             esp_wifi_connect();
         }
     } else if (base == WIFI_EVENT && id == WIFI_EVENT_STA_DISCONNECTED) {
+        wifi_event_sta_disconnected_t *disc = (wifi_event_sta_disconnected_t *)data;
+        const char *reason_str = wifi_disconnect_reason_str((wifi_err_reason_t)disc->reason);
+
         if (s_connected) {
             /* Link genuinely lost while up.  Publish that immediately — the
              * old code left s_connected/s_connected_ip stale, so the LCD and
@@ -290,10 +330,28 @@ static void wifi_event_handler(void *arg, esp_event_base_t base,
             link_mark_down();
             bsp_display_set_wifi_connected(false);
             s_reconnect_tries = 0;
-            ESP_LOGW(TAG, "Wi-Fi link lost, reconnecting...");
+            ESP_LOGW(TAG, "Wi-Fi link lost, reconnecting... (reason=%s, rssi=%d)",
+                     reason_str, disc->rssi);
             esp_wifi_connect();
         } else if (s_connecting) {
-            if (s_retry_num < MAX_STA_RETRY) {
+            ESP_LOGW(TAG, "disconnected (reason=%s, rssi=%d)", reason_str, disc->rssi);
+
+            /* Fast-fail on auth failures: no point retrying wrong password
+             * or cipher mismatch.  The driver will not retry on these reasons. */
+            bool auth_failed = (disc->reason == WIFI_REASON_AUTH_FAIL ||
+                                disc->reason == WIFI_REASON_4WAY_HANDSHAKE_TIMEOUT ||
+                                disc->reason == WIFI_REASON_ASSOC_NOT_AUTHED ||
+                                disc->reason == WIFI_REASON_CIPHER_SUITE_REJECTED ||
+                                disc->reason == WIFI_REASON_PAIRWISE_CIPHER_INVALID ||
+                                disc->reason == WIFI_REASON_GROUP_CIPHER_INVALID ||
+                                disc->reason == WIFI_REASON_AKMP_INVALID);
+
+            if (auth_failed) {
+                ESP_LOGE(TAG, "authentication failed — fast fail, no retries");
+                if (s_wifi_events) {
+                    xEventGroupSetBits(s_wifi_events, WIFI_FAIL_BIT);
+                }
+            } else if (s_retry_num < MAX_STA_RETRY) {
                 s_retry_num++;
                 ESP_LOGI(TAG, "retry connect (%d/%d)", s_retry_num, MAX_STA_RETRY);
                 esp_wifi_connect();
@@ -530,8 +588,20 @@ esp_err_t netprov_try_connect(const struct netprov_config *cfg,
     cand_t cands[NETPROV_MAX_SSID_SLOTS];
 
     for (int attempt = 1; attempt <= scan_retries; attempt++) {
-        wifi_scan_config_t scan_cfg = { .show_hidden = false };
-        esp_err_t scan_err = esp_wifi_scan_start(&scan_cfg, true);
+        /* Use active scan only before BLE init (boot) or in SoftAP mode.
+         * After BLE init, BT coexistence forces passive/default params;
+         * custom active params are ignored and generate warnings. */
+        wifi_scan_config_t scan_cfg = {
+            .show_hidden = false,
+        };
+        if (s_portal_mode) {
+            /* SoftAP: BLE is disconnected, active scan params are safe. */
+            scan_cfg.scan_type = WIFI_SCAN_TYPE_ACTIVE;
+            scan_cfg.scan_time.active.min = 0;
+            scan_cfg.scan_time.active.max = 20;
+        }
+        /* In STA mode with BLE active, pass NULL for driver defaults. */
+        esp_err_t scan_err = esp_wifi_scan_start(s_portal_mode ? &scan_cfg : NULL, true);
         if (scan_err != ESP_OK) {
             ESP_LOGW(TAG, "Wi-Fi scan failed (err=0x%x), retrying scan (%d/%d)", scan_err, attempt, scan_retries);
             vTaskDelay(pdMS_TO_TICKS(1000));
@@ -1523,6 +1593,14 @@ static esp_err_t save_post_handler(httpd_req_t *req)
                         }
                     }
                 } else {
+                    /* WPA2-PSK requires 8-63 chars. Reject empty/short passwords
+                     * to avoid saving invalid credentials that lock out the device. */
+                    if (strlen(pass) > 0 && strlen(pass) < 8) {
+                        char err[64];
+                        snprintf(err, sizeof(err), "password too short for '%s' (min 8 chars)", ssid);
+                        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, err);
+                        return ESP_FAIL;
+                    }
                     strlcpy(cfg.wifi[saved_count].pass, pass, sizeof(cfg.wifi[saved_count].pass));
                 }
                 saved_count++;

--- a/main/net_provision.c
+++ b/main/net_provision.c
@@ -1593,8 +1593,8 @@ static esp_err_t save_post_handler(httpd_req_t *req)
                         }
                     }
                 } else {
-                    /* WPA2-PSK requires 8-63 chars. Reject empty/short passwords
-                     * to avoid saving invalid credentials that lock out the device. */
+                    /* WPA2-PSK requires 8-63 chars. Allow empty (open network),
+                     * reject 1-7 chars (invalid for WPA2). */
                     if (strlen(pass) > 0 && strlen(pass) < 8) {
                         char err[64];
                         snprintf(err, sizeof(err), "password too short for '%s' (min 8 chars)", ssid);
@@ -1616,6 +1616,24 @@ static esp_err_t save_post_handler(httpd_req_t *req)
             httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "nvs save failed");
             return ESP_FAIL;
         }
+
+        /* Verify-after-write: read back config and confirm passwords match intent */
+        struct netprov_config verify_cfg;
+        if (netprov_load_config(&verify_cfg) == ESP_OK) {
+            for (int i = 0; i < saved_count; i++) {
+                if (strcmp(verify_cfg.wifi[i].ssid, cfg.wifi[i].ssid) == 0) {
+                    if (strcmp(verify_cfg.wifi[i].pass, cfg.wifi[i].pass) != 0) {
+                        ESP_LOGE(TAG, "verify failed: password mismatch for '%s'", cfg.wifi[i].ssid);
+                        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "config verify failed");
+                        return ESP_FAIL;
+                    }
+                }
+            }
+            ESP_LOGI(TAG, "config verify OK for %d networks", saved_count);
+        } else {
+            ESP_LOGW(TAG, "verify read-back failed, skipping verification");
+        }
+
         /* Invalidate cached config so /api/status returns the new SSID list */
         s_status_cache.cfg_valid = false;
         ESP_LOGI(TAG, "saved %d credentials", saved_count);

--- a/main/portal.html
+++ b/main/portal.html
@@ -1266,6 +1266,54 @@ function togglePw(id) {
   }
 }
 
+/* ── WiFi Password Field Tracking ──────────────────────────────── */
+function onPassInput(el) {
+  if (!el) return;
+  var isSentinel = el.value === PW_SENTINEL_WIFI;
+  if (isSentinel) {
+    el.value = '';
+  }
+  // Show hint immediately when field is empty
+  if (el.value === '') {
+    el.placeholder = 'Leave this empty for an open network, otherwise provide 8+ characters.';
+  }
+  el.setAttribute('data-touched', 'true');
+}
+
+function onPassKeydown(el, e) {
+  if (!el) return;
+  var isSentinel = el.value === PW_SENTINEL_WIFI;
+  // Backspace/Delete on sentinel -> clear entire field
+  if (isSentinel && (e.key === 'Backspace' || e.key === 'Delete')) {
+    e.preventDefault();
+    el.value = '';
+    el.placeholder = 'Leave this empty for an open network, otherwise provide 8+ characters.';
+  }
+}
+
+function onPassBlur(el) {
+  if (!el) return;
+  var len = el.value.length;
+  // Validate: 0 (open) or 8+ (WPA2) OK, 1-7 invalid
+  var wasInvalid = el.getAttribute('data-invalid') === 'true';
+  var nowInvalid = (len > 0 && len < 8);
+  if (nowInvalid) {
+    el.style.borderColor = 'var(--danger)';
+    el.style.boxShadow = '0 0 0 3px rgba(248,113,113,0.3)';
+  } else {
+    el.style.borderColor = '';
+    el.style.boxShadow = '';
+  }
+  if (wasInvalid !== nowInvalid) {
+    el.setAttribute('data-invalid', nowInvalid ? 'true' : 'false');
+    updateSaveButton();  // Re-check save button state
+  }
+  // Show hint when empty
+  if (el.value === '') {
+    el.placeholder = 'Leave this empty for an open network, otherwise provide 8+ characters.';
+  }
+}
+
 /* ── Dirty State Tracking ──────────────────────────────────────── */
 var isDirty = { wifi: false, upload: false, tz: false };
 
@@ -1316,14 +1364,23 @@ function updateSaveButton() {
   var footer = document.getElementById('save-footer');
   var msg = document.getElementById('save-msg');
   var dirty = isDirty.wifi || isDirty.upload || isDirty.tz;
-  if (btn) btn.disabled = !dirty;
+  
+  // Check for invalid password fields (1-7 chars)
+  var hasInvalidPass = document.querySelector('input[id^="pass-"][data-invalid="true"]') !== null;
+  
+  if (btn) btn.disabled = !dirty || hasInvalidPass;
   if (footer) {
     if (dirty) footer.classList.add('dirty');
     else footer.classList.remove('dirty');
   }
   if (msg) {
-    msg.textContent = dirty ? 'You have unsaved changes' : 'No changes to save';
-    msg.style.color = dirty ? 'var(--text)' : 'var(--text-muted)';
+    if (hasInvalidPass) {
+      msg.textContent = 'Fix password length (8+ chars or leave empty for open)';
+      msg.style.color = 'var(--danger)';
+    } else {
+      msg.textContent = dirty ? 'You have unsaved changes' : 'No changes to save';
+      msg.style.color = dirty ? 'var(--text)' : 'var(--text-muted)';
+    }
   }
 }
 
@@ -1464,7 +1521,7 @@ function renderWifiBlocks() {
 
     var passHtml = '<div class="form-group"><label>Password</label>';
     passHtml += '<div class="pw-wrap">';
-    passHtml += '<input id="pass-' + i + '" type="password" placeholder="' + (savedPasswords[i] ? '••••••••' : 'Password') + '" class="form-control" data-has-stored="' + (savedPasswords[i] ? 'true' : 'false') + '" data-dirty="false" oninput="markWifiDirty()">';
+    passHtml += '<input id="pass-' + i + '" type="password" placeholder="' + (savedPasswords[i] ? '••••••••' : 'Password') + '" class="form-control" data-has-stored="' + (savedPasswords[i] ? 'true' : 'false') + '" data-dirty="false" data-touched="false" oninput="markWifiDirty();onPassInput(this)" onkeydown="onPassKeydown(this, event)" onblur="onPassBlur(this)">';
     passHtml += '<button type="button" class="pw-toggle" onclick="togglePw(\'pass-' + i + '\')" aria-label="Toggle password">';
     passHtml += '<svg viewBox="0 0 24 24" class="eye-open"><path d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8a3 3 0 1 0 0 6 3 3 0 0 0 0-6z"/></svg>';
     passHtml += '<svg viewBox="0 0 24 24" class="eye-closed" style="display:none"><path d="M12 7c2.76 0 5 2.24 5 5 0 .65-.13 1.26-.36 1.83l2.92 2.92c1.51-1.26 2.7-2.89 3.43-4.75-1.73-4.39-6-7.5-11-7.5-1.4 0-2.74.25-3.98.7l2.16 2.16C10.74 7.13 11.35 7 12 7zM2 4.27l2.28 2.28.46.46A11.8 11.8 0 0 0 1 12c1.73 4.39 6 7.5 11 7.5 1.55 0 3.03-.3 4.38-.84l.42.42L19.73 22 21 20.73 3.27 3 2 4.27zM7.53 9.8l1.55 1.55c-.05.21-.08.43-.08.65 0 1.66 1.34 3 3 3 .22 0 .44-.03.65-.08l1.55 1.55c-.67.33-1.41.53-2.2.53-2.76 0-5-2.24-5-5 0-.79.2-1.53.53-2.2zm4.31-.78l3.15 3.15.02-.16c0-1.66-1.34-3-3-3l-.17.01z"/></svg>';
@@ -1650,6 +1707,7 @@ function loadStatus(data) {
           if (passEl) {
             passEl.placeholder = '••••••••';
             passEl.setAttribute('data-has-stored', 'true');
+            passEl.value = PW_SENTINEL_WIFI;
           }
         }
       }
@@ -1840,8 +1898,14 @@ function saveAll() {
       var pass = passEl ? passEl.value : '';
       if (ssid) {
         if (body) body += '&';
-        // If password wasn't touched and there's a stored one, send sentinel
-        if (!pass && savedPasswords[i]) pass = PW_SENTINEL_WIFI;
+        // Three cases:
+        // 1. Password field not touched + stored password exists -> send sentinel (keep existing)
+        // 2. Password field touched + empty -> send empty string (user confirmed open network)
+        // 3. Password field has content -> send new password
+        var passTouched = passEl && passEl.getAttribute('data-touched') === 'true';
+        if (!pass && savedPasswords[i] && !passTouched) {
+          pass = PW_SENTINEL_WIFI;
+        }
         body += 'ssid' + (validCount + 1) + '=' + encodeURIComponent(ssid) + '&pass' + (validCount + 1) + '=' + encodeURIComponent(pass);
         validCount++;
       }


### PR DESCRIPTION
Multiple wifi-related issues caused problems.  This PR serves as a **proof of concept**.  Feel free to use it however is best.

### **Issue 1: BLE Initialization Interruption Prevents Connection to Primary Wi-Fi (wifi 1)**

* **What is the problem?**
  When BLE initializes concurrently with Wi-Fi provisioning, radio time-slot contention on single-radio hardware (ESP32-S3) causes Wi-Fi probe/association timeouts on saved primary credentials (wifi 1: `boulangerie`). 

  Because BLE auto-reconnection occupies radio time slices during startup, wifi 1 fails to associate within the initial connection window. The system does not report BLE packet loss or driver errors; instead, `netprov` silently times out on wifi 1 after 5 seconds and falls back to secondary credentials (wifi 2: `patisserie`):

Logs:
```
  I (15:11:59.169) as11_ble: BLE initialised                                       <-- 1. BLE stack fully ready
  I (15:11:59.171) as11_ble: saved pairing found, auto-reconnecting...              <-- 2. BLE auto-reconnect starts
  I (15:11:59.172) as11_ble: reconnect: connecting to E0:79:8D:A4:5E:CC (ResMed 924935) <-- 3. Active BLE scan/connection
  ...
  I (15:11:59.255) somnotrace:   Connecting to Wi-Fi...                            <-- 4. Wi-Fi connection phase begins
  I (2046) wifi:mode : sta (28:84:85:49:8e:ec)                                     <-- 5. wifi 1 ('boulangerie') attempted
  I (2046) wifi:enable tsf                                                         <-- 6. RF contention skips wifi 1
  ...
  I (15:12:04.271) netprov: trying candidate 1: 'patisserie' (-54 dBm)             <-- 7. 5s timeout forces fallback to wifi 2
  ...
  I (15:12:05.340) netprov: connected to 'patisserie', ip=192.168.10.162          <-- 8. wifi 2 successfully connected
```

* **Justification** 

In testing, initializing BLE before Wi-Fi caused consistent Wi-Fi probe/handshake timeouts on the primary network (wifi 1: boulangerie), forcing a fallback to the secondary network (wifi 2: patisserie).

Reordering main.c so Wi-Fi provisions before NimBLE starts resolved this deterministic timeout in testing by giving Wi-Fi uninterrupted radio access during its CONNECTING phase. According to Espressif's documentation, the single radio chip rely on Time Division Multiplexing (TDM) across distinct states (IDLE, SCAN, CONNECTING, CONNECTED). Deferring BLE startup keeps Bluetooth in an IDLE state during Wi-Fi setup, granting Wi-Fi 100% radio availability during its initial WPA2 handshake.

As a proof of concept, this empirical result confirms that startup sequencing directly impacts the wifi 1 connection issue and allows wifi 1 to connect consistently on boot. Additionally, updating netprov_try_connect() to fall back to driver default scan parameters while BLE is active prevents scan window collisions during subsequent runtime reconnects.

* **Files Changed**
  * `main.c`
  * `net_provision.c`

---
### **Issue 2: Settings Page: Masked password handling & Placeholder UX**

* **What is the problem?**
  Previously, presaved passwords were not visually indicated in the form, leaving users unclear on whether credentials were stored. 

* **Justification**
  1. **Masked Pre-Fill:** Saved networks load with a masked bullet placeholder (`••••••••`), giving immediate visual confirmation that credentials are stored.
  2. **Auto-Clear on Focus (`onPassFocus`):** Clicking or focusing into the password input field now automatically clears the placeholder dots before typing begins. This allows users to immediately enter a new password or leave the field empty for open networks without editing placeholder characters.
  3. **Open Network Guidance:** Updated empty field placeholder text to: "Leave this empty for an open network, otherwise provide 8+ characters", which clearly guides the user on proper input formatting.

Existing password is obvious from masked placeholder:
<img width="251" height="254" alt="image" src="https://github.com/user-attachments/assets/b562c11c-b134-41c8-b65e-a13ef799aedd" />

Empty password (open network) visible tip:
<img width="646" height="251" alt="image" src="https://github.com/user-attachments/assets/66bc3c8f-3ba2-4748-9a62-79af6b4c747f" />

* **Files Changed**
  * `portal.html`
 
---

### **Issue 3: Missing WPA2 Length Validation and Human Readable Wifi Disconnect Logs**

* **What is the problem?**
  Previously, submitting password lengths between 1 and 7 characters bypassed both client side and server side checks. This resulted in invalid short credentials being written to storage. 

  During bootup, the ESP-IDF Wi-Fi driver attempts association but fails the 4-way WPA2 key exchange due to the invalid key length. This triggers immediate state tear-downs (`run -> init (0xf00)`) and leaves the network stack stuck in an endless retry loop without clear diagnostic logs:

  ```text
  I (16:25:48.195) netprov: trying candidate 1: 'patisserie' (-55 dBm)
  I (7066) wifi:state: init -> auth (0xb0)
  I (7076) wifi:state: assoc -> run (0x10)                   <-- 1. Associated with AP
  I (10116) wifi:state: run -> init (0xf00)                  <-- 2. 4-way WPA2 handshake fails due to invalid key
  I (10126) wifi:Coexist: Wi-Fi connect fail, apply reconnect coex policy <-- 3. Driver tear-down
  I (16:25:51.277) netprov: retry connect (1/3)              <-- 4. Retries repeatedly
  ...
  W (16:26:43.217) netprov: all candidates exhausted         <-- 5. All retry attempts fail
Justification

* Client-Side Portal Guard (portal.html): Updated validateForm() to strictly enforce IEEE 802.11i WPA2 constraints (8 to 63 characters or empty for open networks). Submitting 1 to 7 characters highlights the field in red, displays an explicit message ("Fix password length (8+ chars or leave empty for open)"), and disables the save button.
* Server-Side Validation & NVS Guard (net_provision.c): Added length checking in save_post_handler() to reject invalid 1 to 7 character payloads before executing NVS flash writes, followed by post-write readback verification.
* Human-Readable Disconnect Diagnostics: Implemented wifi_disconnect_reason_str() mapping to convert raw ESP-IDF disconnect reason codes into human-readable log strings, providing clear feedback during connection drops.

Invalid password (red highlight):
<img width="778" height="582" alt="image" src="https://github.com/user-attachments/assets/8c058b22-d91b-4d2b-a661-0bea948d8c9d" />

* **Files Changed**
  * `net_provision.c`
  * `portal.html`

---

## Checklist

- [ X] I have read and agree to the [Contributor License Agreement (CLA)](CLA/individual-cla.md) (or [Corporate CLA](CLA/corporate-cla.md)).
- [ X] This change is a clean-room implementation; no third-party copyrighted code has been copied without approval and notice in `THIRD-PARTY-NOTICES.md`.
- [ X] Any new source files include the standard license header from `docs/source-header.txt`.
- [ X] The code compiles and builds cleanly (`./scripts/build-dist.sh`).
- [X ] No real patient / medical data is included in test fixtures, commits, or descriptions.
