### PR TITLE
ci: run the mutation check that has been in the repo since #207

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,0 +1,50 @@
+name: "Mutation check"
+# Runs scripts/mutants.py, which has been in this repo since #207 with nothing invoking it.
+#
+# WHAT IT ADDS OVER THE HOST TESTS. Those answer "do the tests pass?". This answers "would
+# the tests have caught it?" — it plants a known defect in the exporter and fails if the
+# suite still goes green. A test that passes against broken code is worse than no test,
+# because it reports safety it does not provide.
+#
+# IT REFUSES RATHER THAN GUESSES. The harness runs a baseline (must pass), a canary (a
+# planted mutant that MUST die), and reports VOID with a non-zero exit if either control
+# fails — so a run that measured nothing can never be read as a run that found nothing.
+# That is why this job can be blocking: its failure modes are loud by construction.
+on:
+  push:
+    paths: ["main/**", "scripts/**", ".github/workflows/mutation.yml"]
+  pull_request:
+    paths: ["main/**", "scripts/**", ".github/workflows/mutation.yml"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  mutation:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install libcjson
+        # Same dependency the host tests need; without it the harness SKIPS the two suites
+        # that cover the exporter and correctly reports VOID rather than a kill count.
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y --no-install-recommends libcjson-dev
+
+      - name: Run the mutation check
+        run: |
+          set -o pipefail
+          python3 scripts/mutants.py 2>&1 | tee mutants.log
+          tail -1 mutants.log | grep -qE '^[0-9]+/[0-9]+ mutants killed' \
+            || { echo "::error::no kill-count line — the run did not complete"; exit 1; }
+
+      - name: Upload the mutation log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutation-log
+          path: mutants.log
+          retention-days: 7


### PR DESCRIPTION
`scripts/mutants.py` landed with the host tests in #207 and nothing has ever invoked it. This adds the job that does.

**What it adds over the host tests.** Those answer *"do the tests pass?"*. This answers *"would the tests have caught it?"* — it plants a known defect in the exporter, reruns the suite, and fails if the suite still reports green. A test that passes against deliberately broken code is worse than no test, because it reports a safety it does not provide.

**Measured on `main` before proposing, and again in CI:**

| | |
|---|---|
| result | **15 / 15 mutants killed**, canary passed, baseline green |
| CI run time | **61 s** ([green run on my fork](https://github.com/Plantucha/SomnoTrace/actions/runs/34041612537)) |
| new dependencies | none — `libcjson-dev`, the same package `host-tests.yml` already installs |

**Why it is safe to make this blocking.** The harness runs two controls of its own: a baseline that must pass on the unmutated tree, and a canary — a planted mutant that *must* die. If either fails it prints `VOID — this run measured nothing` and exits non-zero, so a run that measured nothing can never be read as a run that found nothing. I verified that path rather than trusting it: running without `libcjson` available produced

```
host tests: 3 run, 0 failed, 2 skipped
canary     killed        2 test(s) skipped — the suite did not cover the file
VOID — this run measured nothing; no kill count is reported:
  - baseline does not pass on the unmutated tree
```

and exit 2. That is the failure mode most tooling of this kind gets wrong, and it is already handled.

The step additionally greps for the `N/M mutants killed` summary line, so a harness that dies midway cannot pass on somebody else's zero exit — the same reasoning as the `set -o pipefail` guard in `host-tests.yml`.

**Three mutants are classified equivalent** and listed in the file with the reasoning for each. They are still *run*: if the suite ever kills one, it is reported as `REFUTED`, meaning the classification was wrong and the comment needs fixing rather than the test. That is deliberate — a suppression that cannot be challenged is a suppression that rots.

Tested on my fork, where the workflow is merged and green. Nothing here touches firmware behaviour: one new workflow file, no source changes.
