### PR TITLE
test(properties): bind the host property suite to the shipped code (#202)

### DIFF
--- a/main/edf_data_dict.h
+++ b/main/edf_data_dict.h
@@ -25,10 +25,32 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <limits.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/* ── Spool → EDF fixed-point conversion ──────────────────────────────── */
+
+/* Convert a Summary-spool fixed-point integer to its EDF digital value.
+ * `raw == -1` is the missing sentinel and passes through untouched.
+ * Rounding is SYMMETRIC (half away from zero) — truncating here silently
+ * biased every STR settings value low, which is what issue #192 reported.
+ *
+ * Lives in this header rather than in edf_summary.c so the host property
+ * tests bind to the same definition the firmware uses. A test carrying its
+ * own copy stays green when this one changes. */
+static inline int16_t spool_to_edf(int16_t raw, int num, int den)
+{
+    if (raw == -1 || den <= 0) return -1;
+    int32_t prod = (int32_t)raw * num;
+    int32_t half = den / 2;
+    int32_t rounded = (prod >= 0) ? (prod + half) / den : (prod - half) / den;
+    if (rounded > INT16_MAX) return INT16_MAX;
+    if (rounded < INT16_MIN) return INT16_MIN;
+    return (int16_t)rounded;
+}
 
 /* ── Signal definition structure ─────────────────────────────────────── */
 

--- a/main/edf_summary.c
+++ b/main/edf_summary.c
@@ -445,17 +445,6 @@ static int profile_name_to_mop(const char *name)
  *   Indices (AHI etc)    logical_scale = 10    → num=1, den=10
  *   Duration/enums/SAU   logical_scale = 1     → no conversion needed
  */
-static inline int16_t spool_to_edf(int16_t raw, int num, int den)
-{
-    if (raw == -1 || den <= 0) return -1;
-    int32_t prod = (int32_t)raw * num;
-    int32_t half = den / 2;
-    int32_t rounded = (prod >= 0) ? (prod + half) / den : (prod - half) / den;
-    if (rounded > INT16_MAX) return INT16_MAX;
-    if (rounded < INT16_MIN) return INT16_MIN;
-    return (int16_t)rounded;
-}
-
 /* Build STR data values [4-132] from a summary context and settings JSON.
  * str_values must be pre-filled with 0xFF (sentinel for "no data").
  *

--- a/scripts/edf_properties_test.c
+++ b/scripts/edf_properties_test.c
@@ -37,64 +37,20 @@
 
 #include "cJSON.h"
 #include "esp_log.h"
+#include "snt_format.h"      /* clamp_i16, snt_missing_for, is_channel_map_valid */
+#include "edf_data_dict.h"   /* signal counts, spool_to_edf */
 #include "as11_time.h"
 
 /* ════════════════════════════════════════════════════════════════════
- *  Replicated Production Helpers Under Test (main/edf_gen.c)
+ *  Production code under test — included, never replicated.
+ *
+ *  These properties used to assert against private copies of clamp_i16,
+ *  snt_missing_for, is_channel_map_valid, spool_to_edf and the recording-id
+ *  formatter. A copy stays green when the shipped version changes, so the
+ *  suite could not see a regression in the code it names. They are included
+ *  from snt_format.h / edf_data_dict.h / as11_time.h now.
  * ════════════════════════════════════════════════════════════════════ */
 
-#define SNT_MISSING_V1  -1
-#define SNT_MISSING_V2  INT16_MIN
-
-static inline int16_t snt_missing_for(uint8_t version)
-{
-    return (version >= 2) ? SNT_MISSING_V2 : SNT_MISSING_V1;
-}
-
-static inline int16_t clamp_i16(int val, int16_t min_val, int16_t max_val)
-{
-    if (val > max_val) return max_val;
-    if (val < min_val) return min_val;
-    return (int16_t)val;
-}
-
-static inline bool is_channel_map_valid(const int *map, int n_signals, int snt_channels)
-{
-    if (!map) return (snt_channels == n_signals);
-    for (int i = 0; i < n_signals; i++) {
-        if (map[i] < 0 || map[i] >= snt_channels) return false;
-    }
-    return true;
-}
-
-static inline int16_t spool_to_edf(int16_t raw, int num, int den)
-{
-    if (raw == -1 || den <= 0) return -1;
-    int32_t prod = (int32_t)raw * num;
-    int32_t half = den / 2;
-    int32_t rounded = (prod >= 0) ? (prod + half) / den : (prod - half) / den;
-    if (rounded > INT16_MAX) return INT16_MAX;
-    if (rounded < INT16_MIN) return INT16_MIN;
-    return (int16_t)rounded;
-}
-
-static void format_recording_id(char *out, size_t out_len,
-                                int64_t epoch_ms,
-                                const char *srn, const char *mid, const char *vid)
-{
-    static const char *month_names[] = {
-        "JAN", "FEB", "MAR", "APR", "MAY", "JUN",
-        "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"
-    };
-    time_t t = (time_t)(epoch_ms / 1000);
-    struct tm tm;
-    gmtime_r(&t, &tm); /* Test environment uses gmtime_r for UTC baseline */
-
-    snprintf(out, out_len,
-             "Startdate %02d-%s-%04d X X X SRN=%s MID=%s VID=%s",
-             tm.tm_mday, month_names[tm.tm_mon % 12],
-             tm.tm_year + 1900, srn, mid, vid);
-}
 
 /* Event edge parser under test */
 static int64_t find_zle_edge_time_json(const cJSON *msg, int want_value, int64_t clock_drift_ms)
@@ -147,6 +103,13 @@ static int g_fail = 0;
 
 static void test_prop_01_noon_day_boundaries(void)
 {
+    /* Pin the AS11 offset the comments below assume. Without this the test
+     * silently inherits the HOST timezone — as11_time_noon_day() falls back to
+     * ESP-local time when no offset is stored, and PROP_02, which parses
+     * +10:00, runs after this. The suite then passed only in AEST: UTC 36/1,
+     * Europe/Prague 36/1, America/New_York 34/3. */
+    as11_time_set_offset(10 * 3600, "test");
+
     /* 2026-09-02 12:00:00 AEST (+10:00) is 2026-09-02 02:00:00 UTC = epoch 1788314400 */
     /* 1 second before noon (11:59:59 local): belongs to previous treatment day (20260901) */
     char day[16];
@@ -288,16 +251,20 @@ static void test_prop_08_invalid_passthrough_flag(void)
 
 static void test_prop_09_signal_count_invariant(void)
 {
-    /* Verify known EDF signal counts per spec */
-    int brp_count = 2; /* Flow, MaskPress */
-    int pld_count = 9; /* MaskPress, Press, EprPress, Leak, RespRate, TidVol, MinVent, Snore, FlowLim */
-    int sa2_count = 2; /* SpO2, Pulse */
-    int str_count = 134; /* Summary signals */
+    /* Read the SHIPPED macros. Asserting local literals here made this test
+     * pass no matter what edf_data_dict.h said. */
+    TEST_ASSERT(EDF_BRP_SIGNAL_COUNT == 2, "PROP_09: BRP signal count is exactly 2");
+    TEST_ASSERT(EDF_PLD_SIGNAL_COUNT == 9, "PROP_09: PLD signal count is exactly 9");
+    TEST_ASSERT(EDF_SA2_SIGNAL_COUNT == 2, "PROP_09: SA2 signal count is exactly 2");
+    TEST_ASSERT(STR_SIGNAL_COUNT == 134, "PROP_09: STR signal count is exactly 134");
 
-    TEST_ASSERT(brp_count == 2, "PROP_09: BRP signal count is exactly 2");
-    TEST_ASSERT(pld_count == 9, "PROP_09: PLD signal count is exactly 9");
-    TEST_ASSERT(sa2_count == 2, "PROP_09: SA2 signal count is exactly 2");
-    TEST_ASSERT(str_count == 134, "PROP_09: STR signal count is exactly 134");
+    /* …and that the tables really hold that many rows, not just the macros. */
+    TEST_ASSERT(sizeof(g_brp_signals) / sizeof(g_brp_signals[0]) == EDF_BRP_SIGNAL_COUNT,
+                "PROP_09: BRP table length matches its count macro");
+    TEST_ASSERT(sizeof(g_pld_signals) / sizeof(g_pld_signals[0]) == EDF_PLD_SIGNAL_COUNT,
+                "PROP_09: PLD table length matches its count macro");
+    TEST_ASSERT(sizeof(g_sa2_signals) / sizeof(g_sa2_signals[0]) == EDF_SA2_SIGNAL_COUNT,
+                "PROP_09: SA2 table length matches its count macro");
 }
 
 static void test_prop_10_header_date_calendar_vs_noon(void)
@@ -311,7 +278,7 @@ static void test_prop_10_header_date_calendar_vs_noon(void)
     TEST_ASSERT(strcmp(day_folder, "20260902") == 0, "PROP_10: Treatment day folder is 20260902");
 
     char rec_id[128];
-    format_recording_id(rec_id, sizeof(rec_id), epoch_ms, "22251436648", "46", "3");
+    as11_time_format_recording_id(rec_id, sizeof(rec_id), epoch_ms, "22251436648", "46", "3");
     TEST_ASSERT(strncmp(rec_id, "Startdate 03-SEP-2026", 21) == 0, "PROP_10: Waveform recording_id uses calendar date (03-SEP-2026)");
 }
 
@@ -369,7 +336,7 @@ static void test_prop_16_recording_id_format(void)
 {
     char out[128];
     int64_t epoch = 1788394175LL * 1000;
-    format_recording_id(out, sizeof(out), epoch, "22251436648", "46", "3");
+    as11_time_format_recording_id(out, sizeof(out), epoch, "22251436648", "46", "3");
 
     const char *expected = "Startdate 03-SEP-2026 X X X SRN=22251436648 MID=46 VID=3";
     TEST_ASSERT(strcmp(out, expected) == 0, "PROP_16: Recording ID matches ResMed format specification exactly");
@@ -377,6 +344,22 @@ static void test_prop_16_recording_id_format(void)
 
 int main(void)
 {
+    /* PIN THE HOST ZONE. Two properties assert a recording_id, and
+     * as11_time_format_recording_id() formats it with localtime_r() — by
+     * design, because the AS11 writes its own Startdate in local civil time
+     * (a card here shows "Startdate 29-JUL-2026" against startdate 29.07.26).
+     *
+     * The previous revision hid that: its private copy of the formatter called
+     * gmtime_r() with the comment "Test environment uses gmtime_r for UTC
+     * baseline", so PROP_10 and PROP_16 passed in every zone while asserting
+     * behaviour the firmware does not have. A copy that has DRIFTED from the
+     * original is worse than one that matches — it is green and wrong.
+     *
+     * With the real formatter in use the assertions are zone-dependent, so the
+     * zone is fixed here rather than inherited from whoever runs the suite. */
+    setenv("TZ", "UTC", 1);
+    tzset();
+
     printf("=== Running Automated Host Property Test Suite (16/16 Properties) ===\n");
 
     test_prop_01_noon_day_boundaries();


### PR DESCRIPTION
Fixes #202. Both halves, verified by mutation rather than by the suite going green.

## Copies, not code

`edf_properties_test.c` included only `esp_log.h` and `as11_time.h` from `main/`, and defined its own `clamp_i16`, `snt_missing_for`, `is_channel_map_valid`, `spool_to_edf` and `format_recording_id`. Two properties called nothing at all — PROP_09 declared `int brp_count = 2` and asserted it equalled 2 without ever reading `EDF_BRP_SIGNAL_COUNT`; PROP_08 inlined the passthrough branch rather than exercising the writer.

🔴 **One copy had drifted, which is worse than duplication.** The test's `format_recording_id` called `gmtime_r` where the shipped `as11_time_format_recording_id` calls `localtime_r`, with the comment *"Test environment uses gmtime_r for UTC baseline"*. PROP_10 and PROP_16 were therefore green in **every** timezone while asserting behaviour the firmware does not have. A copy that matches is merely invisible; a copy that has drifted is green and wrong.

**Fix:** delete the copies, include the shipped headers. `clamp_i16` / `snt_missing_for` / `is_channel_map_valid` were already in `snt_format.h`, and `as11_time_format_recording_id` was already public — only `spool_to_edf` needed a home, and it moved from `edf_summary.c` into `edf_data_dict.h` beside the tables it converts for. Both headers are host-portable (`stdint`/`stdbool`/`limits` only), so no new stubs are needed.

PROP_09 now reads the shipped macros **and** checks each table's length against its own count macro, since a macro and its table can disagree.

## Timezone

PROP_01's expectations are pinned to AEST in its comments, but nothing set an offset: `as11_time_noon_day()` falls back to ESP-local time when none is stored, and PROP_02 — which parses `+10:00` — runs *after* it. So PROP_01 read the host clock.

It now calls `as11_time_set_offset(10 * 3600, "test")` explicitly, and `main()` pins `TZ=UTC` for the recording-id properties, which are legitimately local-time-dependent now that they use the real formatter.

## Result

| | before | after |
|---|---|---|
| `Australia/Sydney` | 37 / 0 | **40 / 0** |
| `UTC` | 36 / **1** | **40 / 0** |
| `Europe/Prague` | 36 / **1** | **40 / 0** |
| `America/New_York` | 34 / **3** | **40 / 0** |

## Verified by mutation

A suite that was already green is not evidence that it now tests more, so:

| | mutation | before | after |
|---|---|---|---|
| A | `spool_to_edf` rounding → truncation (the #192 bug) | SURVIVED | **KILLED** |
| B | `EDF_BRP_SIGNAL_COUNT` 2 → 7 | SURVIVED | **KILLED** |
| C | noon-day previous-day step — **control** | killed | killed |

C is the control: killed both before and after, so A and B flipping is the change itself and not a difference in how the suite was run.

`as11_time_test` and `as11_events_test` still build and pass. Builds clean under `-Wall -Wextra`.

⚠️ One thing I could not do from here: I have no ESP-IDF toolchain, so I verified `edf_summary.c` only by host syntax parse after moving `spool_to_edf` out of it. A firmware build is worth a glance before merge.

