### PR TITLE
ci: build the ESP32-S3 firmware in the pinned IDF container (#215)

### DIFF
--- a/.github/workflows/idf-build.yml
+++ b/.github/workflows/idf-build.yml
@@ -1,0 +1,78 @@
+name: "IDF build"
+# Compiles the ESP32-S3 firmware, which the host tests structurally cannot: they build
+# host-compatible C with gcc, so a broken FreeRTOS call, a missing component CMakeLists, a Kconfig
+# that no longer applies or an app that outgrew its partition all pass them and fail the device.
+#
+# ⚠️ THE IDF VERSION IS DELIBERATELY NOT WRITTEN HERE. The repo already pins it twice — once in
+# `.devcontainer/devcontainer.json` and once as `IDF_TAG` in `scripts/idf.sh` — and a third copy in a
+# file nobody edits during an IDF bump is a pin that silently stops matching. This job runs the same
+# `./scripts/idf.sh build` a developer runs, so CI follows that pin automatically and builds through
+# the wrapper rather than around it. Overriding is still one variable: `IDF_TAG=v5.6 ./scripts/idf.sh`.
+on:
+  push:
+    paths:
+      - "main/**"
+      - "components/**"
+      - "third_party/**"
+      - "CMakeLists.txt"
+      - "sdkconfig.defaults"
+      - "partitions.csv"
+      - "scripts/idf.sh"
+      - "scripts/build-dist.sh"
+      - "scripts/gen_tz_db.py"
+      - ".github/workflows/idf-build.yml"
+  pull_request:
+    paths:
+      - "main/**"
+      - "components/**"
+      - "third_party/**"
+      - "CMakeLists.txt"
+      - "sdkconfig.defaults"
+      - "partitions.csv"
+      - "scripts/idf.sh"
+      - "scripts/build-dist.sh"
+      - "scripts/gen_tz_db.py"
+      - ".github/workflows/idf-build.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  idf-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # FULL history and tags, not the default depth-1. The top-level CMakeLists derives
+          # PROJECT_VER from `git describe --tags --long --dirty`, and that is what ends up in
+          # esp_app_desc_t.version and on the portal's version line. On a shallow clone describe
+          # fails and the fallback yields `0.0.0+1.g<sha>` — a build that succeeds while stamping
+          # the firmware with a version that is not the firmware's.
+          fetch-depth: 0
+
+      - name: Build firmware
+        # The runner's default shell is `bash -e` WITHOUT pipefail, so a failing build piped into
+        # tee would report the exit status of tee — the same fail-open that made a broken host suite
+        # go green before it was caught (see host-tests.yml).
+        run: |
+          set -o pipefail
+          ./scripts/idf.sh build 2>&1 | tee idf-build.log
+
+      - name: Confirm an image was actually produced
+        # A build step can exit 0 having produced nothing if the toolchain is ever invoked wrongly.
+        # Name the artifact and the version the log claims, so a green run says what it built.
+        run: |
+          test -f build/somnotrace.bin || {
+            echo "::error::idf.py build exited 0 but build/somnotrace.bin does not exist"; exit 1; }
+          echo "image: $(stat -c '%n %s bytes' build/somnotrace.bin)"
+          grep -m1 'Firmware version:' idf-build.log || echo "::warning::no version line in the build log"
+
+      - name: Upload the build log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: idf-build-log
+          path: idf-build.log
+          retention-days: 7


### PR DESCRIPTION
Closes #215.

Adds `.github/workflows/idf-build.yml`: builds the ESP32-S3 firmware in the pinned `espressif/idf` container on pushes and pull requests that touch the firmware, plus `workflow_dispatch`.

This catches what the host tests structurally cannot. They compile host-compatible C with gcc, so a broken FreeRTOS call, a missing component `CMakeLists.txt`, a Kconfig that no longer applies, or an app that has outgrown its partition all pass them and fail the device.

**Measured on my fork, green on the first run** ([run](https://github.com/Plantucha/SomnoTrace/actions/runs/34031975719)):

| | |
|---|---|
| job execution | **3 min 21 s** |
| — docker pull `espressif/idf:v5.5.1` | 63 s |
| — `idf.py build` (1317 targets, cold, no cache) | 2 min 14 s |
| — checkout / assert / log upload | ~4 s |
| image | `somnotrace.bin` 2,389,856 bytes |
| partition fit (from the build itself) | `0x247760` used, smallest app partition `0x400000`, **43% free** |

Wall clock on that run was 5 min 36 s, but ~2 min of that was waiting for a runner to be allocated, which varies and is not work — hence the two numbers. Either way it is free on a public repository.

### Two decisions worth reviewing, since both could reasonably have gone the other way

**1. The workflow does not name the IDF version.** It is already pinned twice — `.devcontainer/devcontainer.json` and `IDF_TAG` in `scripts/idf.sh` — and a third copy, in a file nobody opens during an IDF bump, is a pin that silently stops matching the one developers build against. So the job runs `./scripts/idf.sh build`: the same command a developer runs, following the same pin, and exercising the wrapper rather than going around it. Overriding stays one variable (`IDF_TAG=v5.6 ./scripts/idf.sh build`).

I checked the wrapper is CI-safe before relying on it: it adds `-it` only when stdin is a TTY, and forwards a serial device only when one exists — so it needs no CI-specific branch.

The alternative was `container: espressif/idf:v5.5.1` with a step asserting it matches `scripts/idf.sh`. Happy to switch if you would rather see the version in the workflow; it costs the third copy plus a guard, and buys a slightly cleaner Actions UI.

**2. `fetch-depth: 0` on checkout, deliberately, not the default shallow clone.** The top-level `CMakeLists.txt` derives `PROJECT_VER` from `git describe --tags --long --dirty`, and that value lands in `esp_app_desc_t.version` and on the portal's version line. On a depth-1 clone `describe` fails and the fallback produces `0.0.0+1.g<sha>` — the build still goes green while stamping the firmware with a version that is not the firmware's. The run above confirms the fix works: `-- Firmware version: v1.4.1-dev+72`. (It reads low only because my fork carries tags up to v1.4.1; on this repo it resolves against the current tag.)

### Carried over from #212

- `set -o pipefail` around the `| tee`. The runner's default step shell is `bash -e` without pipefail, so the step would otherwise report `tee`'s exit status — the fail-open I proved and fixed in the host-tests workflow.
- A final step asserts `build/somnotrace.bin` exists and echoes its size and the version line, so a green run states *what* it built rather than only that a command exited 0.
- The build log is uploaded as an artifact (7-day retention) so a failure can be read without re-running.

### Not included, on purpose

- **ccache.** It would cut the 2 min 14 s compile substantially, but the cache lives at `/root/.ccache` inside the container and mounting it through `scripts/idf.sh` adds moving parts to a first version. Worth a follow-up once this has proven itself.
- **`scripts/build-dist.sh` instead of `idf.py build`.** The merged-image step is packaging rather than compilation, and the merge gate only needs the compile. Easy to switch if you would rather CI produce a flashable artifact on every run.

The `paths:` filters follow the same shape as `host-tests.yml`, so a docs-only PR does not spend five minutes building firmware. Note the consequence, since it matters if you ever make this a required check: a PR touching none of those paths gets no run at all, rather than a passing one.

Not flashed — I have no ESP32-S3, so this verifies that the firmware **builds**, never that it runs.
