### PR TITLE
Test connection buttons for SMB and SleepHQ (#123)

### DIFF
--- a/components/uploader/upload_sched.c
+++ b/components/uploader/upload_sched.c
@@ -752,6 +752,14 @@ void upload_sched_request_reset(void)             { post(EV_RESET, 0); }
 
 void upload_sched_set_busy_fn(upload_sched_busy_fn_t fn) { s_busy_fn = fn; }
 
+bool upload_sched_uploading(void)
+{
+    for (int i = 0; i < s_n_rt; i++) {
+        if (s_rt[i].be && s_rt[i].state == SB_UPLOADING) return true;
+    }
+    return false;
+}
+
 /* ── Progress reporting ───────────────────────────────────────────── */
 
 static const char *state_name(sb_state_t s)

--- a/components/uploader/upload_sched.h
+++ b/components/uploader/upload_sched.h
@@ -83,6 +83,10 @@ void upload_sched_request_reset(void);
 typedef bool (*upload_sched_busy_fn_t)(void);
 void upload_sched_set_busy_fn(upload_sched_busy_fn_t fn);
 
+/* True while any backend is inside a run (connected and transferring), so a
+ * "Test connection" probe does not open a second transport alongside it. */
+bool upload_sched_uploading(void);
+
 /* Compact progress for the Web UI.  Caller frees. */
 esp_err_t upload_sched_progress_json(char **out_json);
 

--- a/components/uploader/uploader.c
+++ b/components/uploader/uploader.c
@@ -529,3 +529,40 @@ void uploader_request_scan(void)
     if (!s_initialised) return;
     upload_sched_request_scan();
 }
