### PR TITLE
Add POWER-button-controlled backlight mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ The board has three physical buttons on the side. Here's what each one does:
 | Button | Action | What It Does |
 |---|---|---|
 | **BOOT** (left) | Hold 5 seconds | Enters Wi-Fi setup mode (AP hotspot) for initial configuration or network changes. |
-| **POWER** (middle) | Hold 10 seconds | Powers off the device. |
+| **POWER** (middle) | Single click | Toggles the backlight when **Backlight controlled by POWER button** is selected under Display & Sound. |
+| **POWER** (middle) | Hold 5 seconds | Powers off the device. |
 | **POWER** (middle) | Hold 2 seconds | Powers on the device (when off). |
 | **PLUS** (right) | Single click | Acknowledges and silences an interrupted therapy alert (if enabled). |
 | **PLUS** (right) | Double click | Starts or stops therapy on the AirSense 11 (toggle — same as pressing the machine's own button). |

--- a/main/bsp_display.c
+++ b/main/bsp_display.c
@@ -842,6 +842,19 @@ void bsp_display_set_backlight(bool on)
     }
 }
 
+bool bsp_display_toggle_backlight(void)
+{
+    /* SoftAP setup deliberately keeps its connection details visible. */
+    if (s_backlight_force_on) {
+        bsp_display_set_backlight(true);
+        return true;
+    }
+
+    bool on = !s_backlight_on;
+    bsp_display_set_backlight(on);
+    return on;
+}
+
 uint8_t bsp_display_get_brightness(void)
 {
     return s_brightness;
@@ -873,6 +886,9 @@ void bsp_display_apply_backlight_policy(bool force_on)
         break;
     case LCD_THERAPY_ALWAYS_OFF:
         bsp_display_set_backlight(false);
+        break;
+    case LCD_THERAPY_BUTTON:
+        /* A short PWR press owns the backlight state in this mode. */
         break;
     default:
         bsp_display_set_backlight(true);

--- a/main/bsp_display.h
+++ b/main/bsp_display.h
@@ -50,9 +50,11 @@ bool bsp_display_is_therapy_active(void);
 /* Backlight control (LEDC PWM on GPIO 46).
  * set_brightness: 1-200 (tenth-percent units: 1=0.1%, 200=20.0%), applied immediately.
  * set_backlight: hard on/off (used for therapy LCD-off mode).
+ * toggle_backlight: flips the current hardware state and returns the new state.
  * get_brightness: returns last set brightness value. */
 void bsp_display_set_brightness(uint8_t percent);
 void bsp_display_set_backlight(bool on);
+bool bsp_display_toggle_backlight(void);
 uint8_t bsp_display_get_brightness(void);
 
 /* Apply the current backlight policy based on lcd_therapy_mode and therapy

--- a/main/bsp_power.c
+++ b/main/bsp_power.c
@@ -36,6 +36,7 @@
 #include "esp_adc/adc_cali_scheme.h"
 #include "esp_log.h"
 #include "bsp_display.h"
+#include "device_settings.h"
 #include "as11_ble.h"
 #include "esp_sleep.h"
 #include "psram_task.h"
@@ -109,6 +110,8 @@ static void button_monitor_task(void *arg)
     (void)arg;
     const int poll_ms = 50;
     const int double_click_window_ms = 400;
+    const int pwr_short_min_ms = 100;
+    const int pwr_short_max_ms = 1000;
 
     /* Configure all three button GPIOs at once */
     gpio_config_t cfg = {
@@ -122,9 +125,22 @@ static void button_monitor_task(void *arg)
     };
     gpio_config(&cfg);
 
+    /* KEY_PWR may still be held from powering the board on.  Do not treat
+     * that initial release as a short press; arm short-press handling only
+     * after the monitor has observed the button released once. */
+    bool pwr_armed = gpio_get_level(BSP_PIN_KEY_PWR) != 0;
+    bool pwr_pressed = false;
+
     while (true) {
-        /* --- PWR button: long-press = power off --- */
-        if (gpio_get_level(BSP_PIN_KEY_PWR) == 0) {
+        /* --- PWR button: short press = optional backlight toggle,
+         *                  5 s hold = power off --- */
+        int pwr_level = gpio_get_level(BSP_PIN_KEY_PWR);
+        if (!pwr_armed) {
+            if (pwr_level != 0) pwr_armed = true;
+            s_btn.pwr_held_ms = 0;
+            pwr_pressed = false;
+        } else if (pwr_level == 0) {
+            pwr_pressed = true;
             s_btn.pwr_held_ms += poll_ms;
             if (s_btn.pwr_held_ms >= s_btn.pwr_hold_ms) {
                 ESP_LOGW(TAG, "power button long-press: shutting down");
@@ -138,7 +154,17 @@ static void button_monitor_task(void *arg)
                 s_btn.pwr_held_ms = 0;
             }
         } else {
+            if (pwr_pressed && s_btn.pwr_held_ms >= pwr_short_min_ms &&
+                s_btn.pwr_held_ms <= pwr_short_max_ms) {
+                const device_settings_t *dev = device_settings_get();
+                if (dev->lcd_therapy_mode == LCD_THERAPY_BUTTON) {
+                    bool on = bsp_display_toggle_backlight();
+                    ESP_LOGI(TAG, "POWER button short-press: backlight %s",
+                             on ? "on" : "off");
+                }
+            }
             s_btn.pwr_held_ms = 0;
+            pwr_pressed = false;
         }
 
         /* --- BOOT button: 5 s hold = SoftAP entry --- */

--- a/main/device_settings.c
+++ b/main/device_settings.c
@@ -214,7 +214,7 @@ esp_err_t device_settings_save_json(const char *json_str)
     if ((v = cJSON_GetObjectItem(root, "lcd_therapy_mode")) && cJSON_IsNumber(v)) {
         int val = v->valueint;
         if (val == LCD_THERAPY_OFF || val == LCD_THERAPY_ALWAYS_OFF ||
-            val == LCD_THERAPY_INFO) {
+            val == LCD_THERAPY_INFO || val == LCD_THERAPY_BUTTON) {
             cfg.lcd_therapy_mode = (lcd_therapy_mode_t)val;
         } else {
             cfg.lcd_therapy_mode = LCD_THERAPY_GRAPH;

--- a/main/device_settings.h
+++ b/main/device_settings.h
@@ -34,6 +34,7 @@ typedef enum {
     LCD_THERAPY_ALWAYS_OFF = 2,  /* Backlight always off (battery-friendly) —
                                  * except during boot and SoftAP mode */
     LCD_THERAPY_INFO       = 3,  /* Info panel: leak rate + session runtime */
+    LCD_THERAPY_BUTTON     = 4,  /* Backlight toggled by a short PWR press */
 } lcd_therapy_mode_t;
 
 /* LCD rotation in degrees (0 = default, 90 = clockwise) */

--- a/main/portal.html
+++ b/main/portal.html
@@ -691,6 +691,7 @@ Display &amp; Sound
 <option value="3">Show info panel during therapy</option>
 <option value="1">Backlight off during therapy</option>
 <option value="2">Backlight always off (battery)</option>
+<option value="4">Backlight controlled by POWER button</option>
 </select>
 </div>
 <div class="form-group">


### PR DESCRIPTION
## Description

Adds a fifth Display & Sound mode: **Backlight controlled by POWER button**.

In this mode:

- a 100-1,000 ms POWER press toggles the backlight
- holds between 1 and 5 seconds do nothing
- a continuous 5-second hold keeps the existing shutdown behavior
- the release used to power on the board is ignored
- Wi-Fi setup continues to force the display on
- the selected mode persists across reboot, while the instantaneous on/off state does not

The README button table is also updated to document the new mode and match the firmware's 5-second shutdown threshold.

## Testing

Validated on a Waveshare ESP32-S3-Touch-LCD-1.54 using the combined `test/rotation-and-backlight` integration branch containing this PR and #169.

- [x] `git diff --check`
- [x] `./scripts/build-dist.sh` using the pinned `espressif/idf:v5.5.1` Docker image
- [x] OTA image passed `esptool` checksum and validation-hash verification
- [x] Flashed and booted combined firmware `v1.2.2-dev+4`
- [x] A short POWER press toggled the backlight in mode 4
- [x] A full power-off/power-on cycle completed normally; mode 4 persisted and short-press control still worked after boot

Validated artifacts:

- Full image SHA-256: `DB415530E15DB3827DD4D6A211B9FCC9FBB9253616634D76372B9131A6250A2F`
- OTA image SHA-256: `C28EF6EB4B603196380C7B236151A4B783AA4AA6724DB4E359D243E85C941D8E`

## Checklist

- [x] I have read and agree to the [Contributor License Agreement (CLA)](CLA/individual-cla.md) (or [Corporate CLA](CLA/corporate-cla.md)).
- [x] This change is a clean-room implementation; no third-party copyrighted code has been copied without approval and notice in `THIRD-PARTY-NOTICES.md`.
- [x] Any new source files include the standard license header from `docs/source-header.txt`. (No new source files.)
- [x] The code compiles and builds cleanly in the combined integration firmware described above.
- [x] No real patient / medical data is included in test fixtures, commits, or descriptions.