### PR TITLE
Add 180° and 270° rotation options

### DIFF
--- a/main/bsp_display.c
+++ b/main/bsp_display.c
@@ -319,37 +319,37 @@ static void lcd_panel_hw_recover(void)
     ESP_LOGI(TAG, "panel hardware reset + re-init (rot=%u)", (unsigned)s_rotation);
 }
 
-/* Apply rotation to the ST7789 panel via MADCTL (swap_xy + mirror).
- * Called after panel init/recover and when the user changes the setting.
- * The framebuffer layout (s_fb[y * 240 + x]) stays the same; the panel
- * remaps GRAM addressing so the physical pixels appear rotated. */
+/* Apply the hardware portion of the requested rotation.
+ *
+ * The panel's 0° and 90° MADCTL paths are reliable, but mirror_y (needed for
+ * a direct 180°/270° hardware rotation) leaves a split frame on this module.
+ * Keep mirror_y disabled and implement the missing half-turn while packing
+ * the DMA strips in lcd_flush():
+ *
+ *   0°   = panel 0°
+ *   90°  = panel 90°
+ *   180° = panel 0°  + software 180°
+ *   270° = panel 90° + software 180°
+ */
 static void apply_panel_rotation(uint16_t degrees)
 {
     if (!s_panel) return;
-    bool swap_xy = false;
-    bool mirror_x = false, mirror_y = false;
+    bool quarter_turn = false;
 
     switch (degrees) {
         case 0:
+        case 180:
             break;
         case 90:   /* clockwise 90° */
-            swap_xy = true;
-            mirror_x = true;
-            break;
-        case 180:
-            mirror_x = true;
-            mirror_y = true;
-            break;
         case 270:  /* clockwise 270° */
-            swap_xy = true;
-            mirror_y = true;
+            quarter_turn = true;
             break;
         default:
             return;
     }
 
-    esp_lcd_panel_swap_xy(s_panel, swap_xy);
-    esp_lcd_panel_mirror(s_panel, mirror_x, mirror_y);
+    esp_lcd_panel_swap_xy(s_panel, quarter_turn);
+    esp_lcd_panel_mirror(s_panel, quarter_turn, false);
 }
 
 void bsp_display_set_rotation(uint16_t degrees)
@@ -415,8 +415,23 @@ static void lcd_flush(void)
 
         uint16_t *buf = s_strip[bi];
         bi = (bi + 1) % LCD_STRIP_BUFS;
-        memcpy(buf, &s_fb[y0 * LCD_H_RES],
-               (size_t)rows * LCD_H_RES * sizeof(uint16_t));
+        if (s_rotation == 180 || s_rotation == 270) {
+            /* Rotate the framebuffer by 180° while copying it out of PSRAM.
+             * For 270°, the panel applies the remaining known-good 90° turn.
+             * Destination pixels stay contiguous so the DMA transfer format
+             * and strip address windows are unchanged. */
+            for (int dy = 0; dy < rows; dy++) {
+                int src_y = LCD_V_RES - 1 - (y0 + dy);
+                const uint16_t *src = &s_fb[src_y * LCD_H_RES + LCD_H_RES - 1];
+                uint16_t *dst = &buf[dy * LCD_H_RES];
+                for (int x = 0; x < LCD_H_RES; x++) {
+                    dst[x] = src[-x];
+                }
+            }
+        } else {
+            memcpy(buf, &s_fb[y0 * LCD_H_RES],
+                   (size_t)rows * LCD_H_RES * sizeof(uint16_t));
+        }
         /* Queue asynchronously; the DMA of this strip overlaps the memcpy of
          * the next one (the completion callback gives s_flush_done). */
         esp_lcd_panel_draw_bitmap(s_panel, 0, y0, LCD_H_RES, y0 + rows, buf);

--- a/main/bsp_display.c
+++ b/main/bsp_display.c
@@ -85,16 +85,16 @@ static void render_graph(void);
 static void render_info(void);
 static void render_status(void);
 static void display_task(void *arg);
-static void apply_panel_rotation(uint8_t degrees);
+static void apply_panel_rotation(uint16_t degrees);
 
 static esp_lcd_panel_handle_t s_panel = NULL;
 static esp_lcd_panel_io_handle_t s_io = NULL;
 static uint16_t *s_fb = NULL;
 static bool s_wifi_connected = false;
 static bool s_as11_paired = false;
-static uint8_t s_rotation = 0;  /* current LCD rotation in degrees */
+static uint16_t s_rotation = 0;  /* current LCD rotation in degrees */
 static volatile bool s_rotation_pending = false;  /* set_rotation requested, deferred to render task */
