### PR TITLE
fix(sd_storage): use opendir() for the post-format-failure card probe

### DIFF
--- a/main/sd_storage.c
+++ b/main/sd_storage.c
@@ -359,14 +359,15 @@ esp_err_t sd_storage_format(void)
         if (ret != ESP_OK) {
             ESP_LOGE(TAG, "format: esp_vfs_fat_sdcard_format_cfg failed: %s",
                      esp_err_to_name(ret));
-            /* esp_vfs_fat_sdcard_format_cfg unmounts before formatting.  If
-             * f_mkfs failed, the volume may or may not have been remounted.
-             * Probe by trying a trivial VFS op; if it works, the card is
-             * still accessible and we should report it as mounted so other
-             * subsystems can continue.  If not, leave s_mounted=false and
-             * the user will need to reboot. */
-            FILE *f = fopen(SD_APP_DIR, "r");
-            if (f) { fclose(f); s_mounted = true; }
+            /* esp_vfs_fat_sdcard_format_cfg() unmounts, runs f_mkfs, then tries
+             * to remount.  On f_mkfs failure the remount may still have
+             * succeeded (card usable) or failed (driver has recycled s_card).
+             * opendir() on the mount root distinguishes the two: it only
+             * succeeds when the VFS is registered and the volume is mounted,
+             * which is exactly the case where s_card is still valid.  Otherwise
+             * leave s_mounted=false and the user reboots. */
+            DIR *d = opendir(SD_MOUNT_POINT);
+            if (d) { closedir(d); s_mounted = true; }
             return ret;
         }
         s_mounted = true;


### PR DESCRIPTION
Turned up in a post-merge review of #173's follow-up commit (`9eaa72d`).

## Problem

The probe that restores `s_mounted` when the card survived a failed format uses `fopen(SD_APP_DIR, "r")`. `SD_APP_DIR` is a directory, and `fopen("…","r")` on a directory returns NULL on the FATFS VFS even when the card is mounted — so `s_mounted` is never restored and the branch is effectively dead (a failed format always drops the card until a manual reboot).

## Fix

Use `opendir(SD_MOUNT_POINT)` instead. It succeeds only when the VFS path is registered and the volume mounted — which is exactly the case where `esp_vfs_fat_sdcard_format_cfg()` left `s_card` valid (its internal remount succeeded). When the remount failed the driver has already recycled `s_card` and `opendir()` fails, so `s_mounted` correctly stays false and no stale handle is exposed.

`<dirent.h>` is already included. 1 file, 2 code lines (+ comment).

## Testing

Code-review fix — the failure path (format fails while the card stays mounted) needs fault injection to hit directly. `opendir()` on the mount root is the same call the normal successful-format path relies on. Built with ESP-IDF v5.5.1 and flashed; normal Format SD behaves as before.
