### PR TITLE
test(vld3): pin the smallest source a VLD3 file can be

### DIFF
--- a/scripts/vld3_decoder_test.c
+++ b/scripts/vld3_decoder_test.c
@@ -113,6 +113,29 @@ int main(void)
     make_header(header, 0, 2026, 1, 1, 120, 480);
     assert(!ox_vld3_parse_header(header, sizeof(header), 639, &parsed));
 
+    /* The smallest source a VLD3 file can be: the 40-byte header plus exactly one
+       5-byte record. 45 must parse -- a single record is still a recording -- and 44
+       must not, because no whole record follows the header.
+
+       This bound had no test. scripts/mutate_host.py reported oximetry_vld3.c:58 as
+       UNREACHED, meaning relaxing `source_size <` to `<=` -- which rejects a valid
+       45-byte file -- was a change no test could see. The 639 case above exercises the
+       record-alignment check on the line below it, not this one.
+
+       Note 44 is rejected by this guard before the alignment check would also have
+       rejected it, so only the 45 case pins the guard itself. */
+    make_header(header, 0, 2026, 8, 29, 1, 4);
+    assert(ox_vld3_parse_header(header, sizeof(header), 45, &parsed));
+    assert(parsed.sample_count == 1 && parsed.period_us == 4000000);
+    assert(parsed.declared_size_matches);
+    assert(!ox_vld3_parse_header(header, sizeof(header), 44, &parsed));
+
+    /* ...and the 2 s cadence at the same floor, so the bound is not accidentally
+       tied to one sampling mode. */
+    make_header(header, 1, 2026, 8, 29, 1, 2);
+    assert(ox_vld3_parse_header(header, sizeof(header), 45, &parsed));
+    assert(parsed.sample_count == 1 && parsed.period_us == 2000000);
+
     assert(!ox_vld3_parse_header(NULL, sizeof(header), 640, &parsed));
     assert(!ox_vld3_parse_header(header, sizeof(header), 640, NULL));
 


### PR DESCRIPTION
`ox_vld3_parse_header()` refuses a source smaller than one header plus one record:

```c
if (!data || !out || len < OX_VLD3_HEADER_LEN ||
    source_size < OX_VLD3_HEADER_LEN + OX_VLD3_RECORD_LEN)
    return false;
```

Nothing asserted that bound. Relaxing it from `<` to `<=` — which rejects a perfectly valid 45-byte single-record file — was a change no test could see.

## What this adds

`source_size == 45` (40-byte header + exactly one 5-byte record) must parse: a single record is still a recording. `44` must not, because no whole record follows the header. Both cadences are covered so the bound is not accidentally tied to one sampling mode.

## Verified by construction, not assumed

```
unmutated source              → PASS
mutant  <  →  <=              → ABORTED (killed)
previous test file vs mutant  → SURVIVED
```

That last line is what makes this a gap rather than a redundant assertion — the existing suite genuinely does not catch it. The 639-byte case already in the file exercises the record-alignment check on the line *below* this one, not this bound.

One honest note in the source comment: `44` is rejected by this guard before the alignment check would also have rejected it, so only the `45` case pins the guard itself.

## Where it came from

`scripts/mutate_host.py` (#232) reported it. Worth saying plainly that it first reported it *wrongly* — as an unreached line rather than an unasserted one — because of a gcov parsing bug I have since fixed in that PR. The gap is real either way; the diagnosis needed correcting.

With this merged the sweep over `oximetry_vld3.c` reads `killed 21, unasserted 0, unreached 0`.

Host suite: 5 run, 0 failed, 0 skipped.