-static uint8_t s_pending_rotation_deg = 0;        /* requested rotation (valid when s_rotation_pending) */
+static uint16_t s_pending_rotation_deg = 0;       /* requested rotation (valid when s_rotation_pending) */
 
 /* Strip blit: the framebuffer lives in PSRAM (not DMA-capable), so it is
  * pushed to the panel in chunks via small internal DMA-capable buffers.
@@ -316,14 +316,14 @@ static void lcd_panel_hw_recover(void)
         apply_panel_rotation(s_rotation);
     }
     esp_lcd_panel_disp_on_off(s_panel, true);
-    ESP_LOGI(TAG, "panel hardware reset + re-init (rot=%u)", s_rotation);
+    ESP_LOGI(TAG, "panel hardware reset + re-init (rot=%u)", (unsigned)s_rotation);
 }
 
 /* Apply rotation to the ST7789 panel via MADCTL (swap_xy + mirror).
  * Called after panel init/recover and when the user changes the setting.
  * The framebuffer layout (s_fb[y * 240 + x]) stays the same; the panel
  * remaps GRAM addressing so the physical pixels appear rotated. */
-static void apply_panel_rotation(uint8_t degrees)
+static void apply_panel_rotation(uint16_t degrees)
 {
     if (!s_panel) return;
     bool swap_xy = false;
@@ -336,6 +336,14 @@ static void apply_panel_rotation(uint8_t degrees)
             swap_xy = true;
             mirror_x = true;
             break;
+        case 180:
+            mirror_x = true;
+            mirror_y = true;
+            break;
+        case 270:  /* clockwise 270° */
+            swap_xy = true;
+            mirror_y = true;
+            break;
         default:
             return;
     }
@@ -344,13 +352,13 @@ static void apply_panel_rotation(uint8_t degrees)
     esp_lcd_panel_mirror(s_panel, mirror_x, mirror_y);
 }
 
-void bsp_display_set_rotation(uint8_t degrees)
+void bsp_display_set_rotation(uint16_t degrees)
 {
     switch (degrees) {
-        case 0: case 90:
+        case 0: case 90: case 180: case 270:
             break;
         default:
-            ESP_LOGW(TAG, "set_rotation: invalid %u", degrees);
+            ESP_LOGW(TAG, "set_rotation: invalid %u", (unsigned)degrees);
             return;
     }
 
@@ -369,7 +377,7 @@ void bsp_display_set_rotation(uint8_t degrees)
         apply_panel_rotation(degrees);
     }
 
-    ESP_LOGI(TAG, "rotation set to %u°", degrees);
+    ESP_LOGI(TAG, "rotation set to %u°", (unsigned)degrees);
     if (s_display_task) xTaskNotifyGive(s_display_task);
 }
 
@@ -1421,7 +1429,7 @@ static void display_task(void *arg)
         bool dirty = s_status_dirty;
         s_status_dirty = false;
         bool rot_pending = s_rotation_pending;
-        uint8_t rot_deg = s_pending_rotation_deg;
+        uint16_t rot_deg = s_pending_rotation_deg;
         s_rotation_pending = false;
         xSemaphoreGive(s_state_mutex);
 

--- a/main/bsp_display.h
+++ b/main/bsp_display.h
@@ -62,5 +62,6 @@ uint8_t bsp_display_get_brightness(void);
 void bsp_display_apply_backlight_policy(bool force_on);
 
 /* Set LCD rotation in degrees (0, 90, 180, 270). Applied by the display task
- * via ST7789 MADCTL and re-applied after panel reset. */
+ * using the ST7789's reliable 0°/90° paths plus a software half-turn for
+ * 180°/270°, and re-applied after panel reset. */
 void bsp_display_set_rotation(uint16_t degrees);

--- a/main/bsp_display.h
+++ b/main/bsp_display.h
@@ -61,6 +61,6 @@ uint8_t bsp_display_get_brightness(void);
  *   force_on: if true, always turn backlight on (used for SoftAP mode). */
 void bsp_display_apply_backlight_policy(bool force_on);
 
-/* Set LCD rotation in degrees (0, 90, 180, 270). Applies to hardware
- * immediately via ST7789 MADCTL. Must be re-applied after panel reset. */
-void bsp_display_set_rotation(uint8_t degrees);
+/* Set LCD rotation in degrees (0, 90, 180, 270). Applied by the display task
+ * via ST7789 MADCTL and re-applied after panel reset. */
+void bsp_display_set_rotation(uint16_t degrees);

--- a/main/device_settings.c
+++ b/main/device_settings.c
@@ -47,9 +47,22 @@ static const char *TAG = "dev_settings";
 #define MAX_BRIGHTNESS           200 /* 20.0% */
 #define DEFAULT_ALERT_VOLUME     65
 #define MIN_ALERT_VOLUME         50
