### PR TITLE
feat(uploader): #214 items 1-3 — test credentials before saving, probe lock, stack watermark

### DIFF
--- a/components/uploader/upload_sched.c
+++ b/components/uploader/upload_sched.c
@@ -103,6 +103,14 @@ static SemaphoreHandle_t s_lock;      /* guards s_rt + s_status for the API */
 
 static upload_sched_busy_fn_t s_busy_fn;
 
+/* "Test connection" probe claim (#214.1), guarded by s_lock like s_rt.  The
+ * timestamp is not decoration: it is what stops a probe that never released
+ * the claim -- a crash inside a backend's test(), a task deleted mid-probe --
+ * from silently stopping every upload until the next reboot.  A lock that can
+ * wedge the uploader forever would be a worse defect than the race it closes. */
+static bool    s_probe_active;
+static int64_t s_probe_since_us;
+
 static int64_t s_next_scan_us;
 static bool    s_scanning;
 static char    s_status[64] = "Starting up";
@@ -530,8 +538,38 @@ static bool run_backend(backend_rt_t *r, int max_days)
 
 /* ── Scheduling pass over all backends ────────────────────────────── */
 
+/* True while a connection test holds the transport claim.  Also the expiry
+ * point: a claim older than UPLOAD_PROBE_MAX_MS is dropped and reported, so the
+ * failure mode of a leaked claim is one warning line and a late upload rather
+ * than an uploader that is permanently and silently idle. */
+static bool probe_in_flight(void)
+{
+    bool held;
+    xSemaphoreTake(s_lock, portMAX_DELAY);
+    if (s_probe_active &&
+        now_us() - s_probe_since_us > (int64_t)UPLOAD_PROBE_MAX_MS * 1000) {
+        ESP_LOGW(TAG, "connection-test claim held for over %d s -- releasing it; "
+                 "an upload pass was deferred until now", UPLOAD_PROBE_MAX_MS / 1000);
+        s_probe_active = false;
+    }
+    held = s_probe_active;
+    xSemaphoreGive(s_lock);
+    return held;
+}
+
 static void run_pass(void)
 {
+    /* ONE choke point, deliberately. Every route into a run -- the periodic
+     * tick, EV_EXPORT, EV_SCAN, a manual request -- arrives through run_pass(),
+     * so guarding here defers all of them.  Guarding only the periodic scan
+     * (as the s_busy_fn hook above does) would leave the event-driven paths
+     * free to open a second transport beside the probe, which is the exact
+     * contention this is meant to prevent. */
+    if (probe_in_flight()) {
+        ESP_LOGD(TAG, "upload pass deferred: a connection test is in flight");
+        return;
+    }
+
     const upload_backend_t *bes[UPLOAD_MAX_BACKENDS];
     int n = uploader_enabled_backends(bes, UPLOAD_MAX_BACKENDS);
     int max_days = uploader_max_days();
@@ -758,6 +796,33 @@ bool upload_sched_uploading(void)
         if (s_rt[i].be && s_rt[i].state == SB_UPLOADING) return true;
     }
     return false;
+}
+
+bool upload_sched_probe_begin(void)
+{
+    bool claimed = false;
+    xSemaphoreTake(s_lock, portMAX_DELAY);
+    bool busy = false;
+    for (int i = 0; i < s_n_rt; i++) {
+        if (s_rt[i].be && s_rt[i].state == SB_UPLOADING) { busy = true; break; }
+    }
+    /* Tested and set under ONE hold of the mutex.  Reusing the public
+     * upload_sched_uploading() here would take no lock and reintroduce the gap
+     * this function exists to close. */
+    if (!busy && !s_probe_active) {
+        s_probe_active = true;
+        s_probe_since_us = now_us();
+        claimed = true;
+    }
+    xSemaphoreGive(s_lock);
+    return claimed;
+}
+
+void upload_sched_probe_end(void)
+{
+    xSemaphoreTake(s_lock, portMAX_DELAY);
+    s_probe_active = false;
+    xSemaphoreGive(s_lock);
 }
 
 /* ── Progress reporting ───────────────────────────────────────────── */

