### PR TITLE
fix(session_writer): write the v2 missing-data sentinel for absent SA2/PLD samples

### DIFF
--- a/main/session_writer.c
+++ b/main/session_writer.c
@@ -2230,8 +2230,8 @@ void session_writer_on_stream_data_raw(const char *json, int len)
     if (--s->sa2_countdown == 0) {
         s->sa2_countdown = 5;
         if (b->n_sa2 < SA2_CAP) {
-            b->sa2_hr[b->n_sa2] = hr_found ? hr_val : -1;
-            b->sa2_spo2[b->n_sa2] = spo2_found ? spo2_val : -1;
+            b->sa2_hr[b->n_sa2] = hr_found ? hr_val : SNT_MISSING;
+            b->sa2_spo2[b->n_sa2] = spo2_found ? spo2_val : SNT_MISSING;
             b->n_sa2++;
         } else {
             s->sa2_dropped++;
@@ -2254,7 +2254,7 @@ void session_writer_on_stream_data_raw(const char *json, int len)
         if (any_found) {
             if (b->n_pld < PLD_CAP) {
                 for (int k = 0; k < 12; k++)
-                    b->pld[b->n_pld][k] = pld_found[k] ? pld_vals[k] : -1;
+                    b->pld[b->n_pld][k] = pld_found[k] ? pld_vals[k] : SNT_MISSING;
                 b->n_pld++;
                 for (int k = 0; k < 12; k++)
                     s->last_pld[k] = b->pld[b->n_pld - 1][k];


### PR DESCRIPTION
> **Disclaimer: I don't have the hardware.** Not compiled or flashed — written from reading `main @ 9f54bf1`. The change is three sentinel constants in `session_writer.c`; please build and check one no-oximeter night before merging.

## Problem

SNT v2 (6cdfa6a) moved the missing-data sentinel from `−1` to `INT16_MIN` (`SNT_MISSING`, `session_writer.c:99`). The gap-fill path (`:2148-2149`), `parse_scaled_array` (`null` → `SNT_MISSING`) and the BRP path all use it. The SA2 sample path and the PLD path still write the v1 value:

```c
:2233   b->sa2_hr[b->n_sa2]   = hr_found   ? hr_val   : -1;
:2234   b->sa2_spo2[b->n_sa2] = spo2_found ? spo2_val : -1;
:2257   b->pld[b->n_pld][k]   = pld_found[k] ? pld_vals[k] : -1;
```

The reader (`edf_gen.c:1140-1143`) only passes a sample through as "invalid" when `stored == snt_missing_for(version)`, which for a v2 file is `INT16_MIN`. A stored `−1` is treated as a real value: phys = −0.01, digital = 0. So for a night with no oximeter attached, `SA2.edf` (`Pulse.1s`/`SpO2.1s`, `invalid_passthrough = true`) contains **0** for every sample where the AS11's own file — and SomnoTrace before v2 (`spec/archive/edf-esp-vs-as11.md`: "all −1 sentinels pass through correctly") — carries `−1`. OSCAR reads that as a genuine 0 bpm / 0 % sample rather than "no data".

The same happens for PLD channels the AS11 didn't send in a given second: non-passthrough channels clamp to `dig_min` (0) instead of being marked missing.

One thing I can't confirm without a capture: whether the AS11 omits the `HeartRate`/`SpO2` keys when no oximeter is present (→ `hr_found == false` → this bug) or sends `null` (→ `parse_scaled_array` already yields `SNT_MISSING`, and this path is never hit). Either way the fix is correct for a v2 file; it only changes which value is written when a key is absent.

## Fix

Write `SNT_MISSING` instead of `−1` at the three sites, matching the gap path a few lines above and the v2 reader.

## Testing

Not built or run. Verification on hardware: record a session with no oximeter paired, then check the v2 `*_sa2.snt` — sample values should be `-32768` (0x8000), not `-1` — and the resulting `SA2.edf` should be all `−1`, identical to what the AS11 writes for the same night.