-#define DEFAULT_LCD_ROTATION     0
+#define DEFAULT_LCD_ROTATION     LCD_ROTATION_0
 
 static device_settings_t s_settings;
+
+static bool lcd_rotation_is_valid(int degrees)
+{
+    switch (degrees) {
+        case LCD_ROTATION_0:
+        case LCD_ROTATION_90:
+        case LCD_ROTATION_180:
+        case LCD_ROTATION_270:
+            return true;
+        default:
+            return false;
+    }
+}
 
 esp_err_t device_settings_load(device_settings_t *cfg)
 {
@@ -80,15 +93,18 @@ esp_err_t device_settings_load(device_settings_t *cfg)
     if (nvs_get_u8(h, NVS_KEY_ALERT_VOL, &u8val) == ESP_OK) {
         cfg->alert_volume = (u8val < MIN_ALERT_VOLUME) ? MIN_ALERT_VOLUME : u8val;
     }
-    if (nvs_get_u8(h, NVS_KEY_LCD_ROTATION, &u8val) == ESP_OK) {
-        switch (u8val) {
-            case 0: case 90:
-                cfg->lcd_rotation = u8val;
-                break;
-            default:
-                cfg->lcd_rotation = DEFAULT_LCD_ROTATION;
-                break;
-        }
+    uint16_t rotation;
+    esp_err_t rotation_err = nvs_get_u16(h, NVS_KEY_LCD_ROTATION, &rotation);
+    if (rotation_err == ESP_ERR_NVS_TYPE_MISMATCH) {
+        /* Firmware through v1.2.2 stored 0°/90° as uint8_t. Keep those
+         * settings readable until the next save migrates the key to uint16_t. */
+        uint8_t legacy_rotation;
+        rotation_err = nvs_get_u8(h, NVS_KEY_LCD_ROTATION, &legacy_rotation);
+        if (rotation_err == ESP_OK) rotation = legacy_rotation;
+    }
+    if (rotation_err == ESP_OK) {
+        cfg->lcd_rotation = lcd_rotation_is_valid(rotation) ?
+                            rotation : DEFAULT_LCD_ROTATION;
     }
 
     nvs_close(h);
@@ -97,7 +113,7 @@ esp_err_t device_settings_load(device_settings_t *cfg)
     ESP_LOGI(TAG, "loaded: brightness=%u (%.1f%%), lcd_therapy=%u, alert_vol=%u, lcd_rot=%u",
              s_settings.brightness, s_settings.brightness / 10.0,
              s_settings.lcd_therapy_mode, s_settings.alert_volume,
-             s_settings.lcd_rotation);
+             (unsigned)s_settings.lcd_rotation);
     return ESP_OK;
 }
 
@@ -111,7 +127,7 @@ static esp_err_t do_device_settings_save(void *arg)
     nvs_set_u8(h, NVS_KEY_BRIGHTNESS, cfg->brightness);
     nvs_set_u8(h, NVS_KEY_LCD_THERAPY, (uint8_t)cfg->lcd_therapy_mode);
     nvs_set_u8(h, NVS_KEY_ALERT_VOL, cfg->alert_volume);
-    nvs_set_u8(h, NVS_KEY_LCD_ROTATION, cfg->lcd_rotation);
+    nvs_set_u16(h, NVS_KEY_LCD_ROTATION, cfg->lcd_rotation);
     ret = nvs_commit(h);
     nvs_close(h);
     return ret;
@@ -128,7 +144,7 @@ esp_err_t device_settings_save(const device_settings_t *cfg)
         ESP_LOGI(TAG, "saved: brightness=%u (%.1f%%), lcd_therapy=%u, alert_vol=%u, lcd_rot=%u",
                  s_settings.brightness, s_settings.brightness / 10.0,
                  s_settings.lcd_therapy_mode, s_settings.alert_volume,
-                 s_settings.lcd_rotation);
+                 (unsigned)s_settings.lcd_rotation);
     }
     return ret;
 }
@@ -163,14 +179,9 @@ esp_err_t device_settings_set_alert_volume(uint8_t percent)
     return ESP_OK;
 }
 
-esp_err_t device_settings_set_lcd_rotation(uint8_t degrees)
+esp_err_t device_settings_set_lcd_rotation(uint16_t degrees)
 {
-    switch (degrees) {
-        case 0: case 90:
-            break;
-        default:
-            return ESP_ERR_INVALID_ARG;
-    }
+    if (!lcd_rotation_is_valid(degrees)) return ESP_ERR_INVALID_ARG;
     s_settings.lcd_rotation = degrees;
     bsp_display_set_rotation(degrees);
     return ESP_OK;
@@ -228,14 +239,8 @@ esp_err_t device_settings_save_json(const char *json_str)
     }
     if ((v = cJSON_GetObjectItem(root, "lcd_rotation")) && cJSON_IsNumber(v)) {
         int val = v->valueint;
-        switch (val) {
-            case 0: case 90:
-                cfg.lcd_rotation = (uint8_t)val;
-                break;
-            default:
-                cfg.lcd_rotation = 0;
-                break;
-        }
+        cfg.lcd_rotation = lcd_rotation_is_valid(val) ?
+                           (uint16_t)val : DEFAULT_LCD_ROTATION;
     }
 
     cJSON_Delete(root);

