### PR TITLE
edf_summary: log a skipped out-of-day STR window at INFO, not WARNING (#185)

### DIFF
--- a/main/edf_summary.c
+++ b/main/edf_summary.c
@@ -893,7 +893,7 @@ static int build_str_mask_events(summary_ctx_t *ctx, int16_t *str_values,
             int dur_chk = (int)ctx->session_entries[i].duration_min;
             if (min_from_noon < 0 ||
                 min_from_noon + dur_chk > STR_MASK_MINUTES_MAX) {
-                ESP_LOGW(TAG, "STR.edf: %s session %d window %d..%d min is "
+                ESP_LOGI(TAG, "STR.edf: %s session %d window %d..%d min is "
                          "outside the day — entry skipped", day_label, i,
                          min_from_noon, min_from_noon + dur_chk);
                 continue;
@@ -1057,7 +1057,7 @@ static int collect_session_mask_pairs(const char *session_dir,
         /* Never emit a window outside the day this record declares — see
          * STR_MASK_MINUTES_MAX. */
         if (on < 0 || off > STR_MASK_MINUTES_MAX) {
-            ESP_LOGW(TAG, "STR.edf: %s window %d..%d min is outside the day "
+            ESP_LOGI(TAG, "STR.edf: %s window %d..%d min is outside the day "
                      "— entry skipped", session_id, on, off);
             continue;
         }


### PR DESCRIPTION
Follows up on your conclusion in #185: "This is not an issue by itself, but we should demote the Warning status to Informational."

Both sites that log `STR.edf: ... window X..Y min is outside the day â€” entry skipped` go from `ESP_LOGW` to `ESP_LOGI` (`main/edf_summary.c:896` and `:1060`). The message text is unchanged, so anyone grepping a log for it still finds it.

The guard itself is untouched: it still drops the window rather than write a MaskOn/MaskOff outside 0..1440 that OSCAR would flag as SD-card corruption. Your analysis in #185 is the justification, so I won't repeat it here.

Host suite green (`scripts/run_host_tests.sh`: 5 run, 0 failed; `edf_gen_test` compiles `edf_summary.c`). Two lines, one file.