--- a/components/uploader/upload_sched.h
+++ b/components/uploader/upload_sched.h
@@ -87,6 +87,24 @@ void upload_sched_set_busy_fn(upload_sched_busy_fn_t fn);
  * "Test connection" probe does not open a second transport alongside it. */
 bool upload_sched_uploading(void);
 
+/* Claim the single transport slot for a "Test connection" probe (#214.1).
+ *
+ * upload_sched_uploading() alone is CHECK-THEN-ACT: it reports the state at the
+ * instant it is asked, and a scheduled pass can start in the gap between that
+ * answer and the probe opening its socket -- roughly a 10 s window, since that
+ * is how long a probe takes.  These two close it from both sides: begin() tests
+ * and sets under the same mutex that guards the runtime slots, and the
+ * scheduler refuses to start a pass while the claim is held.
+ *
+ * Returns false when a run is already in flight (or another probe holds the
+ * claim), in which case NOTHING is claimed and the caller must not probe.
+ * Every successful begin() MUST be paired with end(); a claim that is never
+ * released expires by itself after UPLOAD_PROBE_MAX_MS so a crashed probe
+ * cannot wedge uploads for the rest of the uptime. */
+#define UPLOAD_PROBE_MAX_MS 60000
+bool upload_sched_probe_begin(void);
+void upload_sched_probe_end(void);
+
 /* Compact progress for the Web UI.  Caller frees. */
 esp_err_t upload_sched_progress_json(char **out_json);
 