--- a/main/device_settings.h
+++ b/main/device_settings.h
@@ -36,17 +36,19 @@ typedef enum {
     LCD_THERAPY_INFO       = 3,  /* Info panel: leak rate + session runtime */
 } lcd_therapy_mode_t;
 
-/* LCD rotation in degrees (0 = default, 90 = clockwise) */
+/* LCD rotation in clockwise degrees (0 = default) */
 typedef enum {
     LCD_ROTATION_0   = 0,
     LCD_ROTATION_90  = 90,
+    LCD_ROTATION_180 = 180,
+    LCD_ROTATION_270 = 270,
 } lcd_rotation_t;
 
 typedef struct {
     uint8_t brightness;        /* tenth-percent units: 1=0.1%, 200=20.0% */
     lcd_therapy_mode_t lcd_therapy_mode;
     uint8_t alert_volume;      /* speaker volume for alerts: 0-100 */
-    uint8_t lcd_rotation;      /* degrees: 0 or 90 */
+    uint16_t lcd_rotation;     /* clockwise degrees: 0, 90, 180, or 270 */
 } device_settings_t;
 
 /* Load settings from NVS. Returns ESP_OK if loaded, ESP_ERR_NVS_NOT_FOUND
@@ -71,9 +73,9 @@ esp_err_t device_settings_set_lcd_therapy_mode(lcd_therapy_mode_t mode);
  * bsp_audio. Call device_settings_save() to persist. */
 esp_err_t device_settings_set_alert_volume(uint8_t percent);
 
-/* Set LCD rotation (0 or 90 degrees). Updates in-memory copy and
+/* Set LCD rotation (0, 90, 180, or 270 degrees). Updates in-memory copy and
  * applies to hardware immediately. Call device_settings_save() to persist. */
-esp_err_t device_settings_set_lcd_rotation(uint8_t degrees);
+esp_err_t device_settings_set_lcd_rotation(uint16_t degrees);
 
 /* Get settings as JSON string for web UI. Caller must free(). */
 esp_err_t device_settings_get_json(char **out_json);

--- a/main/portal.html
+++ b/main/portal.html
@@ -698,6 +698,8 @@ Display &amp; Sound
 <select id="lcd-rotation" class="form-control" onchange="onLcdRotationChange(this)">
 <option value="0">0° (default)</option>
 <option value="90">90° clockwise</option>
+<option value="180">180° clockwise</option>
+<option value="270">270° clockwise</option>
 </select>
 </div>
 <div class="form-group">


### PR DESCRIPTION
## Description

Adds 180° and 270° LCD rotation options alongside the existing 0° and 90° settings.

- Keep the ST7789's proven 0°/90° MADCTL paths.
- Implement the remaining half-turn while packing DMA strips, avoiding the panel's `mirror_y` split-frame artifact at 180°/270°.
- Widen the in-memory and persisted rotation value to `uint16_t` so 270° is representable.
- Preserve existing saved 0°/90° settings by falling back to the legacy `uint8_t` NVS value during upgrade.
- Add 180° and 270° options to the Display & Sound portal control.

## Validation

Validated on a Waveshare ESP32-S3-Touch-LCD-1.54 using the combined integration branch containing this PR and #168.

- [x] `git diff --check`
- [x] `./scripts/build-dist.sh` using the pinned `espressif/idf:v5.5.1` Docker image
- [x] OTA image passed `esptool` checksum and validation-hash verification
- [x] Flashed and booted combined firmware `v1.2.2-dev+4`
- [x] Initial direct `mirror_y` implementation reproduced a split frame; fix commit `894ef0d` was then rebuilt and reflashed
- [x] Physical validation: 0°, 90°, 180°, and 270° each rendered the complete frame correctly
- [x] Full power-off/power-on cycle completed normally and the saved 180° setting persisted

## Checklist

- [x] I have read and agree to the [Contributor License Agreement (CLA)](CLA/individual-cla.md) (or [Corporate CLA](CLA/corporate-cla.md)).
- [x] This change is a clean-room implementation; no third-party copyrighted code has been copied without approval and notice in `THIRD-PARTY-NOTICES.md`.
- [x] No new source files were added.
- [x] The code compiles and builds cleanly in the combined integration firmware described above.
- [x] No real patient / medical data is included in test fixtures, commits, or descriptions.