### PR TITLE
ci: run the host test suites on push and pull request

### DIFF
--- a/.github/workflows/host-tests.yml
+++ b/.github/workflows/host-tests.yml
@@ -1,0 +1,42 @@
+name: "Host tests"
+
+# Builds and runs the gcc host test suites via scripts/run_host_tests.sh.
+# No ESP-IDF: the suites compile main/*.c against the shims in
+# scripts/test_include and the system libcjson, and finish in seconds.
+#
+# The script prints "host tests: N run, M failed, K skipped" as its last line
+# and exits non-zero on a failure; a skipped suite does not fail it (a laptop
+# without libcjson still runs the rest), so this job fails on a skip itself.
+
+on:
+  push:
+    paths:
+      - "main/**"
+      - "scripts/**"
+      - ".github/workflows/host-tests.yml"
+  pull_request:
+    paths:
+      - "main/**"
+      - "scripts/**"
+      - ".github/workflows/host-tests.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  host-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install libcjson
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y --no-install-recommends libcjson-dev
+
+      - name: Run host tests
+        run: |
+          bash scripts/run_host_tests.sh | tee host-tests.log
+          tail -1 host-tests.log | grep -q ' 0 skipped$' || { echo "::error::a host suite was skipped"; exit 1; }

--- a/.github/workflows/host-tests.yml
+++ b/.github/workflows/host-tests.yml
@@ -37,6 +37,11 @@ jobs:
           sudo apt-get install -y --no-install-recommends libcjson-dev
 
       - name: Run host tests
+        # The runner's default shell is `bash -e` without pipefail, so the
+        # script's exit status would be lost behind tee.  Both the status and
+        # the summary line are checked; a run that prints neither fails too.
         run: |
+          set -o pipefail
           bash scripts/run_host_tests.sh | tee host-tests.log
-          tail -1 host-tests.log | grep -q ' 0 skipped$' || { echo "::error::a host suite was skipped"; exit 1; }
+          tail -1 host-tests.log | grep -qE '^host tests: [0-9]+ run, 0 failed, 0 skipped$' \
+            || { echo "::error::host tests failed or were skipped: $(tail -1 host-tests.log)"; exit 1; }


### PR DESCRIPTION
Adds a GitHub Actions job that builds and runs the gcc host suites (`scripts/run_host_tests.sh`) on every push and pull request that touches `main/`, `scripts/` or the workflow itself, plus `workflow_dispatch` for manual runs.

The suites already exist and are documented in `scripts/HOST_TESTS.md`; today they only run when a contributor remembers to. With five people committing to `main/` and `scripts/` in the last two months, this makes them run unconditionally.

**Cost:** ~20 s per run on `ubuntu-latest` (checkout 1 s, `apt-get install libcjson-dev` 9 s, both suites 2 s). Runner minutes are free for public repositories, so this does not cost anything.

**What it checks:** the script's own exit status *and* the final `host tests: N run, 0 failed, 0 skipped` line. A skipped suite fails the job — the script itself exits 0 on a skip, which would otherwise pass silently if `libcjson` ever failed to install.

**One trap worth knowing about, for anyone writing further jobs here:** the runner's default step shell is `bash -e {0}` without `pipefail`, so `bash scripts/run_host_tests.sh | tee log` is fail-open — the step's status is `tee`'s, not the script's. I proved this on my fork before fixing it: a deliberately broken suite produced a green run ([run](https://github.com/Plantucha/SomnoTrace/actions/runs/33972627571), log shows `host tests: 5 run, 1 failed`). The workflow sets `set -o pipefail` and greps the summary line; re-proven both ways after the fix — [positive](https://github.com/Plantucha/SomnoTrace/actions/runs/33972751134) (green on a good tree) and [negative](https://github.com/Plantucha/SomnoTrace/actions/runs/33972752154) (red on the broken suite).

Tested on my fork as a merge gate for two PRs (Plantucha/SomnoTrace #3 and #5); both merged only after the check went green.

**Question, not part of this PR:** would you be OK with a second job that runs `idf.py build` in the `espressif/idf` Docker image pinned to whichever IDF version you build releases with (I've been building against v5.5.1)? That one would catch the failure mode this job cannot — a PR that breaks the firmware build — but it takes roughly 5 minutes per push/merge rather than 20 seconds. Same free runner minutes, nothing runs on your machine. If you want it, I'd prototype it on my fork first the same way as this one and open it separately.
