### PR TITLE
fix(net_provision): create s_format_mtx at startup, not lazily

### DIFF
--- a/main/net_provision.c
+++ b/main/net_provision.c
@@ -2904,7 +2904,6 @@ static esp_err_t actions_handler(httpd_req_t *req)
             cJSON_Delete(root);
             return send_busy(req, "therapy recording in progress");
         }
-        if (!s_format_mtx) s_format_mtx = xSemaphoreCreateMutex();
         xSemaphoreTake(s_format_mtx, portMAX_DELAY);
         if (s_format_progress.active) {
             xSemaphoreGive(s_format_mtx);
@@ -2962,6 +2961,9 @@ static esp_err_t start_webserver(void)
     /* Periodic upload scans yield to a live therapy recording; event-driven
      * uploads still run, since they matter more than a housekeeping scan. */
     upload_sched_set_busy_fn(sd_storage_recording_active);
+    /* Guards s_format_progress between format_sd_task and the progress handler.
+     * Created here so it exists before any request can reach the handler. */
+    if (!s_format_mtx) s_format_mtx = xSemaphoreCreateMutex();
 
     httpd_config_t config = HTTPD_DEFAULT_CONFIG();
     config.lru_purge_enable = true;


### PR DESCRIPTION
Turned up in a post-merge review of #173's follow-up commit (`9eaa72d`).

## Problem

`s_format_mtx` is created only inside the `format-sd` branch of `actions_handler`:

```c
if (!s_format_mtx) s_format_mtx = xSemaphoreCreateMutex();
```

`format_progress_handler` (`GET /api/format-progress`) and the other guarded sites take it unconditionally. Before the first `format-sd` POST of a boot the handle is NULL, so a `GET /api/format-progress` — a direct request, or a Maintenance-page `pollFormatProgress` fetch that spans a reboot and resolves against the fresh boot — hits `configASSERT` in `xSemaphoreTake` and panic-reboots the device.

Reproduce: `curl http://<device>/api/format-progress` right after a boot.

## Fix

Create the mutex in `start_webserver()`, before `httpd_start`, so it exists before any handler can run. Drop the lazy init in `actions_handler`. `start_webserver()` is re-entrant on Wi-Fi reconnect; the `if (!s_format_mtx)` guard keeps re-init a no-op.

1 file, +3 −1.

## Testing

Built with ESP-IDF v5.5.1, flashed to a Waveshare ESP32-S3-Touch-LCD-1.54. Confirmed `curl /api/format-progress` immediately after boot returns `{"active":false,"done":false,"ok":false,"error":""}` and the device stays up (panics on current `main`). Normal Format SD unchanged.
