### PR TITLE
docs: describe cross-noon sessions as the feature they are

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,33 @@ Connect with any FTP client (e.g., FileZilla) to `ftp://somnotrace.local`.
 
 </details>
 
+<details>
+<summary><b>🕛 Sessions That Cross Noon</b></summary>
+
+Therapy that runs through midday — a late morning lie-in, a nap that starts before 12:00 and ends after — is recorded by SomnoTrace as **one continuous session**. The AS10 and AS11 cannot do this: they cut a session at noon and write the two halves to different days.
+
+This is deliberate, and it is why SomnoTrace records the stream itself rather than relying on the machine's own summary.
+
+**Why noon at all?** ResMed's file format organises therapy into noon-to-noon days, so a session that begins before 12:00 belongs to the *previous* date. Sleeping from 23:00 Monday to 07:00 Tuesday is one "Monday" night, which is what you want. A session that crosses the noon boundary is the awkward case that convention creates.
+
+**What you will see**
+
+| Where | How a cross-noon session appears |
+| :--- | :--- |
+| SomnoTrace dashboard | One session, with its true start and end |
+| OSCAR | One session, with its true start and end |
+| Exported `BRP`/`PLD`/`EVE`/`CSL` EDFs | One recording, not split |
+
+OSCAR takes a session's extent from the recording files themselves, not from the `MaskOn`/`MaskOff` pairs in `STR.edf` — those pairs only group files into sessions and mark a day as having usable data. So a session running 06:00–13:00 displays as one seven-hour session.
+
+**The boundary detail, for anyone reading the STR file**
+
+`MaskOn`/`MaskOff` are minutes from noon and the format declares a maximum of 1440. A cross-noon session produces a window that runs past that. SomnoTrace **clamps** such a window to `[0, 1440]` rather than discarding it, so the day keeps a valid STR record — and therefore its settings: mode, pressures, EPR, and the day's statistics. A dropped record would leave the night importable but with none of that attached.
+
+**Limits of the above.** OSCAR's behaviour here is read from its source (`resmed_loader.cpp`), not measured against a running copy. SleepHQ's importer is closed, so nothing is claimed for it.
+
+</details>
+
 ---
 
 ## Feature Overview
@@ -255,6 +282,7 @@ Connect with any FTP client (e.g., FileZilla) to `ftp://somnotrace.local`.
 | **BLE → Wi-Fi RPC Proxy** | ✅ Implemented | Local HTTP endpoint for remote machine queries and smart home control. |
 | **FTP File Server** | ✅ Implemented | Download EDF and session files directly from the MicroSD card using any FTP client (e.g., FileZilla). |
 | **O2 Ring Bluetooth Sync** | ✅ Implemented | Downloads stored oximetry recordings from Viatom O2 Ring (Gen1 & Gen2) over Bluetooth, with automatic upload to SMB and SleepHQ. |
+| **Cross-Noon Sessions** | ✅ Implemented | Therapy spanning midday is recorded as one continuous session instead of being split at noon the way the AS10/AS11 split it. |
 
 ---
 


### PR DESCRIPTION
The documentation half of #88. The clamp that makes cross-noon sessions safe landed in `cce8337`; this is the part that tells a user about it.

Your scoping on that issue was *"Maybe some edge-case analysis to ensure it gets displayed properly (in all platforms — internal UI, OSCAR, SHQ) + documenting it as a feature."* The analysis happened in the thread; the documenting did not, and the issue is still open because of it.

## What it adds

A `<details>` block in **Advanced Features & Documentation**, alongside the FTP one, plus a row in the Feature Overview table.

It covers:

- that therapy spanning midday is recorded as **one continuous session**, and that the AS10/AS11 cannot do this
- why the noon boundary exists at all — ResMed's noon-to-noon day, so a session starting before 12:00 belongs to the previous date
- what the session looks like in the dashboard, in OSCAR, and in the exported EDFs
- why OSCAR shows it as one session: it takes session extent from the recording files, not from the `MaskOn`/`MaskOff` pairs, which only group files and validate the day
- why a window past 1440 is **clamped** rather than dropped — a dropped STR record leaves the night importable but strips its settings (mode, pressures, EPR) and the day's statistics

## What it deliberately does not claim

Two limits are stated in the text rather than left for a reader to assume:

- OSCAR's behaviour is read from `resmed_loader.cpp`, not measured against a running copy
- SleepHQ's importer is closed, so nothing is claimed for it

I would rather the README be explicit about which of the three platforms was actually verified than imply all of them were.

Documentation only — no code touched.
