### PR TITLE
fix(sleephq): say WHY a finalise failed, instead of one message for three causes

### DIFF
--- a/components/uploader/uploader_sleephq.c
+++ b/components/uploader/uploader_sleephq.c
@@ -562,20 +562,52 @@ static esp_err_t shq_wait_import(esp_tls_t *tls, const char *import_id)
         char *body = NULL; size_t body_len = 0;
         int status = shq_http_request(tls, "GET", path, NULL, s_token,
                                        NULL, NULL, &body, &body_len);
-        if (status < 200 || status >= 300) { free(body); return ESP_FAIL; }
-        cJSON *root = cJSON_Parse(body); free(body);
-        if (!root) return ESP_FAIL;
+        /* Every failure below used to return the same bare ESP_FAIL, and the caller
+         * reports all of them as "import processing failed for day <d>" -- which reads
+         * as "SleepHQ rejected the import" whichever one actually happened. Three
+         * different causes wearing one message is why #151 could run for weeks without
+         * the cause being identifiable from a log. Say which.
+         *
+         * Measured on the log attached to #151: the failing GET returns HTTP 200 with a
+         * 1971-byte body, well under the read cap, so the body is NOT truncated and the
+         * failure is decided in the lines below -- but which line is not recoverable
+         * from the log as it stands. */
+        if (status < 200 || status >= 300) {
+            ESP_LOGW(TAG, "import %s: status query returned HTTP %d", import_id, status);
+            free(body);
+            return ESP_FAIL;
+        }
+        cJSON *root = cJSON_Parse(body);
+        if (!root) {
+            /* A body we cannot parse is OUR problem, not SleepHQ's verdict. The length
+             * and the head of it separate the cases: a truncated body shows a length at
+             * the read cap, a de-chunking fault shows hex chunk prefixes in the text. */
+            ESP_LOGW(TAG, "import %s: unparseable status body (%u bytes): %.120s",
+                     import_id, (unsigned)body_len, body ? body : "(null)");
+            free(body);
+            return ESP_FAIL;
+        }
+        free(body);
         cJSON *data = cJSON_GetObjectItem(root, "data");
         cJSON *attrs = data ? cJSON_GetObjectItem(data, "attributes") : NULL;
         cJSON *st = attrs ? cJSON_GetObjectItem(attrs, "status") : NULL;
         const char *name = cJSON_IsString(st) ? st->valuestring : "";
         bool complete = strcmp(name, "complete") == 0 || strcmp(name, "completed") == 0;
         bool failed = strcmp(name, "failed") == 0 || strcmp(name, "error") == 0;
+        if (failed || (!name[0] && attempt == 0)) {
+            /* The remote verdict, verbatim. An absent status means the reply was not the
+             * shape we expect, which is a different bug from a rejected import -- warn on
+             * the first poll only, since that case still retries and would otherwise log
+             * thirty times. Behaviour is unchanged by this commit; only what it says is. */
+            ESP_LOGW(TAG, "import %s: remote status \"%s\" after %d poll(s)",
+                     import_id, name[0] ? name : "(absent)", attempt + 1);
+        }
         cJSON_Delete(root);
         if (complete) return ESP_OK;
         if (failed) return ESP_FAIL;
         vTaskDelay(pdMS_TO_TICKS(2000));
     }
+    ESP_LOGW(TAG, "import %s: still not complete after 30 polls (~60 s)", import_id);
     return ESP_ERR_TIMEOUT;
 }
 


### PR DESCRIPTION
`shq_wait_import()` returns a bare `ESP_FAIL` from three different places:

- a non-2xx reply to the status query
- a body `cJSON_Parse` rejected
- an import SleepHQ actually marked `failed`

The caller prints the same sentence for all three — `import processing failed for day <d>` — which reads as *"SleepHQ rejected the import"* whichever one happened. #151 has been open since 27 August with logs that cannot separate our bug from their verdict.

## What this adds

Each path now says which it was. The rejected case prints SleepHQ's status string verbatim. The unparseable case prints the body length and its first 120 bytes, which separates the two ways that can happen: a truncated body shows a length at the read cap, a de-chunking fault shows hex chunk prefixes in the text. The poll loop says so when it exhausts its thirty attempts.

## No behaviour change

Deliberately. I have no SomnoTrace hardware, so this had to be safe to merge without me having run it on a device.

The same conditions return the same values in the same order. The only structural change is that `free(body)` moves after the parse check so the body can be logged before it is released. The absent-status warning fires on the first poll only, because that case still retries and would otherwise log thirty times.

I did write a behaviour change into an earlier draft — making an absent status fail immediately instead of retrying — and took it out. It may well be right, but it is a separate decision and not one to smuggle into a logging commit.

## What the log already tells us, and what it cannot

Measured against [the log attached to #151](https://github.com/user-attachments/files/31722757/somnotrace-logs.1.txt) (v1.4.1, day 20260807):

```
08:10:27.689  response: HTTP 201 (13 bytes body)          <- process_files accepted
08:10:27.690  sending GET /api/v1/imports/16117550
08:10:28.183  response: HTTP 200 (1971 bytes body)
08:10:28.187  import processing failed for day 20260807
```

Four milliseconds, on the **first** poll of thirty.

Worth recording a negative here: I expected our read buffer to be truncating. It is not. `shq_http_read_response()` allocates `SHQ_RESP_CAP + 1024` = 5120 bytes and stops with a bare `break` when full — a real latent hazard, but not this. The failing body is 1971 bytes and the largest anywhere in that log is 1977. The body arrives whole, and the failure is decided in the lines this PR instruments.

Builds clean in the pinned IDF v5.5.1 container.

Refs #151.