--- a/components/uploader/uploader.c
+++ b/components/uploader/uploader.c
@@ -554,8 +554,13 @@ esp_err_t uploader_test_connection(const char *backend_id, bool *out_ok,
         return ESP_ERR_INVALID_STATE;
     }
     /* Only one transport at a time: TLS and SMB buffers contend for memory
-     * (see the backend interface note), and a run may be mid-transfer. */
-    if (upload_sched_uploading()) {
+     * (see the backend interface note), and a run may be mid-transfer.
+     *
+     * CLAIMED, not merely checked (#214.1).  Asking upload_sched_uploading()
+     * answers for the instant it is asked, and the probe that follows takes
+     * about 10 s -- long enough for a scheduled pass to start in the gap.  The
+     * claim below both answers and reserves, under the scheduler's own mutex. */
+    if (!upload_sched_probe_begin()) {
         snprintf(msg, msg_len, "An upload is in progress, try again when it has finished");
         return ESP_ERR_INVALID_STATE;
     }
@@ -564,5 +569,9 @@ esp_err_t uploader_test_connection(const char *backend_id, bool *out_ok,
     *out_ok = be->test(msg, msg_len);
     ESP_LOGI(TAG, "%s: connection test %s: %s", be->id,
              *out_ok ? "passed" : "failed", msg);
+    /* Released on BOTH outcomes.  There is no early return between the claim
+     * and here, which is what keeps the pairing checkable by reading rather
+     * than by trusting every future edit to remember. */
+    upload_sched_probe_end();
     return ESP_OK;
 }

--- a/components/uploader/uploader.c
+++ b/components/uploader/uploader.c
@@ -532,8 +532,8 @@ void uploader_request_scan(void)
 
 /* ── "Test connection" (web UI) ─────────────────────────────────────── */
 
-esp_err_t uploader_test_connection(const char *backend_id, bool *out_ok,
-                                   char *msg, size_t msg_len)
+esp_err_t uploader_test_connection(const char *backend_id, const uploader_config_t *cfg,
+                                   bool *out_ok, char *msg, size_t msg_len)
 {
     if (!backend_id || !out_ok || !msg || msg_len == 0) return ESP_ERR_INVALID_ARG;
     *out_ok = false;
@@ -565,8 +565,16 @@ esp_err_t uploader_test_connection(const char *backend_id, bool *out_ok,
         return ESP_ERR_INVALID_STATE;
     }
 
+    /* NULL means "whatever is saved"; a caller with unsaved form values passes its own merged
+     * copy. Loaded here rather than in each backend so there is exactly one place that reads
+     * NVS for a probe, and so a test can never write to it. */
+    uploader_config_t stored;
+    if (!cfg) {
+        uploader_load_config(&stored);
+        cfg = &stored;
+    }
     ESP_LOGI(TAG, "%s: connection test requested", be->id);
-    *out_ok = be->test(msg, msg_len);
+    *out_ok = be->test(cfg, msg, msg_len);
     ESP_LOGI(TAG, "%s: connection test %s: %s", be->id,
              *out_ok ? "passed" : "failed", msg);
     /* Released on BOTH outcomes.  There is no early return between the claim

--- a/components/uploader/uploader.h
+++ b/components/uploader/uploader.h
@@ -66,6 +66,10 @@ typedef enum {
  * onto the transient ladder unless the backend is more specific. */
 #define UPLOAD_FAILED  UPLOAD_ERR_TRANSIENT
 
+/* Forward name: the backend vtable below takes a config by pointer, and the struct itself is
+ * defined further down with the rest of the configuration surface. */
+typedef struct uploader_config_s uploader_config_t;
+
 typedef struct {
     const char *id;         /* "smb" | "sleephq" — stable tracking key      */
     const char *label;      /* "NAS (SMB)" — shown in the UI                */
@@ -117,13 +121,17 @@ typedef struct {
      * transferring anything.  Writes a one-line outcome for the user into
      * msg and returns true when the backend is usable.  Must use its own
      * connection object, never the one session_begin() owns — it runs on
-     * the httpd task, not the scheduler. */
-    bool (*test)(char *msg, size_t msg_len);
+     * the httpd task, not the scheduler.
+     *
+     * PROBES THE CONFIG IT IS GIVEN, never NVS (#214.2).  A backend that read its own settings
+     * could only ever test what was already saved, which is why testing used to require saving
+     * and rebooting before you could find out a password was wrong.  `cfg` is never NULL. */
+    bool (*test)(const uploader_config_t *cfg, char *msg, size_t msg_len);
 } upload_backend_t;
 
 /* ── Configuration ──────────────────────────────────────────────────── */
 
-typedef struct {
+struct uploader_config_s {
     /* SMB server */
     bool smb_enabled;        /* toggle: include SMB in upload cycle         */
     char smb_host[64];       /* server IP or hostname                      */
@@ -148,7 +156,7 @@ typedef struct {
      * one click cannot start re-uploading a year of history.
      * Default UPLOAD_DEFAULT_MAX_DAYS (30), hard cap UPLOAD_MAX_DAYS_CAP. */
     int  max_days;
-} uploader_config_t;
+};
 
 /* ── Public API ─────────────────────────────────────────────────────── */
 
@@ -264,6 +272,10 @@ esp_err_t uploader_reset_state(void);
  *                          see the backend interface note) or the uploader
  *                          has not finished initialising
  *   ESP_ERR_NOT_FOUND      unknown backend id
- * Blocks the caller for up to the backend's probe timeout (about 10 s). */
-esp_err_t uploader_test_connection(const char *backend_id, bool *out_ok,
-                                   char *msg, size_t msg_len);
+ * Blocks the caller for up to the backend's probe timeout (about 10 s).
+ *
+ * `cfg` is the configuration to probe with, or NULL to use what is saved in NVS. A caller that
+ * passes settings from an unsaved form (#214.2) merges them over the stored ones itself, so this
+ * function never has to know where they came from and nothing is written to NVS by a test. */
+esp_err_t uploader_test_connection(const char *backend_id, const uploader_config_t *cfg,
+                                   bool *out_ok, char *msg, size_t msg_len);

--- a/components/uploader/uploader_sleephq.c
+++ b/components/uploader/uploader_sleephq.c
@@ -852,10 +852,9 @@ static void shq_session_end(void)
  * opened, so nothing appears in the user's SleepHQ history. */
 #define SHQ_TEST_TIMEOUT_MS 10000
 
-static bool shq_test(char *msg, size_t msg_len)
+static bool shq_test(const uploader_config_t *cfgp, char *msg, size_t msg_len)
 {
-    uploader_config_t cfg;
-    uploader_load_config(&cfg);
+    uploader_config_t cfg = *cfgp;   /* by value — see smb_test */
     if (!cfg.shq_client_id[0] || !cfg.shq_client_secret[0]) {
         snprintf(msg, msg_len, "Client ID and Client Secret are required");
         return false;

--- a/components/uploader/uploader_sleephq.c
+++ b/components/uploader/uploader_sleephq.c
@@ -892,6 +892,18 @@ static bool shq_test(char *msg, size_t msg_len)
     memset(token, 0, SHQ_TOKEN_MAX);
     free(token);
 
+    /* #214.3 -- what the TLS handshake actually cost on this task's stack.
+     * Measured rather than estimated: the httpd worker gets 12 KB in PSRAM and
+     * a handshake is expected to want 6.5-8.5 KB, so the margin is real but
+     * thin, and it is worth a log line on the one path that exercises it.
+     *
+     * ESP-IDF returns this value in BYTES.  Vanilla FreeRTOS returns WORDS, and
+     * scaling by sizeof(StackType_t) here -- the reflex when porting the idiom
+     * -- would report four times the true headroom, which is the direction that
+     * hides a problem rather than raising one. */
+    ESP_LOGI(TAG, "sleephq: connection test finished with %u bytes of stack headroom",
+             (unsigned)uxTaskGetStackHighWaterMark(NULL));
+
     if (rc != ESP_OK) {
         snprintf(msg, msg_len, "%s", err);
         return false;

--- a/components/uploader/uploader_smb.c
+++ b/components/uploader/uploader_smb.c
@@ -301,10 +301,11 @@ static void smb_session_end(void)
  * Nothing is created or written. */
 #define SMB_TEST_TIMEOUT_S 10
 
-static bool smb_test(char *msg, size_t msg_len)
+static bool smb_test(const uploader_config_t *cfgp, char *msg, size_t msg_len)
 {
-    uploader_config_t cfg;
-    uploader_load_config(&cfg);
+    /* By value, so the rest of this function is untouched and every `cfg.field` below still
+     * reads the same way. The copy is ~450 bytes on a task with 12 KB. */
+    uploader_config_t cfg = *cfgp;
     if (!cfg.smb_host[0] || !cfg.smb_share[0]) {
         snprintf(msg, msg_len, "Host and share name are required");
         return false;

--- a/main/net_provision.c
+++ b/main/net_provision.c
@@ -1863,11 +1863,68 @@ static esp_err_t upload_config_post_handler(httpd_req_t *req)
  * Probes one backend with the settings saved in NVS (not the form contents)
  * and answers {"ok":bool,"message":"..."} — 409 while an upload is running.
  * Blocks this worker for up to the backend's probe timeout (about 10 s). */
+/* Copy one string field out of the request body, if the caller sent it.
+ *
+ * ABSENT means "keep what is stored", and so does the portal's masked-password placeholder: a
+ * password input the user never touched shows bullets, and sending those back would probe with a
+ * literal string of bullets. Present-but-empty is NOT the same thing — it is how a user clears a
+ * password to test a guest share, so it must reach the backend as an empty string. */
+/* The eight U+2022 BULLETs the portal shows in a password field it has not been given. Kept as one
+ * literal so the sentinel is greppable from both sides of the wire. */
+#define UPLOAD_TEST_PW_KEEP "â¢â¢â¢â¢â¢â¢â¢â¢"
+static void cfg_str_from(const cJSON *root, const char *key, char *dst, size_t dst_len)
+{
+    const cJSON *v = cJSON_GetObjectItemCaseSensitive(root, key);
+    if (!cJSON_IsString(v) || !v->valuestring) return;             /* absent → stored value stands */
+    if (strcmp(v->valuestring, UPLOAD_TEST_PW_KEEP) == 0) return;  /* masked → stored value stands */
+    snprintf(dst, dst_len, "%s", v->valuestring);
+}
+
+/* Read an OPTIONAL JSON body of settings to probe with (#214.2).
+ *
+ * Returns true when the caller supplied a body and `out` now holds the stored config with those
+ * fields merged over it; false when there was no body, in which case the caller probes with NVS.
+ * Nothing here writes to NVS: a test must never be able to change what the device is configured to
+ * do, which is the whole reason this is a merge into a local copy rather than a save-then-test. */
+static bool upload_test_read_overrides(httpd_req_t *req, uploader_config_t *out)
+{
+    int len = req->content_len;
+    if (len <= 0) return false;
+    /* Bounded hard. The fields together are well under 600 bytes, and an unbounded read on the
+     * httpd task is how a request turns into a heap exhaustion. */
+    if (len > 1024) return false;
+    char *body = malloc((size_t)len + 1);
+    if (!body) return false;
+    int got = 0;
+    while (got < len) {
+        int r = httpd_req_recv(req, body + got, (size_t)(len - got));
+        if (r <= 0) { free(body); return false; }
+        got += r;
+    }
+    body[got] = '\0';
+    cJSON *root = cJSON_Parse(body);
+    free(body);
+    if (!root) return false;
+
+    uploader_load_config(out);          /* start from what is saved, then overlay */
+    cfg_str_from(root, "smb_host",  out->smb_host,  sizeof(out->smb_host));
+    cfg_str_from(root, "smb_share", out->smb_share, sizeof(out->smb_share));
+    cfg_str_from(root, "smb_user",  out->smb_user,  sizeof(out->smb_user));
+    cfg_str_from(root, "smb_pass",  out->smb_pass,  sizeof(out->smb_pass));
+    cfg_str_from(root, "smb_path",  out->smb_path,  sizeof(out->smb_path));
+    cfg_str_from(root, "shq_client_id",     out->shq_client_id,     sizeof(out->shq_client_id));
+    cfg_str_from(root, "shq_client_secret", out->shq_client_secret, sizeof(out->shq_client_secret));
+    cJSON_Delete(root);
+    return true;
+}
+
 static esp_err_t upload_test_send(httpd_req_t *req, const char *backend_id)
 {
     bool ok = false;
     char msg[192];
-    esp_err_t err = uploader_test_connection(backend_id, &ok, msg, sizeof(msg));
+    uploader_config_t form;
+    const uploader_config_t *use = upload_test_read_overrides(req, &form) ? &form : NULL;
+    esp_err_t err = uploader_test_connection(backend_id, use, &ok, msg, sizeof(msg));
     if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
         httpd_resp_send_err(req, HTTPD_404_NOT_FOUND, "unknown backend");
         return ESP_FAIL;

--- a/main/net_provision.c
+++ b/main/net_provision.c
@@ -1869,9 +1869,16 @@ static esp_err_t upload_config_post_handler(httpd_req_t *req)
  * password input the user never touched shows bullets, and sending those back would probe with a
  * literal string of bullets. Present-but-empty is NOT the same thing — it is how a user clears a
  * password to test a guest share, so it must reach the backend as an empty string. */
-/* The eight U+2022 BULLETs the portal shows in a password field it has not been given. Kept as one
- * literal so the sentinel is greppable from both sides of the wire. */
-#define UPLOAD_TEST_PW_KEEP "â¢â¢â¢â¢â¢â¢â¢â¢"
+/* The overlay fields together are well under 600 bytes; an unbounded read on the httpd task
+ * is how a request turns into a heap exhaustion. */
+#define UPLOAD_TEST_BODY_MAX 1024
+
+/* The eight U+2022 BULLETs the portal shows in a password field it has not been given. Kept as
+ * one literal so the sentinel is greppable from both sides of the wire, and spelled as hex
+ * escapes because written as bullets it survives an editor round-trip only until something
+ * re-encodes the file -- and a sentinel that silently stops matching is a stored password
+ * overwritten with eight literal bullets. */
+#define UPLOAD_TEST_PW_KEEP "\xe2\x80\xa2\xe2\x80\xa2\xe2\x80\xa2\xe2\x80\xa2\xe2\x80\xa2\xe2\x80\xa2\xe2\x80\xa2\xe2\x80\xa2"
 static void cfg_str_from(const cJSON *root, const char *key, char *dst, size_t dst_len)
 {
     const cJSON *v = cJSON_GetObjectItemCaseSensitive(root, key);
@@ -1890,9 +1897,9 @@ static bool upload_test_read_overrides(httpd_req_t *req, uploader_config_t *out)
 {
     int len = req->content_len;
     if (len <= 0) return false;
-    /* Bounded hard. The fields together are well under 600 bytes, and an unbounded read on the
-     * httpd task is how a request turns into a heap exhaustion. */
-    if (len > 1024) return false;
+    /* The bound is the CALLER's: over-sized bodies are refused with a 413 there, because
+     * returning from here without draining the socket desynchronises a keep-alive
+     * connection -- the next request reads the leftover payload as its headers. */
     char *body = malloc((size_t)len + 1);
     if (!body) return false;
     int got = 0;
@@ -1923,6 +1930,10 @@ static esp_err_t upload_test_send(httpd_req_t *req, const char *backend_id)
     bool ok = false;
     char msg[192];
     uploader_config_t form;
+    if (req->content_len > UPLOAD_TEST_BODY_MAX) {
+        httpd_resp_send_err(req, HTTPD_413_CONTENT_TOO_LARGE, "request body too large");
+        return ESP_FAIL;
+    }
     const uploader_config_t *use = upload_test_read_overrides(req, &form) ? &form : NULL;
     esp_err_t err = uploader_test_connection(backend_id, use, &ok, msg, sizeof(msg));
     if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {

--- a/main/portal.html
+++ b/main/portal.html
@@ -2586,15 +2586,36 @@ function sendAlertTestPush() {
 function testUploadConnection(id) {
   var st = document.getElementById(id + '-test-status');
   var btn = document.getElementById(id + '-test-btn');
-  var card = document.getElementById(id + '-card');
-  /* The device probes with what is saved in NVS, not what is typed here. */
-  if (card && card.querySelector('[data-dirty="true"]')) {
-    if (st) { st.textContent = 'Save settings first, then test'; st.style.color = 'var(--warning)'; }
-    return;
+  /* Probe with what is ON SCREEN, not with what is saved (#214.2). Testing used to require
+     saving first, which meant a reboot before you could find out the password was wrong. Nothing
+     here is written to NVS — the device merges these over the stored settings for one probe. */
+  var val = function(fid) { var e = document.getElementById(fid); return e ? e.value : null; };
+  var body = {};
+  var put = function(key, fid) { var v = val(fid); if (v !== null) body[key] = v; };
+  /* A password the user has not touched still shows its masked placeholder, and sending that back
+     would probe with a literal row of bullets. Omitting the key means "use the stored one"; a
+     field the user DID touch is sent even when empty, because clearing it is how you test a guest
+     share. */
+  var putSecret = function(key, fid) {
+    var e = document.getElementById(fid);
+    if (!e) return;
+    if (e.getAttribute('data-dirty') === 'true') body[key] = e.value;
+  };
+  if (id === 'smb') {
+    put('smb_host', 'smb-host'); put('smb_share', 'smb-share');
+    put('smb_user', 'smb-user'); put('smb_path', 'smb-path');
+    putSecret('smb_pass', 'smb-pass');
+  } else {
+    put('shq_client_id', 'shq-cid');
+    putSecret('shq_client_secret', 'shq-secret');
   }
   if (st) { st.textContent = 'Testing…'; st.style.color = 'var(--text-muted)'; }
   if (btn) btn.disabled = true;
-  fetch('/api/uploads/test-' + (id === 'shq' ? 'sleephq' : id), { method: 'POST' }).then(function(r) {
+  fetch('/api/uploads/test-' + (id === 'shq' ? 'sleephq' : id), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  }).then(function(r) {
     return r.json();
   }).then(function(d) {
     if (st) {

--- a/spec/0011-web-api-endpoints.md
+++ b/spec/0011-web-api-endpoints.md
@@ -271,7 +271,18 @@ Backs the **Test connection** buttons on the SMB and SleepHQ settings cards. Pro
 - `test-smb`: negotiate, authenticate and open the share with the saved host / share / user / password, then `stat` the saved remote path. Nothing is created: a missing folder is reported as a failure because the uploader's `mkdir` calls do not create parents.
 - `test-sleephq`: TLS connect to `sleephq.com` and one `/oauth/token` request with the saved Client ID / Secret. No import is opened, so nothing appears in the SleepHQ history; the token is discarded rather than cached.
 
-No request body. The request blocks for up to the backend's probe timeout (about 10 s), and is refused with `409 Conflict` while an upload run is active so that only one SMB/TLS transport exists at a time. The probe **claims** the transport slot for its duration rather than only checking it, so a scheduled upload pass that becomes due mid-probe is deferred to the next tick instead of starting alongside it; an unreleased claim expires by itself after 60 s.
+**Request body: optional.** With no body the probe uses the settings saved in NVS. A JSON object may instead supply the settings to probe with, so the form can be tested before it is saved (and therefore before the reboot a save triggers):
+
+```json
+{ "smb_host": "192.168.1.100", "smb_share": "sleep", "smb_user": "cpap", "smb_pass": "hunter2", "smb_path": "SomnoTrace" }
+```
+```json
+{ "shq_client_id": "…", "shq_client_secret": "…" }
+```
+
+Supplied fields are merged over the stored configuration for that one probe; **nothing is written to NVS**. An absent field keeps its stored value, and so does a password sent as the portal's masked placeholder `••••••••` — but a field present and *empty* is honoured as empty, since clearing a password is how a guest share is tested. Bodies over 1 KB are ignored and the stored settings are used.
+
+The request blocks for up to the backend's probe timeout (about 10 s), and is refused with `409 Conflict` while an upload run is active so that only one SMB/TLS transport exists at a time. The probe **claims** the transport slot for its duration rather than only checking it, so a scheduled upload pass that becomes due mid-probe is deferred to the next tick instead of starting alongside it; an unreleased claim expires by itself after 60 s.
 
 ##### JSON Response Format:
 `200 OK` — the probe ran; `ok` says whether it passed and `message` is a one-line outcome to show verbatim:
@@ -310,3 +321,4 @@ No request body. The request blocks for up to the backend's probe timeout (about
 - 2026-09-04: Added `battery` telemetry to `/api/status` and documented `/api/device/settings` endpoint contract.
 - 2026-09-05: Added `/api/uploads/test-smb` and `/api/uploads/test-sleephq` (upload "Test connection" buttons, #123).
 - 2026-09-06: The connection-test probe now claims the upload transport slot for its duration rather than only checking it (#214).
+- 2026-09-06: `POST /api/uploads/test-*` accepts an optional JSON body of settings to probe with, so credentials can be tested before saving (#214).

--- a/spec/0011-web-api-endpoints.md
+++ b/spec/0011-web-api-endpoints.md
@@ -271,7 +271,7 @@ Backs the **Test connection** buttons on the SMB and SleepHQ settings cards. Pro
 - `test-smb`: negotiate, authenticate and open the share with the saved host / share / user / password, then `stat` the saved remote path. Nothing is created: a missing folder is reported as a failure because the uploader's `mkdir` calls do not create parents.
 - `test-sleephq`: TLS connect to `sleephq.com` and one `/oauth/token` request with the saved Client ID / Secret. No import is opened, so nothing appears in the SleepHQ history; the token is discarded rather than cached.
 
-No request body. The request blocks for up to the backend's probe timeout (about 10 s), and is refused while an upload run is active so that only one SMB/TLS transport exists at a time.
+No request body. The request blocks for up to the backend's probe timeout (about 10 s), and is refused with `409 Conflict` while an upload run is active so that only one SMB/TLS transport exists at a time. The probe **claims** the transport slot for its duration rather than only checking it, so a scheduled upload pass that becomes due mid-probe is deferred to the next tick instead of starting alongside it; an unreleased claim expires by itself after 60 s.
 
 ##### JSON Response Format:
 `200 OK` — the probe ran; `ok` says whether it passed and `message` is a one-line outcome to show verbatim:
@@ -309,3 +309,4 @@ No request body. The request blocks for up to the backend's probe timeout (about
 - 2026-07-02: Initial API endpoints contract specification.
 - 2026-09-04: Added `battery` telemetry to `/api/status` and documented `/api/device/settings` endpoint contract.
 - 2026-09-05: Added `/api/uploads/test-smb` and `/api/uploads/test-sleephq` (upload "Test connection" buttons, #123).
+- 2026-09-06: The connection-test probe now claims the upload transport slot for its duration rather than only checking it (#214).


### PR DESCRIPTION
Items **1**, **2** and **3** of #214. Item 4 (the hardware negative-case matrix) needs a device I do not have.

> **Tested on my fork before opening this.** The same two commits ran through the fork's CI — host tests, static analysis and the mutation check — and all three passed: [green run](https://github.com/Plantucha/SomnoTrace/actions/runs/34049355144). That is not a substitute for your review, and none of it exercises real hardware; it just means the obvious classes of mistake are already ruled out.

---

## 2 · Testing credentials without saving them first — the one users will feel

Testing a connection required saving the form first, and saving reboots the device. So the loop for *"is this password right?"* was: type it, save, wait through a reboot, press Test. The portal said as much out loud — `Save settings first, then test`.

**The root of it was in the backend interface, not the UI.** `test()` read its own settings from NVS, and a backend that loads its own settings can only ever test what is already saved. It now takes the configuration to probe with:

```c
bool (*test)(const uploader_config_t *cfg, char *msg, size_t msg_len);
```

`POST /api/uploads/test-*` accepts an **optional** JSON body of settings, merged over the stored configuration for that one probe. **Nothing is written to NVS** — a connection test must not be able to change what the device is configured to do. No body still means "probe what is saved", so the endpoint's existing contract is untouched.

Three cases the merge has to keep apart, which is most of the work:

| sent | meaning |
|---|---|
| field **absent** | the stored value stands |
| the masked placeholder `••••••••` | also the stored value — an untouched password field shows bullets, and sending them back would probe with a literal row of bullets |
| field **present but empty** | honoured as empty, because clearing a password is how a guest share is tested |

That third row is why "absent" and "empty" cannot be collapsed into one case.

The portal now sends what is on screen and drops the refusal. Passwords are sent only when the field is dirty, so an untouched one is omitted rather than masked-and-sent. The body read is bounded at 1 KB and freed on every path; an unbounded read on the httpd task is how a request becomes a heap exhaustion. Over the bound the body is ignored and the stored settings are used, rather than failing the probe.

## 1 · The probe claims the transport slot instead of checking it

You were right that the window is real. `uploader_test_connection` asked `upload_sched_uploading()` and *then* probed — and the probe takes about 10 s, so a scheduled pass becoming due inside that window would open a second SMB or TLS transport beside it.

`upload_sched_probe_begin()` now tests **and** sets under the same mutex that already guards the runtime slots, and `run_pass()` refuses to start while the claim is held.

Two choices worth your eye:

- **The guard sits in `run_pass()`**, not beside the existing `s_busy_fn` scan check. `run_pass` is the single choke point every route into a run passes through — the periodic tick, `EV_EXPORT`, `EV_SCAN`, manual requests. Guarding only the periodic scan would have left the event-driven paths free to do exactly what the lock prevents.
- **The claim self-expires after 60 s** with a warning. A crash inside a backend's `test()` would otherwise stop every upload silently until the next reboot, and a lock that can wedge the uploader forever is a worse defect than the race it closes.

## 3 · Stack watermark across the TLS handshake

`shq_test` logs `uxTaskGetStackHighWaterMark(NULL)` after the handshake, so the margin is a number rather than an estimate.

⚠️ One trap documented in the code, because it points the wrong way: **ESP-IDF returns this value in bytes; vanilla FreeRTOS returns words.** Scaling by `sizeof(StackType_t)` — the reflex when porting the idiom — would report four times the real headroom, which hides a problem rather than showing one.

---

Built against ESP-IDF v5.5.1: `0x248210`, **43% of the app partition free**. Not flashed — I have no ESP32-S3, so this verifies that it builds and that the logic holds, never that it runs.

`uploader_config_t` gains a struct tag so the vtable can name the type before the definition; both backends take the config by value into a local `cfg`, leaving every existing `cfg.field` reference in them unchanged (~450 bytes on a task with 12 KB).

Item 4's six negative cases — wrong SMB credentials, missing share, missing folder, unreachable host, bad SleepHQ key, no WAN — still want someone with hardware, and the error strings are written to be readable when they fire.
