### PR TITLE
fix(edf): CSL.edf must write "CSR Start" and "CSR End", not "CSR" for both

### DIFF
--- a/main/edf_gen.c
+++ b/main/edf_gen.c
@@ -3095,10 +3095,16 @@ static const char *event_label_map_str(const char *ev_name, bool csl_mode)
 {
     if (!ev_name) return NULL;
     if (csl_mode) {
-        if (strcmp(ev_name, "CsrStart") == 0 || strcmp(ev_name, "CsrEnd") == 0 ||
-            strcmp(ev_name, "CSRStart") == 0 || strcmp(ev_name, "CSREnd") == 0) {
-            return "CSR";
-        }
+        /* The AS11 writes the two edges as SEPARATE labels — "CSR Start" and
+         * "CSR End", each a zero-duration marker — and a reader pairs them to
+         * recover the episode.  Returning one label for both loses that: the
+         * two annotations become indistinguishable, and the dedup below (same
+         * onset_sec + same label) then merges a genuine pair that lands in the
+         * same second. */
+        if (strcmp(ev_name, "CsrStart") == 0 || strcmp(ev_name, "CSRStart") == 0)
+            return "CSR Start";
+        if (strcmp(ev_name, "CsrEnd") == 0 || strcmp(ev_name, "CSREnd") == 0)
+            return "CSR End";
         return NULL;
     }
     if (strcmp(ev_name, "HypopneaEnd") == 0)          return "Hypopnea";


### PR DESCRIPTION
Closes #190. You said you'd fix this yourself — if you already have, just
close this; I'd rather hand you the patch than have you redo it.

`event_label_map_str()` mapped every CSR edge to the single label `"CSR"`.
The AS11 writes two, verified across 301 real `CSL.edf` files on my own
AirSense 11's card, where CSR episodes appear as a pair of zero-duration
markers:

```
+<onset>\x150\x14CSR Start\x14\x00
+<onset>\x150\x14CSR End\x14\x00
```

So the generated `CSL.edf` carried a label the machine never emits, and the
start/end distinction was gone — both annotations read `CSR` with the same
duration, leaving nothing to pair them by or to reconstruct the span from.

There is a second-order effect in the same function that the label change also
fixes. `generate_eve_edf()` drops an event when the previous one has the same
`onset_sec` **and** the same label. That is right for BLE retransmits of a
single event, but once both edges carry the same label it also merges a
genuine start/end pair landing in the same second — a short CSR episode
became one annotation.

Your own trace of the origin is the best evidence of why this was never
caught: `spec/archive/edf-esp-vs-as11.md:143` says the CSR codes were
"extrapolated from the +1 pattern; no CSR events have been observed in test
sessions to confirm."

## What this does not settle

It does **not** establish that `CsrStart`/`CsrEnd` (or the `CSRStart`/`CSREnd`
spellings) are the names the AS11 actually sends under
`TherapyEvents-RespiratoryEvents`. I have no BLE capture of that stream. If
none of the four match, `CSL.edf` contains no CSR events at all rather than
mislabelled ones — a different and larger bug that this change does not fix
and cannot detect. Worth a look if you have a capture with CSR in it.

Not built with ESP-IDF or run on a device: I have an AirSense 11 but no ESP32
running this firmware, so this is read against real machine output rather than
observed on hardware.

