### PR TITLE
chore: add .mailmap so one contributor is not counted as two

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,9 @@
+# Canonical author identities for `git shortlog`, `git log --author` and any
+# contributor list generated from the history.
+#
+# Format: <canonical name> <canonical email> <name as committed> <email as committed>
+#
+# This file changes NOTHING about the commits themselves — mailmap is a display
+# mapping applied by git at read time. No history is rewritten.
+
+Michal Planicka <plantucha@gmail.com> Plantucha <plantucha@gmail.com>


### PR DESCRIPTION
One file, seven lines of comment and one mapping line.

`git shortlog -sne` currently reports the same person, at the same address, twice:

```
   342  Ilya Kruchinin <16409780+ilyakruchinin@users.noreply.github.com>
    11  Michal Planicka <plantucha@gmail.com>
     8  Plantucha <plantucha@gmail.com>          ← same person, same email
     5  hungrycactus <1281061+moldbuster@users.noreply.github.com>
     4  cwm12345 <chris@wyattmoore.com>
     3  Chris Awad <dev@chrisawad.com>
```

Both are me; the names differ only because git was configured differently on two machines. With the mapping:

```
   342  Ilya Kruchinin <…>
    19  Michal Planicka <plantucha@gmail.com>
     5  hungrycactus <…>
     4  cwm12345 <…>
     3  Chris Awad <…>
```

**GitHub was never wrong about this** — it attributes by email, so the contributor graph has always been correct. What is split is every *git-side* view: `shortlog`, `git log --author`, `git blame` summaries, and anything generated from them.

`.mailmap` is the standard fix and the conservative one: a **display mapping git applies at read time**. It rewrites no history, changes no commit, moves no hash, and deleting the file restores the previous output exactly.

**I have deliberately not mapped anyone else.** Mine is the only identity in this history that is actually split. `hungrycactus <…+moldbuster@…>` commits under a name that differs from their GitHub handle, but that is one identity, not two, and it may well be intentional — choosing someone else's canonical name is theirs to make, not mine. The file has room for those entries if anyone ever wants one.

No code, no build impact.
