### PR TITLE
test: assert the boundaries the mutation harness showed were never asserted

### DIFF
--- a/scripts/as11_time_test.c
+++ b/scripts/as11_time_test.c
@@ -77,6 +77,19 @@ static void check_period_end(const char *what, int y, int m, int d, int h, int m
     expect_str(what, buf, want_dt);
 }
 
+/* Feed one TimeZoneOffset string through the settings parser, in the FlowGenerator shape
+ * Scenario 4 builds by hand. A successful parse also makes the value the anchor for every
+ * later noon-stamp derivation, which is what Scenario 11 relies on. */
+static bool parse_tz_setting(const char *value, as11_offset_t *out)
+{
+    cJSON n_off = { .child = NULL, .next = NULL, .string = "TimeZoneOffset", .valuestring = (char *)value, .type = cJSON_String };
+    cJSON n_tz = { .child = &n_off, .next = NULL, .string = "TimeZoneFeature", .valuestring = NULL, .type = 0 };
+    cJSON n_fp = { .child = &n_tz, .next = NULL, .string = "FeatureProfiles", .valuestring = NULL, .type = 0 };
+    cJSON n_sp = { .child = &n_fp, .next = NULL, .string = "SettingProfiles", .valuestring = NULL, .type = 0 };
+    cJSON n_fg = { .child = &n_sp, .next = NULL, .string = "FlowGenerator", .valuestring = NULL, .type = 0 };
+    return as11_time_offset_from_settings(&n_fg, out);
+}
+
 int main(void)
 {
     printf("\n=== Scenario 1: Issue #75 Vector (AS11 -05:00 vs ESP MST7MDT) ===\n");
@@ -226,6 +239,59 @@ int main(void)
     expect_str("noon-day label on 2100-03-01 (century boundary)", day, "21000301");
     as11_time_noon_day(4107502800000LL, day, sizeof(day));   /* 2100-02-28T13:00Z */
     expect_str("noon-day label on 2100-02-28 (2100 is not a leap year)", day, "21000228");
+    reset_offset();
+
+    printf("\n=== Scenario 10: Settings Offset Parser Boundaries ===\n");
+    reset_offset();
+    /* Every earlier settings case is a whole hour in the interior of [-12:00, +14:00], so
+     * hh*3600 + mm*60 was never told apart from hh*3600 - mm*60, and neither bound was
+     * ever shown to be inclusive. */
+    expect_int("+05:30 (half-hour offset)", parse_tz_setting("+05:30", &off) ? off : -999999, 19800);
+    expect_int("-03:30 (negative half-hour)", parse_tz_setting("-03:30", &off) ? off : -999999, -12600);
+    expect_int("+00:00 (hour zero is a valid hour)", parse_tz_setting("+00:00", &off) ? off : -999999, 0);
+    expect_int("-12:00 (lower bound is inclusive)", parse_tz_setting("-12:00", &off) ? off : -999999, -43200);
+    expect_int("+14:00 (upper bound is inclusive)", parse_tz_setting("+14:00", &off) ? off : -999999, 50400);
+    expect_int("-12:15 refused (below lower bound)", parse_tz_setting("-12:15", &off) ? 1 : 0, 0);
+    expect_int("+14:15 refused (above upper bound)", parse_tz_setting("+14:15", &off) ? 1 : 0, 0);
+    expect_int("+15:00 refused (hour out of range)", parse_tz_setting("+15:00", &off) ? 1 : 0, 0);
+    /* The sign is optional: an unsigned value reads as positive, and its first digit must
+     * not be swallowed as though it were a sign character. */
+    expect_int("10:00 (unsigned reads as +10:00)", parse_tz_setting("10:00", &off) ? off : -999999, 36000);
+
+    /* as11_time_set_offset() applies the same bounds, inclusive, and ignores the rest. */
+    as11_time_set_offset(-43200, "test");
+    expect_int("set_offset accepts -12:00", as11_time_get_offset(&off) ? off : -999999, -43200);
+    as11_time_set_offset(-43201, "test");
+    expect_int("set_offset ignores 1 s below -12:00", as11_time_get_offset(&off) ? off : -999999, -43200);
+    as11_time_set_offset(50400, "test");
+    expect_int("set_offset accepts +14:00", as11_time_get_offset(&off) ? off : -999999, 50400);
+    as11_time_set_offset(50401, "test");
+    expect_int("set_offset ignores 1 s above +14:00", as11_time_get_offset(&off) ? off : -999999, 50400);
+
+    printf("\n=== Scenario 11: Noon-Stamp Derivation Edges ===\n");
+    /* PS_MEL is 2026-06-29T02:00:00Z, local noon at +10:00. Anchor +10:00 through the
+     * settings parser so the derivation is compared against a known value, not the host TZ. */
+    parse_tz_setting("+10:00", &off);
+    expect_int("PeriodStart 0 refused", as11_time_offset_from_period_start(0, &off) ? 1 : 0, 0);
+    expect_int("noon + 5:00 accepted (at tolerance)",
+               as11_time_offset_from_period_start(PS_MEL + 300 * 1000, &off) ? off : -999999, 36000);
+    expect_int("noon - 5:00 accepted (at tolerance)",
+               as11_time_offset_from_period_start(PS_MEL - 300 * 1000, &off) ? off : -999999, 36000);
+    expect_int("noon + 5:01 refused",
+               as11_time_offset_from_period_start(PS_MEL + 301 * 1000, &off) ? 1 : 0, 0);
+
+    /* 00:00Z is local noon at +12:00 and at -12:00 alike; the anchor decides, and -12:00 is
+     * the lower bound itself. */
+    const int64_t PS_MIDNIGHT_Z = 1782691200000LL;   /* 2026-06-29T00:00:00Z */
+    parse_tz_setting("-10:00", &off);
+    expect_int("00:00Z, anchor -10:00 -> -12:00 (the bound itself)",
+               as11_time_offset_from_period_start(PS_MIDNIGHT_Z, &off) ? off : -999999, -43200);
+    parse_tz_setting("+10:00", &off);
+    expect_int("00:00Z, anchor +10:00 -> +12:00",
+               as11_time_offset_from_period_start(PS_MIDNIGHT_Z, &off) ? off : -999999, 43200);
+    parse_tz_setting("+00:00", &off);
+    expect_int("00:00Z, anchor 00:00 -> +12:00 (tie keeps the raw candidate)",
+               as11_time_offset_from_period_start(PS_MIDNIGHT_Z, &off) ? off : -999999, 43200);
     reset_offset();
 
     printf("\n%s (%d failure%s)\n", fails ? "FAILURES" : "ALL PASS",

--- a/scripts/as11_time_test.c
+++ b/scripts/as11_time_test.c
@@ -192,6 +192,42 @@ int main(void)
     check_period_end("Feb 28 23:00 (leap year rollover)", 2024, 2, 28, 23, 0, "2024-02-29 12:00");
     check_period_end("Oct 24 23:00 (evening before fall-back)", 2026, 10, 24, 23, 0, "2026-10-25 12:00");
 
+    printf("\n=== Scenario 9: Civil-Date Arithmetic at the February Boundary ===\n");
+    /* days_from_civil() is Hinnant's algorithm: the year is shifted so it starts on
+     * March 1, and the shift only fires for January and February. Every scenario above
+     * reaches it with a March-or-later date, so a wrong shift (m < 2, m >= 2) would
+     * pass the whole suite. The event-timestamp parser is the only caller that sees
+     * arbitrary dates and had no host test. Expected values are from an independent
+     * calendar (Python datetime), not from the function under test. */
+    expect_int("ISO event on leap day 2024-02-29T12:00:00.000Z",
+               as11_time_parse_iso8601_ms("2024-02-29T12:00:00.000Z"), 1709208000000LL);
+    expect_int("ISO event last ms of Feb 28 (leap year)",
+               as11_time_parse_iso8601_ms("2024-02-28T23:59:59.999Z"), 1709164799999LL);
+    expect_int("ISO event last second of Feb 28 (non-leap, no ms)",
+               as11_time_parse_iso8601_ms("2023-02-28T23:59:59Z"), 1677628799000LL);
+    expect_int("ISO event first second of Mar 1 (non-leap, no ms)",
+               as11_time_parse_iso8601_ms("2023-03-01T00:00:00Z"), 1677628800000LL);
+    expect_int("ISO event malformed returns -1",
+               as11_time_parse_iso8601_ms("2024-02-29"), -1);
+    expect_int("day number for 20240229 (leap day)",
+               as11_time_day_number("20240229"), 19782);
+    expect_int("day number for 20240301 (day after leap day)",
+               as11_time_day_number("20240301"), 19783);
+    /* 2100 is the first non-leap century year in the era that began in 2000; the
+     * doe/36524 term is inert for every date before it. */
+    expect_int("ISO event on 2100-03-01 (century non-leap boundary)",
+               as11_time_parse_iso8601_ms("2100-03-01T00:00:00Z"), 4107542400000LL);
+    expect_int("day number for 21000301",
+               as11_time_day_number("21000301"), 47541);
+    /* The reverse direction, civil_from_days(), is reached only through the noon-day
+     * label. Pin the offset so the label is a pure function of the epoch. */
+    as11_time_set_offset(0, "test");
+    as11_time_noon_day(4107589200000LL, day, sizeof(day));   /* 2100-03-01T13:00Z */
+    expect_str("noon-day label on 2100-03-01 (century boundary)", day, "21000301");
+    as11_time_noon_day(4107502800000LL, day, sizeof(day));   /* 2100-02-28T13:00Z */
+    expect_str("noon-day label on 2100-02-28 (2100 is not a leap year)", day, "21000228");
+    reset_offset();
+
     printf("\n%s (%d failure%s)\n", fails ? "FAILURES" : "ALL PASS",
            fails, fails == 1 ? "" : "s");
     return fails ? 1 : 0;

--- a/scripts/vld3_decoder_test.c
+++ b/scripts/vld3_decoder_test.c
@@ -65,7 +65,9 @@ int main(void)
     uint8_t header[OX_VLD3_HEADER_LEN];
     ox_vld3_header_t parsed;
     make_header(header, 0, 2026, 8, 29, 5485, 21940);
+    le16(header + 15, 19800);
     assert(ox_vld3_parse_header(header, sizeof(header), 27465, &parsed));
+    assert(parsed.duration_seconds == 21940 && parsed.asleep_seconds == 19800);
     assert(parsed.version == 3 && parsed.mode == 0 && parsed.year == 2026);
     assert(parsed.month == 8 && parsed.day == 29 && parsed.hour == 22);
     assert(parsed.minute == 24 && parsed.second == 42);
@@ -75,6 +77,7 @@ int main(void)
     make_header(header, 1, 2024, 2, 29, 120, 240);
     assert(ox_vld3_parse_header(header, sizeof(header), 640, &parsed));
     assert(parsed.mode == 1 && parsed.period_us == 2000000);
+    assert(parsed.datetime_valid);                  /* Feb 29 in a leap year is a real day */
     le32(header + 9, 1234);
     assert(ox_vld3_parse_header(header, sizeof(header), 640, &parsed));
     assert(!parsed.declared_size_matches);
@@ -82,13 +85,41 @@ int main(void)
     header[5] = 30;
     assert(ox_vld3_parse_header(header, sizeof(header), 640, &parsed));
     assert(!parsed.datetime_valid);
+    make_header(header, 0, 2023, 2, 29, 120, 240);
+    assert(ox_vld3_parse_header(header, sizeof(header), 640, &parsed));
+    assert(!parsed.datetime_valid);                 /* ...and not in a common year */
+
+    /* Bounds of the date and time-of-day checks, each side of every edge. */
+    make_header(header, 0, 2015, 1, 1, 120, 240);
+    assert(ox_vld3_parse_header(header, sizeof(header), 640, &parsed) && parsed.datetime_valid);
+    make_header(header, 0, 2014, 12, 31, 120, 240);
+    assert(ox_vld3_parse_header(header, sizeof(header), 640, &parsed) && !parsed.datetime_valid);
+    make_header(header, 0, 2099, 12, 31, 120, 240);
+    assert(ox_vld3_parse_header(header, sizeof(header), 640, &parsed) && parsed.datetime_valid);
+    make_header(header, 0, 2100, 1, 1, 120, 240);
+    assert(ox_vld3_parse_header(header, sizeof(header), 640, &parsed) && !parsed.datetime_valid);
+    make_header(header, 0, 2026, 8, 31, 120, 240);
+    header[6] = 23; header[7] = 59; header[8] = 59;
+    assert(ox_vld3_parse_header(header, sizeof(header), 640, &parsed) && parsed.datetime_valid);
+    header[6] = 24;
+    assert(ox_vld3_parse_header(header, sizeof(header), 640, &parsed) && !parsed.datetime_valid);
+    header[6] = 23; header[7] = 60;
+    assert(ox_vld3_parse_header(header, sizeof(header), 640, &parsed) && !parsed.datetime_valid);
+    header[7] = 59; header[8] = 60;
+    assert(ox_vld3_parse_header(header, sizeof(header), 640, &parsed) && !parsed.datetime_valid);
+
     make_header(header, 0, 2026, 1, 1, 120, 361);
     assert(!ox_vld3_parse_header(header, sizeof(header), 640, &parsed));
     make_header(header, 0, 2026, 1, 1, 120, 480);
     assert(!ox_vld3_parse_header(header, sizeof(header), 639, &parsed));
 
+    assert(!ox_vld3_parse_header(NULL, sizeof(header), 640, &parsed));
+    assert(!ox_vld3_parse_header(header, sizeof(header), 640, NULL));
+
     uint8_t record[OX_VLD3_RECORD_LEN] = { 97, 0x2c, 0x01, 7, 0x40 };
     ox_vld3_record_t sample;
+    assert(!ox_vld3_parse_record(NULL, &sample));
+    assert(!ox_vld3_parse_record(record, NULL));
     assert(ox_vld3_parse_record(record, &sample));
     assert(sample.spo2 == 97 && sample.pulse == 300);
     assert(sample.acceleration == 7 && sample.reserved == 0x40);


### PR DESCRIPTION
> **Stacked on #204** — this adds Scenarios 10 and 11 after #204's Scenario 9 in `scripts/as11_time_test.c`; the diff shows #204's commit until it merges. This PR's own change is the single commit `b564500` (97 lines across two test files).

Running the host mutation harness over `as11_time.c` and `oximetry_vld3.c` (on v2.0.0 with #203–#205 applied) left 17 and 7 survivors respectively — mutants the suites executed but never noticed. 18 of them are test gaps and this PR closes them; the other 6 are equivalent mutants (a boundary where the original and the mutant agree at the only value that separates them), recorded with their arguments in the harness's `mutate_equivalent.txt`. **No shipped code changes**; every new expectation passes against the unmodified firmware.

### `as11_time_test.c` — Scenario 10, settings offset parser and `as11_time_set_offset()`
Every earlier settings case was a whole hour in the interior of [-12:00, +14:00], so `hh*3600 + mm*60` was indistinguishable from `hh*3600 - mm*60`, hour 0 was never parsed, neither bound was shown inclusive, and the `'+'` branch was only ever taken with a sign present. Adds half-hour offsets, `+00:00`, both bounds and one step past each, and an unsigned value.

### `as11_time_test.c` — Scenario 11, noon-stamp derivation
`PeriodStart == 0` (the `<= 0` guard), the 5-minute tolerance from both sides and one second past it, and `00:00Z` — local noon at +12:00 and −12:00 alike — resolved against anchors −10:00, +10:00 and 00:00: −12:00 (the lower bound itself), +12:00, and +12:00 (a tie keeps the raw candidate). The anchor is set through the settings parser so the result does not depend on the host TZ.

### `vld3_decoder_test.c`
The 2024-02-29 header was parsed but `datetime_valid` never asserted, so the leap-year rule, `month == 2`, and `day <= max_day` could all be inverted unnoticed. `asleep_seconds` and `duration_seconds` were decoded and never read. The year/hour/minute/second bounds had no case on either side. The NULL guards were untested.

### Verification
| file | before | after |
|---|---|---|
| `as11_time.c` | killed 44, unasserted 17 | killed 55, unasserted **0**, equivalent 8 |
| `oximetry_vld3.c` | killed 13, unasserted 7 | killed 20, unasserted **0** |

Both suites pass on host. Harness: `scripts/mutate_host.py` on the `tools/host-mutation-harness` branch (offered on #203).

### One observation, not changed here
`as11_time_parse_iso8601_ms()` (`as11_time.c:320-330`) retries with a second `sscanf` format when the first returns fewer than 6 fields — but the two formats are identical through the sixth conversion, so the retry can never succeed where the first failed. It's harmless dead code; the two mutants on those lines are recorded equivalent for that reason. Flagging in case you want to drop the retry during the rewrite.