+
+/* ── "Test connection" (web UI) ─────────────────────────────────────── */
+
+esp_err_t uploader_test_connection(const char *backend_id, bool *out_ok,
+                                   char *msg, size_t msg_len)
+{
+    if (!backend_id || !out_ok || !msg || msg_len == 0) return ESP_ERR_INVALID_ARG;
+    *out_ok = false;
+
+    const upload_backend_t *be = NULL;
+    for (int i = 0; i < s_n_backends; i++) {
+        if (s_backends[i] && strcmp(s_backends[i]->id, backend_id) == 0) {
+            be = s_backends[i];
+            break;
+        }
+    }
+    if (!be || !be->test) {
+        snprintf(msg, msg_len, "Unknown backend");
+        return ESP_ERR_NOT_FOUND;
+    }
+    if (!s_initialised) {
+        snprintf(msg, msg_len, "Uploader is still starting up, try again in a moment");
+        return ESP_ERR_INVALID_STATE;
+    }
+    /* Only one transport at a time: TLS and SMB buffers contend for memory
+     * (see the backend interface note), and a run may be mid-transfer. */
+    if (upload_sched_uploading()) {
+        snprintf(msg, msg_len, "An upload is in progress, try again when it has finished");
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    ESP_LOGI(TAG, "%s: connection test requested", be->id);
+    *out_ok = be->test(msg, msg_len);
+    ESP_LOGI(TAG, "%s: connection test %s: %s", be->id,
+             *out_ok ? "passed" : "failed", msg);
+    return ESP_OK;
+}

--- a/components/uploader/uploader.h
+++ b/components/uploader/uploader.h
@@ -25,6 +25,7 @@
 
 #include "esp_err.h"
 #include <stdbool.h>
+#include <stddef.h>
 #include "upload_scan.h"
 #include "upload_ox.h"
 
@@ -110,6 +111,14 @@ typedef struct {
 
     /* Close the connection. Always called if session_begin() succeeded. */
     void (*session_end)(void);
+
+    /* Optional "Test connection" probe for the web UI: connect and
+     * authenticate with the saved configuration, then disconnect, without
+     * transferring anything.  Writes a one-line outcome for the user into
+     * msg and returns true when the backend is usable.  Must use its own
+     * connection object, never the one session_begin() owns — it runs on
+     * the httpd task, not the scheduler. */
+    bool (*test)(char *msg, size_t msg_len);
 } upload_backend_t;
 
 /* ── Configuration ──────────────────────────────────────────────────── */
@@ -246,3 +255,15 @@ esp_err_t uploader_save_config_json(const char *json_str);
  * config.max_days, so this cannot start an unbounded re-upload.
  * Asynchronous: the work happens on the scheduler task. */
 esp_err_t uploader_reset_state(void);
+
+/* "Test connection" for the web UI: probe one backend ("smb" | "sleephq")
+ * with the configuration currently saved in NVS, without uploading anything.
+ * msg receives a one-line outcome for the user in every case.
+ *   ESP_OK                 the probe ran; *out_ok says whether it passed
+ *   ESP_ERR_INVALID_STATE  an upload is in progress (one transport at a time,
+ *                          see the backend interface note) or the uploader
+ *                          has not finished initialising
+ *   ESP_ERR_NOT_FOUND      unknown backend id
+ * Blocks the caller for up to the backend's probe timeout (about 10 s). */
+esp_err_t uploader_test_connection(const char *backend_id, bool *out_ok,
+                                   char *msg, size_t msg_len);

--- a/components/uploader/uploader_sleephq.c
+++ b/components/uploader/uploader_sleephq.c
@@ -357,18 +357,13 @@ static int shq_http_request(esp_tls_t *tls, const char *method,
 
 /* ── Authentication ─────────────────────────────────────────────────── */
 
-static esp_err_t shq_authenticate(esp_tls_t *tls, const uploader_config_t *cfg)
+/* One token request.  On success the token is copied into `token` and its
+ * lifetime into *expires_s.  On failure `err` (may be NULL) receives a
+ * one-line reason worded for the web UI. */
+static esp_err_t shq_request_token(esp_tls_t *tls, const uploader_config_t *cfg,
+                                   char *token, size_t token_cap, int *expires_s,
+                                   char *err, size_t err_len)
 {
-    if (s_token && s_token[0] && s_token_expires > 0) {
-        int64_t now_s = time(NULL);
-        int elapsed = (int)(now_s - s_token_time_s);
-        if (elapsed < s_token_expires - 60) {
-            return ESP_OK;
-        }
-    }
-
-    ESP_LOGI(TAG, "authenticating with SleepHQ...");
-
     char body[512];
     snprintf(body, sizeof(body),
              "grant_type=password&client_id=%s&client_secret=%s&scope=read+write",
@@ -381,6 +376,15 @@ static esp_err_t shq_authenticate(esp_tls_t *tls, const uploader_config_t *cfg)
                                   &resp_body, &resp_len);
     if (status < 200) {
         ESP_LOGE(TAG, "auth request failed (status=%d)", status);
+        if (err) snprintf(err, err_len, "No answer from %s", SHQ_HOST);
+        free(resp_body);
+        return ESP_FAIL;
+    }
+    if (status >= 300) {
+        /* 401 is what a wrong or revoked Client ID / Secret produces. */
+        if (err) snprintf(err, err_len, "SleepHQ rejected the API key (HTTP %d): "
+                          "check Client ID / Secret and that the account has API access",
+                          status);
         free(resp_body);
         return ESP_FAIL;
     }
@@ -390,27 +394,47 @@ static esp_err_t shq_authenticate(esp_tls_t *tls, const uploader_config_t *cfg)
 
     if (!root) {
         ESP_LOGE(TAG, "auth: failed to parse JSON");
+        if (err) snprintf(err, err_len, "Unexpected reply from %s", SHQ_HOST);
         return ESP_FAIL;
     }
 
-    cJSON *token = cJSON_GetObjectItem(root, "access_token");
+    cJSON *tok = cJSON_GetObjectItem(root, "access_token");
     cJSON *expires = cJSON_GetObjectItem(root, "expires_in");
 
-    if (!token || !cJSON_IsString(token)) {
+    if (!tok || !cJSON_IsString(tok)) {
         ESP_LOGE(TAG, "auth: no access_token in response");
+        if (err) snprintf(err, err_len, "SleepHQ did not issue a token");
         cJSON_Delete(root);
         return ESP_FAIL;
     }
 
-    if (!shq_token_ready()) {
-        cJSON_Delete(root);
-        return ESP_ERR_NO_MEM;
+    strlcpy(token, tok->valuestring, token_cap);
+    *expires_s = (expires && cJSON_IsNumber(expires)) ? expires->valueint : 7200;
+    cJSON_Delete(root);
+    return ESP_OK;
+}
+
+static esp_err_t shq_authenticate(esp_tls_t *tls, const uploader_config_t *cfg)
+{
+    if (s_token && s_token[0] && s_token_expires > 0) {
+        int64_t now_s = time(NULL);
+        int elapsed = (int)(now_s - s_token_time_s);
+        if (elapsed < s_token_expires - 60) {
+            return ESP_OK;
+        }
     }
-    strlcpy(s_token, token->valuestring, SHQ_TOKEN_MAX);
-    s_token_expires = (expires && cJSON_IsNumber(expires)) ? expires->valueint : 7200;
+
+    ESP_LOGI(TAG, "authenticating with SleepHQ...");
+
+    if (!shq_token_ready()) return ESP_ERR_NO_MEM;
+
+    int expires_s = 0;
+    esp_err_t rc = shq_request_token(tls, cfg, s_token, SHQ_TOKEN_MAX, &expires_s,
+                                     NULL, 0);
+    if (rc != ESP_OK) return rc;
+    s_token_expires = expires_s;
     s_token_time_s = time(NULL);
 
-    cJSON_Delete(root);
     ESP_LOGI(TAG, "authenticated, token expires in %d s", s_token_expires);
     return ESP_OK;
 }
@@ -819,6 +843,64 @@ static void shq_session_end(void)
     s_import_id[0] = '\0';
 }
 
+/* ── "Test connection" (web UI) ───────────────────────────────────────
+ *
+ * TLS connect plus one token request with the saved Client ID / Secret, on
+ * a private connection so it can run from the httpd task while the
+ * scheduler is idle.  The token is discarded rather than cached: the cache
+ * belongs to the scheduler task and a probe must not race it.  No import is
+ * opened, so nothing appears in the user's SleepHQ history. */
+#define SHQ_TEST_TIMEOUT_MS 10000
+
+static bool shq_test(char *msg, size_t msg_len)
+{
+    uploader_config_t cfg;
+    uploader_load_config(&cfg);
+    if (!cfg.shq_client_id[0] || !cfg.shq_client_secret[0]) {
+        snprintf(msg, msg_len, "Client ID and Client Secret are required");
+        return false;
+    }
+
+    esp_tls_cfg_t tls_cfg = {
+        .crt_bundle_attach = esp_crt_bundle_attach,
+        .timeout_ms = SHQ_TEST_TIMEOUT_MS,
+    };
+    esp_tls_t *tls = esp_tls_init();
+    if (!tls) {
+        snprintf(msg, msg_len, "Out of memory");
+        return false;
+    }
+    if (esp_tls_conn_http_new_sync(SHQ_URL_BASE, &tls_cfg, tls) != 1) {
+        snprintf(msg, msg_len, "Cannot reach %s: check the internet connection", SHQ_HOST);
+        esp_tls_conn_destroy(tls);
+        return false;
+    }
+
+    char *token = heap_caps_malloc(SHQ_TOKEN_MAX, MALLOC_CAP_SPIRAM);
+    if (!token) token = malloc(SHQ_TOKEN_MAX);
+    if (!token) {
+        snprintf(msg, msg_len, "Out of memory");
+        esp_tls_conn_destroy(tls);
+        return false;
+    }
+
+    int expires_s = 0;
+    char err[128];
+    esp_err_t rc = shq_request_token(tls, &cfg, token, SHQ_TOKEN_MAX, &expires_s,
+                                     err, sizeof(err));
+    esp_tls_conn_destroy(tls);
+    memset(token, 0, SHQ_TOKEN_MAX);
+    free(token);
+
+    if (rc != ESP_OK) {
+        snprintf(msg, msg_len, "%s", err);
+        return false;
+    }
+    snprintf(msg, msg_len, "Signed in to SleepHQ, API key accepted (token valid for %d min)",
+             expires_s / 60);
+    return true;
+}
+
 static upload_result_t shq_day_begin(const char *day)
 {
     if (!s_tls) {
@@ -966,4 +1048,5 @@ const upload_backend_t sleephq_backend = {
     .put_bundle = shq_put_bundle,
     .day_end = shq_day_end,
     .session_end = shq_session_end,
+    .test = shq_test,
 };

--- a/components/uploader/uploader_smb.c
+++ b/components/uploader/uploader_smb.c
@@ -291,6 +291,69 @@ static void smb_session_end(void)
     s_smb = NULL;
 }
 
+/* ── "Test connection" (web UI) ───────────────────────────────────────
+ *
+ * The same handshake as smb_session_begin() — negotiate, authenticate, open
+ * the share — on a private context so it can run from the httpd task while
+ * the scheduler is idle, followed by a stat of the configured folder: the
+ * uploader's mkdir calls do not create parents, so a remote path that does
+ * not exist on the share fails on the first upload rather than here.
+ * Nothing is created or written. */
+#define SMB_TEST_TIMEOUT_S 10
+
+static bool smb_test(char *msg, size_t msg_len)
+{
+    uploader_config_t cfg;
+    uploader_load_config(&cfg);
+    if (!cfg.smb_host[0] || !cfg.smb_share[0]) {
+        snprintf(msg, msg_len, "Host and share name are required");
+        return false;
+    }
+    const char *user = cfg.smb_user[0] ? cfg.smb_user : "Guest";
+
+    struct smb2_context *ctx = smb2_init_context();
+    if (!ctx) {
+        snprintf(msg, msg_len, "Out of memory");
+        return false;
+    }
+    smb2_set_security_mode(ctx, SMB2_NEGOTIATE_SIGNING_ENABLED);
+    smb2_set_timeout(ctx, SMB_TEST_TIMEOUT_S);
+    smb2_set_user(ctx, user);
+    if (cfg.smb_pass[0]) smb2_set_password(ctx, cfg.smb_pass);
+
+    ESP_LOGI(TAG, "test: connecting to %s/%s as %s", cfg.smb_host, cfg.smb_share, user);
+    if (smb2_connect_share(ctx, cfg.smb_host, cfg.smb_share, user) != 0) {
+        snprintf(msg, msg_len, "Cannot open //%s/%s as %s: %s",
+                 cfg.smb_host, cfg.smb_share, user, smb2_get_error(ctx));
+        smb2_destroy_context(ctx);
+        return false;
+    }
+
+    /* Relative to the share root, as in smb_session_begin(). */
+    const char *p = cfg.smb_path;
+    while (*p == '/' || *p == '\\') p++;
+
+    bool ok = true;
+    if (!*p) {
+        snprintf(msg, msg_len, "Connected to //%s/%s (share root)",
+                 cfg.smb_host, cfg.smb_share);
+    } else {
+        struct smb2_stat_64 st;
+        if (smb2_stat(ctx, p, &st) == 0) {
+            snprintf(msg, msg_len, "Connected to //%s/%s, folder '%s' found",
+                     cfg.smb_host, cfg.smb_share, p);
+        } else {
+            snprintf(msg, msg_len, "Connected to //%s/%s, but folder '%s' was not "
+                     "found on the share: create it or fix Remote Path",
+                     cfg.smb_host, cfg.smb_share, p);
+            ok = false;
+        }
+    }
+    smb2_disconnect_share(ctx);
+    smb2_destroy_context(ctx);
+    return ok;
+}
+
 static upload_result_t smb_day_begin(const char *day)
 {
     if (!s_smb) return UPLOAD_ERR_TRANSIENT;
@@ -399,4 +462,5 @@ const upload_backend_t smb_backend = {
     .put_bundle = smb_put_bundle,
     .day_end = smb_day_end,
     .session_end = smb_session_end,
+    .test = smb_test,
 };

--- a/main/net_provision.c
+++ b/main/net_provision.c
@@ -1849,6 +1849,51 @@ static esp_err_t upload_config_post_handler(httpd_req_t *req)
     return ESP_OK;
 }
 
+/* ── Upload "Test connection" ─────────────────────────────────────────
+ * Probes one backend with the settings saved in NVS (not the form contents)
+ * and answers {"ok":bool,"message":"..."} — 409 while an upload is running.
+ * Blocks this worker for up to the backend's probe timeout (about 10 s). */
+static esp_err_t upload_test_send(httpd_req_t *req, const char *backend_id)
+{
+    bool ok = false;
+    char msg[192];
+    esp_err_t err = uploader_test_connection(backend_id, &ok, msg, sizeof(msg));
+    if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
+        httpd_resp_send_err(req, HTTPD_404_NOT_FOUND, "unknown backend");
+        return ESP_FAIL;
+    }
+
+    cJSON *root = cJSON_CreateObject();
+    if (!root) {
+        httpd_resp_send_500(req);
+        return ESP_FAIL;
+    }
+    cJSON_AddBoolToObject(root, "ok", err == ESP_OK && ok);
+    cJSON_AddStringToObject(root, "message", msg);
+    char *json = cJSON_PrintUnformatted(root);
+    cJSON_Delete(root);
+    if (!json) {
+        httpd_resp_send_500(req);
+        return ESP_FAIL;
+    }
+
+    if (err == ESP_ERR_INVALID_STATE) httpd_resp_set_status(req, "409 Conflict");
+    httpd_resp_set_type(req, "application/json");
+    httpd_resp_sendstr(req, json);
+    cJSON_free(json);
+    return ESP_OK;
+}
+
+static esp_err_t upload_test_smb_handler(httpd_req_t *req)
+{
+    return upload_test_send(req, "smb");
+}
+
+static esp_err_t upload_test_sleephq_handler(httpd_req_t *req)
+{
+    return upload_test_send(req, "sleephq");
+}
+
 /* ── Device settings endpoints ─────────────────────────────────────── */
 
 /* ── Therapy alert config endpoints ─────────────────────────────────── */
@@ -3064,6 +3109,12 @@ static esp_err_t start_webserver(void)
     httpd_register_uri_handler(s_httpd, &up_cfg_post);
     httpd_register_uri_handler(s_httpd, &up_prog_get);
     httpd_register_uri_handler(s_httpd, &up_state_get);
+
+    /* "Test connection" buttons: probe a backend with the saved settings */
+    httpd_uri_t up_test_smb = { .uri = "/api/uploads/test-smb", .method = HTTP_POST, .handler = upload_test_smb_handler };
+    httpd_uri_t up_test_shq = { .uri = "/api/uploads/test-sleephq", .method = HTTP_POST, .handler = upload_test_sleephq_handler };
+    httpd_register_uri_handler(s_httpd, &up_test_smb);
+    httpd_register_uri_handler(s_httpd, &up_test_shq);
 
     /* Device settings endpoints (brightness, LCD therapy mode) */
     httpd_uri_t settings_all = { .uri = "/api/settings/all", .method = HTTP_GET, .handler = settings_all_get_handler };

--- a/main/portal.html
+++ b/main/portal.html
@@ -588,6 +588,10 @@ Network Folder (SMB Share)
 <label style="font-size:.8rem;color:var(--text-muted)">Connection Preview</label>
 <div class="smb-preview" id="smb-uri-preview">smb://guest:@192.168.1.100/sleep/SomnoTrace</div>
 </div>
+<div style="margin-top:12px">
+<button type="button" class="btn btn-sm" id="smb-test-btn" onclick="testUploadConnection('smb')">Test connection</button>
+<span id="smb-test-status" class="status-msg" style="margin-left:8px;text-align:left"></span>
+</div>
 </div>
 
 <!-- SleepHQ Cloud -->
@@ -614,6 +618,10 @@ SleepHQ Cloud Upload
 <svg viewBox="0 0 24 24" class="eye-closed" style="display:none"><path d="M12 7c2.76 0 5 2.24 5 5 0 .65-.13 1.26-.36 1.83l2.92 2.92c1.51-1.26 2.7-2.89 3.43-4.75-1.73-4.39-6-7.5-11-7.5-1.4 0-2.74.25-3.98.7l2.16 2.16C10.74 7.13 11.35 7 12 7zM2 4.27l2.28 2.28.46.46A11.8 11.8 0 0 0 1 12c1.73 4.39 6 7.5 11 7.5 1.55 0 3.03-.3 4.38-.84l.42.42L19.73 22 21 20.73 3.27 3 2 4.27zM7.53 9.8l1.55 1.55c-.05.21-.08.43-.08.65 0 1.66 1.34 3 3 3 .22 0 .44-.03.65-.08l1.55 1.55c-.67.33-1.41.53-2.2.53-2.76 0-5-2.24-5-5 0-.79.2-1.53.53-2.2zm4.31-.78l3.15 3.15.02-.16c0-1.66-1.34-3-3-3l-.17.01z"/></svg>
 </button>
 </div>
+</div>
+<div style="margin-top:12px">
+<button type="button" class="btn btn-sm" id="shq-test-btn" onclick="testUploadConnection('shq')">Test connection</button>
+<span id="shq-test-status" class="status-msg" style="margin-left:8px;text-align:left"></span>
 </div>
 <div style="margin-top:14px;padding:10px 14px;border-radius:8px;background:rgba(167,139,250,.08);border:1px solid rgba(167,139,250,.25);font-size:.8rem;line-height:1.5;color:var(--text-muted)">
 <div style="margin-bottom:6px"><span style="font-weight:600;color:var(--accent,#a78bfa)">Requires SleepHQ Pro subscription.</span> The free SleepHQ tier does not include API access.</div>
@@ -2556,6 +2564,32 @@ function sendAlertTestPush() {
     if (r.ok) setTimeout(function(){ if (st) st.textContent = ''; }, 3000);
   }).catch(function() {
     if (st) { st.textContent = 'Network error'; st.style.color = 'var(--danger)'; }
+  });
+}
+
+/* ── Upload "Test connection" ──────────────────────────────────── */
+function testUploadConnection(id) {
+  var st = document.getElementById(id + '-test-status');
+  var btn = document.getElementById(id + '-test-btn');
+  var card = document.getElementById(id + '-card');
+  /* The device probes with what is saved in NVS, not what is typed here. */
+  if (card && card.querySelector('[data-dirty="true"]')) {
+    if (st) { st.textContent = 'Save settings first, then test'; st.style.color = 'var(--warning)'; }
+    return;
+  }
+  if (st) { st.textContent = 'Testing…'; st.style.color = 'var(--text-muted)'; }
+  if (btn) btn.disabled = true;
+  fetch('/api/uploads/test-' + (id === 'shq' ? 'sleephq' : id), { method: 'POST' }).then(function(r) {
+    return r.json();
+  }).then(function(d) {
+    if (st) {
+      st.textContent = d.message || (d.ok ? 'Connected' : 'Failed');
+      st.style.color = d.ok ? 'var(--success)' : 'var(--danger)';
+    }
+  }).catch(function() {
+    if (st) { st.textContent = 'Network error'; st.style.color = 'var(--danger)'; }
+  }).then(function() {
+    if (btn) btn.disabled = false;
   });
 }
 

--- a/spec/0011-web-api-endpoints.md
+++ b/spec/0011-web-api-endpoints.md
@@ -265,6 +265,30 @@ data: I (1280) upload_smb: SMB connected
 
 ---
 
+### 4.7 Upload Connection Test (`POST /api/uploads/test-smb` & `POST /api/uploads/test-sleephq`)
+Backs the **Test connection** buttons on the SMB and SleepHQ settings cards. Probes one upload backend with the settings **currently saved in NVS** (the form must be saved first; the enable toggle is not consulted) without transferring anything:
+
+- `test-smb`: negotiate, authenticate and open the share with the saved host / share / user / password, then `stat` the saved remote path. Nothing is created: a missing folder is reported as a failure because the uploader's `mkdir` calls do not create parents.
+- `test-sleephq`: TLS connect to `sleephq.com` and one `/oauth/token` request with the saved Client ID / Secret. No import is opened, so nothing appears in the SleepHQ history; the token is discarded rather than cached.
+
+No request body. The request blocks for up to the backend's probe timeout (about 10 s), and is refused while an upload run is active so that only one SMB/TLS transport exists at a time.
+
+##### JSON Response Format:
+`200 OK` — the probe ran; `ok` says whether it passed and `message` is a one-line outcome to show verbatim:
+```json
+{ "ok": true, "message": "Connected to //192.168.1.100/sleep, folder 'SomnoTrace' found" }
+```
+```json
+{ "ok": false, "message": "SleepHQ rejected the API key (HTTP 401): check Client ID / Secret and that the account has API access" }
+```
+`409 Conflict` — an upload is in progress, or the uploader has not finished starting:
+```json
+{ "ok": false, "message": "An upload is in progress, try again when it has finished" }
+```
+`404 Not Found` — unknown backend.
+
+---
+
 ## 5. Security / privacy considerations
 
 - Wi-Fi and cloud upload settings are saved in an **encrypted NVS partition** to prevent raw credential theft in case of device physical tampering.
@@ -284,3 +308,4 @@ data: I (1280) upload_smb: SMB connected
 
 - 2026-07-02: Initial API endpoints contract specification.
 - 2026-09-04: Added `battery` telemetry to `/api/status` and documented `/api/device/settings` endpoint contract.
+- 2026-09-05: Added `/api/uploads/test-smb` and `/api/uploads/test-sleephq` (upload "Test connection" buttons, #123).


### PR DESCRIPTION
Closes #123. Adds a "Test connection" button to the SMB and SleepHQ cards in the portal, backed by two endpoints that probe the settings **saved in NVS** without starting an upload.

### Endpoints

`POST /api/uploads/test-smb` and `POST /api/uploads/test-sleephq`, no body. Response is always `{"ok": bool, "message": "..."}`:

- `200` — the probe ran; `ok` says whether it succeeded, `message` says why not (or what it reached).
- `409` — an upload run is active, or the uploader has not finished init.
- `404` — unknown backend.

The portal button refuses with "Save settings first, then test" while the card has unsaved inputs, so the probe never tests something other than what the uploader will use.

### What each probe does

- **SMB**: `smb2_connect_share` on a private context (`smb2_set_timeout(10)`), then `smb2_stat` of the saved remote path. A missing folder is reported as a failure on purpose: the uploader's `smb2_mkdir` calls never create parents, so that configuration would fail on the first upload.
- **SleepHQ**: TLS connect (10 s) and one `/oauth/token` request; the token is discarded, no import is opened. `shq_authenticate()` short-circuited on a cached token, which would have made a "test" a no-op, so it is now `shq_request_token()` plus the cache wrapper. The upload path's behaviour is unchanged (same `ESP_FAIL` cases; a 4xx returns before the JSON parse instead of failing at "no access_token").

Wiring: an optional `bool (*test)(char *msg, size_t)` on `upload_backend_t`; `uploader_test_connection()` does the registry lookup and the busy check (`upload_sched_uploading()`). `spec/0011-web-api-endpoints.md` gets its first `/api/uploads/*` section (4.7) — the existing upload endpoints were not documented there before.

### Decisions you may want to change

1. The probe ignores the enable toggle, so a backend can be tested before it is enabled.
2. The busy check is check-then-run; a run starting inside the ~10 s probe window is not excluded. Closing that needs a probe flag the scheduler honours, which seemed too invasive for this.
3. The probe blocks the httpd worker for up to ~10 s (status polling stalls meanwhile) — same as `/api/alert/test` today.
4. The 409 body uses `{ok,message}` rather than `send_busy()`'s `{ok,error}`, to keep one shape per endpoint.
5. Therapy-active is not a guard: the code only defers periodic scans during recording and still runs event uploads, so the probe is not blocked either.

### Verification and its limits

Full `espressif/idf:v5.5.1` esp32s3 build: `Project build complete`, 0 warnings in the touched files, total warning count unchanged (6 → 6).

Not verified, no hardware here: not flashed; never run against a real SMB share or SleepHQ account; httpd worker stack headroom for a TLS handshake (the uploader does the same on a 12 KB task, so it should fit, but it is unmeasured); whether libsmb2's `smb2_set_timeout` bounds the TCP connect phase against a silent host (it bounds PDUs — a SYN with no reply may hang longer). A run on a device against a wrong password, a wrong share name and a missing folder would be the useful test.

9 files, +346/−19.
