### PR TITLE
ci: build the release images in CI and attest them

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,13 +39,20 @@ jobs:
           ./scripts/build-dist.sh 2>&1 | tee release-build.log
           ls -l dist/
 
-      - name: Confirm both images exist and are plausible
+      - name: Confirm both images exist, and name them for attestation
         # A release step that exits 0 having published nothing is the failure this
         # catches. Sizes are a floor, not a checksum: an empty or truncated image is
         # the realistic accident, not a subtly wrong one.
+        #
+        # -type f is the whole trick. build-dist.sh also writes
+        # somnotrace-latest-full.bin as a SYMLINK to the versioned file, so a plain
+        # dist/*-full.bin glob matches two paths for one artifact — which failed this
+        # check on its first run, correctly. Attesting the symlink as well would have
+        # produced two subjects for one image and made the attestation say something
+        # slightly untrue, so the real files are resolved here and passed on by name.
         run: |
-          shopt -s nullglob
-          full=(dist/*-full.bin); ota=(dist/*-ota.bin)
+          mapfile -t full < <(find dist -maxdepth 1 -type f -name '*-full.bin')
+          mapfile -t ota  < <(find dist -maxdepth 1 -type f -name '*-ota.bin')
           [ ${#full[@]} -eq 1 ] || { echo "::error::expected exactly one -full.bin, got ${#full[@]}"; exit 1; }
           [ ${#ota[@]}  -eq 1 ] || { echo "::error::expected exactly one -ota.bin, got ${#ota[@]}"; exit 1; }
           for f in "${full[0]}" "${ota[0]}"; do
@@ -53,11 +60,14 @@ jobs:
             [ "$sz" -gt 1000000 ] || { echo "::error::$f is only $sz bytes"; exit 1; }
             echo "$(basename "$f")  $sz bytes  sha256=$(sha256sum "$f" | cut -d' ' -f1)"
           done
+          { echo "FULL_BIN=${full[0]}"; echo "OTA_BIN=${ota[0]}"; } >> "$GITHUB_ENV"
 
       - name: Attest the images
         uses: actions/attest-build-provenance@v2
         with:
-          subject-path: "dist/*-full.bin,dist/*-ota.bin"
+          subject-path: |
+            ${{ env.FULL_BIN }}
+            ${{ env.OTA_BIN }}
 
       - name: Upload the images
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+name: "Release build"
+# Builds the two distributable images the releases page carries today —
+# somnotrace-<ver>-full.bin (flashable at 0x0) and -ota.bin — through the repo's own
+# scripts/build-dist.sh, and ATTESTS them.
+#
+# WHY ATTEST. A string compiled into a binary proves nothing: anyone rebuilding the
+# source can copy it. A build attestation is different in kind — it is a signed
+# statement, made by GitHub's own workflow identity and recorded in a public
+# transparency log, binding this exact artifact digest to the repository, workflow and
+# commit that produced it. A fork building the same source gets an attestation naming
+# THE FORK, which is precisely the distinction a watermark cannot make on its own.
+#
+# It costs nothing on a public repository and adds seconds, not minutes.
+on:
+  workflow_dispatch:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+  id-token: write        # mint the OIDC token the attestation is signed against
+  attestations: write    # record the attestation on the repository
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Tags, not a shallow clone: build-dist.sh derives the version — and therefore
+          # the ARTIFACT FILENAMES — from `git describe --tags`. On a depth-1 clone every
+          # release would be published as somnotrace-0.0.0+1.g<sha>-full.bin.
+          fetch-depth: 0
+
+      - name: Build the distributable images
+        run: |
+          set -o pipefail
+          ./scripts/build-dist.sh 2>&1 | tee release-build.log
+          ls -l dist/
+
+      - name: Confirm both images exist and are plausible
+        # A release step that exits 0 having published nothing is the failure this
+        # catches. Sizes are a floor, not a checksum: an empty or truncated image is
+        # the realistic accident, not a subtly wrong one.
+        run: |
+          shopt -s nullglob
+          full=(dist/*-full.bin); ota=(dist/*-ota.bin)
+          [ ${#full[@]} -eq 1 ] || { echo "::error::expected exactly one -full.bin, got ${#full[@]}"; exit 1; }
+          [ ${#ota[@]}  -eq 1 ] || { echo "::error::expected exactly one -ota.bin, got ${#ota[@]}"; exit 1; }
+          for f in "${full[0]}" "${ota[0]}"; do
+            sz=$(stat -c %s "$f")
+            [ "$sz" -gt 1000000 ] || { echo "::error::$f is only $sz bytes"; exit 1; }
+            echo "$(basename "$f")  $sz bytes  sha256=$(sha256sum "$f" | cut -d' ' -f1)"
+          done
+
+      - name: Attest the images
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: "dist/*-full.bin,dist/*-ota.bin"
+
+      - name: Upload the images
+        uses: actions/upload-artifact@v4
+        with:
+          name: somnotrace-images
+          path: |
+            dist/*-full.bin
+            dist/*-ota.bin
+          retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,11 @@ permissions:
 
 jobs:
   release:
+    # Only the upstream repository publishes releases. A fork that pushes a v* tag
+    # would otherwise mint an attestation naming the fork and upload images that look
+    # official; the attestation would be honest about its origin, but the artifacts
+    # would still be sitting on a releases page. Requested in discussion #223.
+    if: github.repository == 'ilyakruchinin/SomnoTrace'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
Builds the two distributable images in CI and attests them, as proposed in discussion #223.

## What it does

On a `v*` tag (or `workflow_dispatch`) it runs the repo's own `scripts/build-dist.sh`, checks that both images exist and are plausibly sized, attests them with `actions/attest-build-provenance@v2`, and uploads them as workflow artifacts.

## The three points you raised in #223

**1. Verification.** After a release built this way, anyone can run:

```
gh attestation verify somnotrace-<ver>-ota.bin --repo ilyakruchinin/SomnoTrace
```

Measured on the fork: exit 0 against the correct repo, 404 against the wrong one, and 404 again after flipping a single bit in the image. That last one is the property that matters — the attestation is over the artifact digest, so a modified binary cannot inherit it.

**2. The release boundary stays manual.** There is no publish step in this workflow. The only output is `actions/upload-artifact`, so a tag produces attested images for you to look at and attach yourself. Nothing reaches the releases page without you putting it there.

**3. The repository guard, as you asked:**

```yaml
jobs:
  release:
    if: github.repository == 'ilyakruchinin/SomnoTrace'
```

Without it a fork pushing a `v*` tag would build, attest and upload a pair of official-looking images. The attestation would still be honest — it names whichever repository produced it, which is the whole point — but the artifacts would exist, and a maintainer triaging a report has no reason to expect that.

## One fix folded in

`ci(release): resolve the real images, not the latest-* symlinks` — `build-dist.sh` leaves `latest-*` symlinks beside the versioned images, and globbing picked them up, so the attestation subject could end up being a symlink rather than the file. Found on the fork after the original proposal.

## Cost

Seconds, not minutes, and free on a public repository. `permissions:` is scoped to `contents: read` plus the `id-token: write` / `attestations: write` the action requires.

## Testing

Run on the fork end to end: images built, attested, verified with `gh attestation verify`, and the negative controls above. The guard means this job will not run on the fork again, which is the intended behaviour.
