### PR TITLE
feat: stamp the source repository into the build and show it in the portal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,34 @@ endif()
 
 set(PROJECT_VER "${FIRMWARE_VERSION}")
 
+# ── Source repository stamp ─────────────────────────────────────────────────
+# WHICH REPOSITORY THIS BINARY WAS BUILT FROM, decided at build time rather than
+# written into the source. A fork that builds through its own CI stamps its own
+# slug without anyone having to remember to: GITHUB_REPOSITORY is set by GitHub
+# Actions for every run, in every fork, and cannot be inherited by accident.
+#
+# ⚠️ THIS IS NOT AN AUTHENTICITY CONTROL and must never be presented as one. Any
+# string compiled into a binary can be copied verbatim by anyone rebuilding it.
+# It answers "where did this build come from?" honestly for honest builds, which
+# is what makes the GPLv3 §7 attribution easy to comply with rather than a chore.
+# Proving origin needs a signature over the artifact, which is a separate matter.
+if(DEFINED ENV{GITHUB_REPOSITORY})
+    set(SOURCE_REPO "$ENV{GITHUB_REPOSITORY}")
+else()
+    set(SOURCE_REPO "local build")
+endif()
+message(STATUS "Source repository: ${SOURCE_REPO}")
+add_compile_definitions(SNT_SOURCE_REPO="${SOURCE_REPO}")
+
+# The project this source descends from. Unlike SOURCE_REPO above this is NOT read
+# from the environment: it travels IN THE TREE, so a fork inherits it by copying the
+# code and would have to edit this line deliberately to remove it. That is the point.
+# SOURCE_REPO alone answers "where was this built?", which leaves a fork's portal
+# naming a repository the reader has no reference point for; this answers "what is it
+# a fork OF?", which is the attribution NOTICE already requires be preserved.
+set(UPSTREAM_REPO "ilyakruchinin/SomnoTrace")
+add_compile_definitions(SNT_UPSTREAM_REPO="${UPSTREAM_REPO}")
+
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
 project(somnotrace)

--- a/main/net_provision.c
+++ b/main/net_provision.c
@@ -921,6 +921,15 @@ cJSON *netprov_build_status_json(void)
 
     const esp_app_desc_t *app_desc = esp_app_get_description();
     cJSON_AddStringToObject(resp, "fw_ver", app_desc ? app_desc->version : "unknown");
+    /* Where this build came from (CMakeLists). "local build" off CI. Reported so the
+     * portal can name the source repository beside the version; see the note in
+     * CMakeLists.txt for why this is provenance-for-honest-builds and NOT proof. */
+#ifdef SNT_SOURCE_REPO
+    cJSON_AddStringToObject(resp, "source_repo", SNT_SOURCE_REPO);
+#endif
+#ifdef SNT_UPSTREAM_REPO
+    cJSON_AddStringToObject(resp, "upstream_repo", SNT_UPSTREAM_REPO);
+#endif
 
     if (!s_portal_mode) {
         /* Live link state: SSID, IP, RSSI — all derived from the event-driven

--- a/main/portal.html
+++ b/main/portal.html
@@ -1037,6 +1037,8 @@ Upload Progress
 <div class="card info-list">
 <div class="card-title">System Status</div>
 <div class="info-row"><span class="info-label">Firmware</span><span class="info-value" id="status-fw">--</span></div>
+<div class="info-row"><span class="info-label">Built from</span><span class="info-value" id="status-repo">--</span></div>
+<div class="info-row" id="row-upstream" style="display:none"><span class="info-label">Upstream</span><span class="info-value" id="status-upstream">--</span></div>
 <div class="info-row"><span class="info-label">Uptime</span><span class="info-value" id="status-uptime">--</span></div>
 <div class="info-row"><span class="info-label">Local IP</span><span class="info-value" id="status-ip">--</span></div>
 <div id="status-nets"></div>
@@ -1765,6 +1767,20 @@ function formatSdSpace(total, free) {
 function loadStatusTab(d) {
   function setEl(id, val) { var el = document.getElementById(id); if (el) el.textContent = val; }
   setEl('status-fw', d.fw_ver || '--');
+  /* Which repository this firmware was built from. Absent on builds from before the
+     stamp existed, so fall back rather than printing "undefined" at people. */
+  setEl('status-repo', d.source_repo || '--');
+  /* The upstream project, shown ONLY when this build did not come from it — on an
+     official build the two are the same and a second identical line is just noise.
+     A local build ("local build") is not a fork and must not be labelled as one, so
+     it is excluded too: this row answers "what is this a fork of?", and the honest
+     answer for an unbuilt-by-CI tree is "nothing yet". */
+  var srcRepo = d.source_repo || '';
+  var upstream = d.upstream_repo || '';
+  var isFork = upstream && srcRepo && srcRepo !== upstream && srcRepo !== 'local build';
+  var upRow = document.getElementById('row-upstream');
+  if (upRow) upRow.style.display = isFork ? '' : 'none';
+  setEl('status-upstream', upstream || '--');
 
   /* Wi-Fi link state from the new nested object, with fallback to the
    * old flat fields for backward compatibility. */


### PR DESCRIPTION
The technical half of discussion #222 — the build stamp and the Status row. **`NOTICE` is untouched**, per your decision there.

## The problem

A screenshot of the Status tab cannot currently tell you which repository the firmware was built from. A bug report from a fork's build looks exactly like one from an official image, and gets triaged against source that does not contain the bug.

## Two values, deliberately different in kind

**`SNT_SOURCE_REPO`** — read from `GITHUB_REPOSITORY` at configure time. A fork building through its own CI stamps its own slug without anyone remembering to, because GitHub Actions sets that variable for every run in every fork and it cannot be inherited by accident. Off CI it reads `local build`.
*Answers: where was this built?*

**`SNT_UPSTREAM_REPO`** — a constant in the tree, not from the environment, so it travels with the code and a fork would have to delete it on purpose. This one exists because the source slug alone leaves a reader looking at a repository name they have no reference point for.
*Answers: what is this a fork of?*

## What the user sees

```
Firmware     2.0.3
Built from   ilyakruchinin/SomnoTrace
Uptime       ...
```

The **Upstream** row renders only when the build came from CI *and* the two slugs differ. On an official build they are identical and a second line is just noise; a local build is not a fork and must not be labelled as one. So official images look exactly as they do today.

## Not an authenticity control

The source comments say this outright, in both `CMakeLists.txt` and `net_provision.c`. Any string compiled into a binary can be copied verbatim by whoever rebuilds it. This makes honest builds legible, which is a triage aid — it is not evidence of origin. Proving origin needs a signature over the artifact, which is the separate proposal in #223.

## Cost

+1.3 KB. Three files, +53 lines, no behaviour change to anything that exists.

## Testing

Builds clean in the pinned IDF v5.5.1 container. Verified in the built image rather than only in source: `local build` present off CI, `ilyakruchinin/SomnoTrace` present as the upstream constant, and the Upstream row correctly hidden when the two match.
