### PR TITLE
fix(ble): free collected spool fragments when the pull times out

### DIFF
--- a/main/as11_ble.c
+++ b/main/as11_ble.c
@@ -2759,8 +2759,17 @@ static esp_err_t spool_one_round(const char *spool_addr_json,
     if (xSemaphoreTake(coll.sem, pdMS_TO_TICKS(30000)) != pdTRUE) {
         ESP_LOGE(TAG, "spool: fragment collection timeout (%d frags received)",
                  coll.frag_count);
-        vSemaphoreDelete(coll.sem);
+        /* Detach first: a SpoolFragment notification arriving late must not
+         * append to a collector that is being torn down. */
         s_spool_collector = NULL;
+        vSemaphoreDelete(coll.sem);
+        /* Fragments already received were malloc'd by the notification
+         * handler.  The success and out-of-memory paths free them; this one
+         * did not, leaking up to SPOOL_MAX_FRAGS x maxFragmentSize per
+         * timed-out round. */
+        for (int i = 0; i < coll.frag_count; i++) {
+            free(coll.frags[i].data);
+        }
         /* Clear any stale RPC response state so subsequent RPCs
          * don't pick up a leftover response from the timed-out pull. */
         clear_response();


### PR DESCRIPTION
`SpoolFragment` notifications `malloc` each fragment and hand it to the
collector. `spool_one_round()` frees them on the success path (as it
concatenates) and on the out-of-memory path — but the 30 s collection timeout
returns `ESP_FAIL` without freeing what had already arrived.

A timed-out round therefore drops up to `SPOOL_MAX_FRAGS` (32) fragments of up
to `maxFragmentSize` (2808) bytes — roughly 90 KB — and spool pulls are
retried, so it accumulates. The rounds that time out are the ones under a weak
link, which is also when rounds repeat most.

Two lines of the diff are not the leak fix and are worth calling out:

- The collector is now detached **before** the semaphore is deleted rather
  than after. A `SpoolFragment` notification arriving during teardown would
  otherwise append to a collector that is going away — and now that the
  fragments are freed there, appending to it is worse than it was.
- The free loop runs after that detach for the same reason: nothing can be
  handed a pointer that is about to be released.

## Verification

Read-only reasoning, not observation. I have an AirSense 11 but no ESP32
running this firmware, so this has not been built with ESP-IDF or run on a
device, and `as11_ble.c` needs FreeRTOS so it does not compile on a host
either. What I did check is the ownership on both sides: the fragments are
allocated in the notification handler and stored in `coll.frags[i].data`, and
the only `free()` calls for them are on the concatenate path and the malloc
failure path.

Rebased onto `dee8853`. `as11_ble.c` changed substantially since I wrote this
(+221/−177) and the hunk still applies; the timeout path still frees nothing.

