### PR TITLE
[7-inch][4/12] Add the Waveshare 7B board and recoverable touch

### DIFF
--- a/.github/workflows/host-tests.yml
+++ b/.github/workflows/host-tests.yml
@@ -1,23 +1,19 @@
-name: "Host tests"
-
-# Builds and runs the gcc host test suites via scripts/run_host_tests.sh.
-# No ESP-IDF: the suites compile main/*.c against the shims in
-# scripts/test_include and the system libcjson, and finish in seconds.
-#
-# The script prints "host tests: N run, M failed, K skipped" as its last line
-# and exits non-zero on a failure; a skipped suite does not fail it (a laptop
-# without libcjson still runs the rest), so this job fails on a skip itself.
+name: Host tests
 
 on:
   push:
     paths:
       - "main/**"
+      - "components/**"
       - "scripts/**"
+      - "third_party/**"
       - ".github/workflows/host-tests.yml"
   pull_request:
     paths:
       - "main/**"
+      - "components/**"
       - "scripts/**"
+      - "third_party/**"
       - ".github/workflows/host-tests.yml"
   workflow_dispatch:
 
@@ -30,18 +26,21 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-
       - name: Install libcjson
         run: |
           sudo apt-get update -q
           sudo apt-get install -y --no-install-recommends libcjson-dev
-
-      - name: Run host tests
-        # The runner's default shell is `bash -e` without pipefail, so the
-        # script's exit status would be lost behind tee.  Both the status and
-        # the summary line are checked; a run that prints neither fails too.
+      - name: Run upstream host tests
         run: |
           set -o pipefail
           bash scripts/run_host_tests.sh | tee host-tests.log
           tail -1 host-tests.log | grep -qE '^host tests: [0-9]+ run, 0 failed, 0 skipped$' \
             || { echo "::error::host tests failed or were skipped: $(tail -1 host-tests.log)"; exit 1; }
+
+  synthetic-regressions:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run 7-inch host contracts
+        run: ./scripts/test-host.sh

--- a/.github/workflows/host-tests.yml
+++ b/.github/workflows/host-tests.yml
@@ -42,5 +42,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
+      - name: Resolve hash-verified LVGL input test source
+        run: python3 scripts/prepare_host_lvgl.py
       - name: Run 7-inch host contracts
         run: ./scripts/test-host.sh

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ Thumbs.db
 .venv/
 __pycache__/
 *.pyc
+
+.host-deps/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,3 +88,17 @@ set(PROJECT_VER "${FIRMWARE_VERSION}")
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
 project(somnotrace)
+
+# The 7-inch UI creates a much larger LVGL object tree than the original
+# display. Scope its allocator to PSRAM first so small widgets and copied text
+# do not consume the internal heap needed by Wi-Fi, BLE and RTOS stacks.
+if(CONFIG_SOMNOTRACE_BOARD_WAVESHARE_7B)
+    idf_component_get_property(_somnotrace_lvgl_lib lvgl__lvgl COMPONENT_LIB)
+    target_include_directories(${_somnotrace_lvgl_lib} PRIVATE
+        "${CMAKE_CURRENT_LIST_DIR}/main")
+    target_compile_definitions(${_somnotrace_lvgl_lib} PRIVATE
+        LV_MEM_CUSTOM_INCLUDE="somnotrace_lvgl_psram.h"
+        LV_MEM_CUSTOM_ALLOC=somnotrace_lvgl_alloc
+        LV_MEM_CUSTOM_FREE=somnotrace_lvgl_free
+        LV_MEM_CUSTOM_REALLOC=somnotrace_lvgl_realloc)
+endif()

--- a/README.md
+++ b/README.md
@@ -299,3 +299,9 @@ Any redistributed or derivative works must remain licensed under GPLv3 and prese
 SomnoTrace is an independent open-source project and is **not affiliated with, endorsed by, or associated with** ResMed, Wellue / Viatom, or SleepHQ. It is intended strictly for personal data portability and interoperability research. SomnoTrace is **not a medical device** and must not be used for clinical diagnosis, treatment decisions, or life-critical monitoring. Use entirely at your own risk.
 
 ![GitHub Downloads (all assets, latest release)](https://img.shields.io/github/downloads/ilyakruchinin/somnotrace/latest/total)
+
+### Waveshare 7B display
+
+The physical 1024×600 Waveshare ESP32-S3-Touch-LCD-7B is selected with
+`scripts/build-7b.sh`. See [wiring and display behavior](docs/hardware/waveshare-7b.md).
+The original 240×240 board remains the default build.

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -234,3 +234,9 @@ triggered. Reverse engineering for interoperability is recognised in many
 jurisdictions (e.g. the EU Software Directive, US DMCA s.1201(f), and
 interoperability provisions of Australia's Copyright Act 1968). This is not
 legal advice; obtain professional advice before any commercial distribution.
+
+## ESP-IDF HTTP asynchronous request cleanup
+
+The checked ESP-IDF v5.5.1 HTTP asynchronous request fixture under
+`third_party/esp-idf-patches/` derives from Espressif ESP-IDF and is licensed
+under Apache-2.0; the license and source identity are retained beside it.

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -240,3 +240,8 @@ legal advice; obtain professional advice before any commercial distribution.
 The checked ESP-IDF v5.5.1 HTTP asynchronous request fixture under
 `third_party/esp-idf-patches/` derives from Espressif ESP-IDF and is licensed
 under Apache-2.0; the license and source identity are retained beside it.
+## Waveshare 7B hardware reference
+
+The 7B pin map, controller sequence and RGB timing were checked against
+Waveshare's ESP32-S3-Touch-LCD-7B reference at commit
+`c652c902db607f7ffb376257393cfd7657aa6428`.

--- a/components/therapy_alert/CMakeLists.txt
+++ b/components/therapy_alert/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
-    SRCS "therapy_alert.c"
+    SRCS "therapy_alert.c" "alert_history.c" "alert_config_model.c"
     INCLUDE_DIRS "."
     REQUIRES nvs_flash json esp_http_client esp_timer mbedtls
 )

--- a/components/therapy_alert/alert_config_model.c
+++ b/components/therapy_alert/alert_config_model.c
@@ -1,0 +1,16 @@
+#include "therapy_alert.h"
+#include <string.h>
+esp_err_t therapy_alert_validate_config(const therapy_alert_config_t *cfg)
+{
+    if (!cfg || cfg->win_start > 1439 || cfg->win_end > 1439 ||
+        cfg->delay1 > 180 || cfg->delay2 > 180 || cfg->ntfy_prio < 1 || cfg->ntfy_prio > 5 ||
+        !memchr(cfg->ntfy_srv, 0, sizeof(cfg->ntfy_srv)) ||
+        !memchr(cfg->ntfy_topic, 0, sizeof(cfg->ntfy_topic))) return ESP_ERR_INVALID_ARG;
+    if (strncmp(cfg->ntfy_srv, "https://", 8) && strncmp(cfg->ntfy_srv, "http://", 7)) return ESP_ERR_INVALID_ARG;
+    const char *host = strstr(cfg->ntfy_srv, "://") + 3;
+    if (!*host || strpbrk(host, " \r\n?#@")) return ESP_ERR_INVALID_ARG;
+    for (const char *p = cfg->ntfy_topic; *p; ++p)
+        if (!( (*p >= 'a' && *p <= 'z') || (*p >= 'A' && *p <= 'Z') ||
+               (*p >= '0' && *p <= '9') || *p == '-' || *p == '_' )) return ESP_ERR_INVALID_ARG;
+    return ESP_OK;
+}

--- a/components/therapy_alert/alert_history.c
+++ b/components/therapy_alert/alert_history.c
@@ -1,0 +1,94 @@
+#include "alert_history.h"
+#include "nvs.h"
+#include "mbedtls/sha256.h"
+#include <string.h>
+#include <stdio.h>
+#include <time.h>
+static alert_history_executor_t s_exec;
+static int s_write_error;
+static esp_err_t remember_write(esp_err_t result)
+{
+    if (result != ESP_OK && result != ESP_ERR_NOT_FOUND)
+        __atomic_store_n(&s_write_error, result, __ATOMIC_RELEASE);
+    return result;
+}
+esp_err_t alert_history_storage_error(void)
+{ return __atomic_load_n(&s_write_error, __ATOMIC_ACQUIRE); }
+void alert_history_set_executor(alert_history_executor_t fn) { s_exec = fn; }
+typedef struct { uint32_t id; bool test, escalated; alert_delivery_t result;
+                 int action; size_t offset; alert_history_page_t *page; } request_t;
+static uint32_t epoch(void) { time_t n = time(NULL); return n > 1609459200 ? (uint32_t)n : 0; }
+static bool retained(const alert_history_record_t *r, uint32_t now)
+{ return r->id && (!now || !r->epoch || r->epoch > now || now - r->epoch <= ALERT_HISTORY_DAYS * 86400U); }
+static esp_err_t operate(void *arg)
+{
+    request_t *q = arg;
+    nvs_handle_t h;
+    esp_err_t err = nvs_open("alert_history", NVS_READWRITE, &h);
+    if (err != ESP_OK) return err;
+    uint32_t seq = 0; nvs_get_u32(h, "seq", &seq);
+    uint32_t now = epoch();
+    if (q->action == 3) {
+        bool pruned = false;
+        q->page->time_valid = now != 0;
+        for (uint32_t n = 0; n < ALERT_HISTORY_CAPACITY && n < seq; n++) {
+            uint32_t id = seq - n;
+            char key[16]; snprintf(key, sizeof(key), "r%03u", (unsigned)(id % ALERT_HISTORY_CAPACITY));
+            alert_history_record_t r = {0}; size_t len = sizeof(r);
+            if (nvs_get_blob(h, key, &r, &len) != ESP_OK || len != sizeof(r) || r.id != id) continue;
+            if (!retained(&r, now)) {
+                esp_err_t removed = nvs_erase_key(h,key);
+                if (removed != ESP_OK) remember_write(removed);
+                else pruned = true;
+                continue;
+            }
+            size_t index = q->page->total++;
+            if (index >= q->offset && q->page->count < ALERT_HISTORY_PAGE)
+                q->page->rows[q->page->count++] = r;
+        }
+        if (pruned) remember_write(nvs_commit(h));
+    } else {
+        if (q->action == 0) q->id = seq + 1;
+        char key[16]; snprintf(key, sizeof(key), "r%03u", (unsigned)(q->id % ALERT_HISTORY_CAPACITY));
+        alert_history_record_t r = {0}; size_t len = sizeof(r);
+        if (q->action == 0) { r.id = q->id; r.epoch = now; r.test = q->test; }
+        else if (nvs_get_blob(h, key, &r, &len) != ESP_OK || len != sizeof(r) || r.id != q->id) { nvs_close(h); return ESP_ERR_NOT_FOUND; }
+        if (q->action == 1) { r.result = q->result; r.escalated |= q->escalated; }
+        if (q->action == 4 && r.result == ALERT_DELIVERY_PENDING) r.result = ALERT_DELIVERY_CANCELLED;
+        if (q->action == 2) { r.acknowledged = true; r.ack_epoch = now; }
+        err = nvs_set_blob(h, key, &r, sizeof(r));
+        if (err == ESP_OK && q->action == 0) err = nvs_set_u32(h, "seq", q->id);
+        if (err == ESP_OK) err = nvs_commit(h);
+    }
+    nvs_close(h); return err;
+}
+static esp_err_t execute(request_t *q) { esp_err_t r = s_exec ? s_exec(operate, q) : operate(q); return q->action == 3 ? r : remember_write(r); }
+uint32_t alert_history_begin(bool test)
+{ request_t q = { .test = test }; return execute(&q) == ESP_OK ? q.id : 0; }
+void alert_history_result(uint32_t id, alert_delivery_t result, bool escalated)
+{ if (id) { request_t q = { .action = 1, .id = id, .result = result, .escalated = escalated }; execute(&q); } }
+void alert_history_ack(uint32_t id)
+{ if (id) { request_t q = { .action = 2, .id = id }; execute(&q); } }
+void alert_history_read(size_t offset, alert_history_page_t *out)
+{ memset(out, 0, sizeof(*out)); request_t q = { .action = 3, .offset = offset, .page = out }; out->storage_result = execute(&q); out->write_error = alert_history_storage_error(); }
+
+typedef struct { uint8_t hash[32]; uint32_t at; } verification_t;
+typedef struct { verification_t receipt; bool write; } verify_request_t;
+static esp_err_t verification(void *arg)
+{
+    verify_request_t *q = arg; nvs_handle_t h;
+    esp_err_t e = nvs_open("alert_history", q->write ? NVS_READWRITE : NVS_READONLY, &h);
+    if (e != ESP_OK) return e;
+    if (q->write) { e = nvs_set_blob(h, "verified", &q->receipt, sizeof(q->receipt)); if (e == ESP_OK) e = nvs_commit(h); }
+    else { size_t len = sizeof(q->receipt); e = nvs_get_blob(h, "verified", &q->receipt, &len); if (len != sizeof(q->receipt)) e = ESP_ERR_INVALID_SIZE; }
+    nvs_close(h); return e;
+}
+static void fingerprint(const char *server, const char *topic, uint8_t out[32])
+{ char buf[132]; snprintf(buf, sizeof(buf), "%s\n%s", server, topic); mbedtls_sha256((unsigned char *)buf, strlen(buf), out, 0); memset(buf, 0, sizeof(buf)); }
+void alert_history_verify(const char *server, const char *topic, bool accepted)
+{ verify_request_t q = { .write = true }; fingerprint(server, topic, q.receipt.hash); q.receipt.at = accepted ? epoch() : 0; remember_write(s_exec ? s_exec(verification, &q) : verification(&q)); }
+uint32_t alert_history_verified_at(const char *server, const char *topic)
+{ uint8_t hash[32]; fingerprint(server, topic, hash); verify_request_t q = {0}; esp_err_t e = s_exec ? s_exec(verification, &q) : verification(&q); return e == ESP_OK && !memcmp(hash, q.receipt.hash, 32) ? q.receipt.at : 0; }
+
+void alert_history_cancel(uint32_t id)
+{ if (id) { request_t q = { .action = 4, .id = id }; execute(&q); } }

--- a/components/therapy_alert/alert_history.h
+++ b/components/therapy_alert/alert_history.h
@@ -1,0 +1,36 @@
+/* Bounded NVS delivery receipts. No topic, URL, message body or credentials. */
+#pragma once
+#include "esp_err.h"
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#define ALERT_HISTORY_CAPACITY 512
+#define ALERT_HISTORY_PAGE 8
+#define ALERT_HISTORY_DAYS 30
+
+typedef enum { ALERT_DELIVERY_PENDING, ALERT_DELIVERY_ACCEPTED,
+               ALERT_DELIVERY_FAILED, ALERT_DELIVERY_SCREEN, ALERT_DELIVERY_CANCELLED } alert_delivery_t;
+typedef struct {
+    uint32_t id, epoch, ack_epoch;
+    uint8_t result, test, escalated, acknowledged;
+} alert_history_record_t;
+typedef struct {
+    alert_history_record_t rows[ALERT_HISTORY_PAGE];
+    size_t count, total;
+    bool time_valid;
+    esp_err_t storage_result;
+    esp_err_t write_error; /* sticky last failed write this boot; reads cannot hide it */
+} alert_history_page_t;
+typedef esp_err_t (*alert_history_executor_t)(esp_err_t (*fn)(void *), void *);
+void alert_history_set_executor(alert_history_executor_t fn);
+uint32_t alert_history_begin(bool test);
+void alert_history_result(uint32_t id, alert_delivery_t result, bool escalated);
+void alert_history_ack(uint32_t id);
+void alert_history_read(size_t offset, alert_history_page_t *out);
+/* A server acceptance receipt is not evidence a phone received or read it. */
+void alert_history_verify(const char *server, const char *topic, bool accepted);
+uint32_t alert_history_verified_at(const char *server, const char *topic);
+
+void alert_history_cancel(uint32_t id); /* cancellation never acknowledges */
+
+esp_err_t alert_history_storage_error(void);

--- a/components/therapy_alert/alert_lifecycle.h
+++ b/components/therapy_alert/alert_lifecycle.h
@@ -1,0 +1,68 @@
+#pragma once
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/* Caller serializes access. Retain the latest cycle's ordered START/STOP/ACK
+ * independently of the lossy wake queue. A newer START supersedes older cycles;
+ * duplicate STARTs cannot erase an ACK or fill a queue ahead of STOP. */
+typedef enum { ALERT_EDGE_NONE, ALERT_EDGE_ACTIVE, ALERT_EDGE_STOPPED,
+               ALERT_EDGE_DISCONNECTED, ALERT_EDGE_UNCERTAIN } alert_edge_t;
+typedef enum { ALERT_DO_START, ALERT_DO_STOP, ALERT_DO_DISCONNECT,
+               ALERT_DO_ACK } alert_action_t;
+typedef struct {
+    uint64_t sequence, cycle, stop_sequence, ack_sequence, ack_cycle;
+    alert_edge_t edge;
+} alert_lifecycle_t;
+
+static inline void alert_lifecycle_start(alert_lifecycle_t *s)
+{
+    if (s->edge == ALERT_EDGE_ACTIVE) return;
+    ++s->cycle;
+    ++s->sequence;
+    s->stop_sequence = 0;
+    s->edge = ALERT_EDGE_ACTIVE;
+}
+static inline void alert_lifecycle_stop(alert_lifecycle_t *s)
+{
+    if (s->edge != ALERT_EDGE_ACTIVE) return;
+    s->stop_sequence = ++s->sequence;
+    s->edge = ALERT_EDGE_STOPPED;
+}
+static inline void alert_lifecycle_disconnect(alert_lifecycle_t *s, bool uncertain)
+{
+    ++s->sequence;
+    s->edge = uncertain || s->edge == ALERT_EDGE_UNCERTAIN
+            ? ALERT_EDGE_UNCERTAIN : ALERT_EDGE_DISCONNECTED;
+}
+static inline void alert_lifecycle_ack(alert_lifecycle_t *s)
+{
+    s->ack_sequence = ++s->sequence;
+    s->ack_cycle = s->cycle;
+}
+/* Maximum four actions; cursor belongs to the state owner, snapshot is copied
+ * under the producer lock. ACK ordering within a cycle is preserved. */
+static inline size_t alert_lifecycle_actions(const alert_lifecycle_t *s,
+    alert_lifecycle_t *cursor, alert_action_t out[4])
+{
+    size_t n = 0;
+    bool changed_cycle = s->cycle != cursor->cycle;
+    bool ack = s->ack_sequence != cursor->ack_sequence &&
+               s->ack_cycle == s->cycle;
+    if (s->edge == ALERT_EDGE_DISCONNECTED || s->edge == ALERT_EDGE_UNCERTAIN) {
+        if (changed_cycle) out[n++] = ALERT_DO_START;
+        if (ack) out[n++] = ALERT_DO_ACK;
+        if (s->sequence != cursor->sequence) out[n++] = ALERT_DO_DISCONNECT;
+    } else {
+        if (changed_cycle) out[n++] = ALERT_DO_START;
+        bool stop = s->edge == ALERT_EDGE_STOPPED &&
+                    (changed_cycle || cursor->edge != ALERT_EDGE_STOPPED);
+        if (ack && stop && s->ack_sequence < s->stop_sequence)
+            out[n++] = ALERT_DO_ACK;
+        if (stop) out[n++] = ALERT_DO_STOP;
+        if (ack && (!stop || s->ack_sequence > s->stop_sequence))
+            out[n++] = ALERT_DO_ACK;
+    }
+    *cursor = *s;
+    return n;
+}

--- a/components/therapy_alert/therapy_alert.c
+++ b/components/therapy_alert/therapy_alert.c
@@ -23,12 +23,15 @@
  */
 
 #include "therapy_alert.h"
+#include "therapy_alert_runtime.h"
 
 #include <string.h>
 #include <stdio.h>
 #include <time.h>
 
 #include "esp_log.h"
+#include "alert_history.h"
+#include "alert_lifecycle.h"
 #include "esp_http_client.h"
 #include "esp_crt_bundle.h"
 #include "esp_random.h"
@@ -42,51 +45,39 @@
 #include "freertos/queue.h"
 
 static const char *TAG = "therapy_alert";
+static uint32_t s_active_history_id; /* owner task only */
+typedef struct { uint32_t gen, history_id; } alert_routine_args_t;
 
 #define NVS_NAMESPACE  "alert"
 #define NVS_KEY_CFG    "cfg"
 
 /* ── Injected functions ─────────────────────────────────────────────── */
+static alert_task_create_fn_t s_task_create;
+static alert_task_delete_fn_t s_task_delete;
+void therapy_alert_set_task_fns(alert_task_create_fn_t create,
+                                alert_task_delete_fn_t destroy)
+{ s_task_create = create; s_task_delete = destroy; }
 static alert_beep_fn_t          s_beep_fn  = NULL;
 static alert_nvs_exec_fn_t       s_nvs_exec = NULL;
 static alert_therapy_active_fn_t s_therapy_active_fn = NULL;
 
 void therapy_alert_set_beep_fn(alert_beep_fn_t fn)    { s_beep_fn = fn; }
-void therapy_alert_set_nvs_executor(alert_nvs_exec_fn_t fn) { s_nvs_exec = fn; }
+void therapy_alert_set_nvs_executor(alert_nvs_exec_fn_t fn) { s_nvs_exec = fn; alert_history_set_executor(fn); }
 void therapy_alert_set_therapy_active_fn(alert_therapy_active_fn_t fn) { s_therapy_active_fn = fn; }
 
-/* ── Concurrency model ──────────────────────────────────────────────────
- *
- * This component is single-owner: exactly one task (`alert_monitor`) reads
- * and writes the state machine.  Every external event — TherapyStart/Stop,
- * BLE disconnect, button acknowledge, config change, and the escalation
- * routine's own progress — is delivered as a message on s_evt_q and applied
- * by that task.  Callers never mutate state and never block on the alert
- * subsystem, which matters because two of them are a NimBLE host callback
- * and a button monitor.
- *
- * Why this shape rather than a lock: the previous design guarded a single
- * enum with a heap-allocated mutex, which
- *   (a) did not make the read-decide-write sequences in reevaluate_state()
- *       atomic anyway — the lock was released between the read and the
- *       write, so it bought no real mutual exclusion; and
- *   (b) placed a FreeRTOS queue object (with its embedded per-queue
- *       spinlock) on the heap, where a neighbouring task-stack overflow
- *       could corrupt the lock word.  A corrupt spinlock owner value spins
- *       forever with interrupts disabled → INT_WDT reset, which is the
- *       2026-08-09 failure.
- *
- * The event queue, its storage, the config mutex and the owner task's stack
- * are all statically allocated in .bss for the same reason: nothing in this
- * component's synchronisation path is a heap neighbour of any task stack.
- * A single writer also means s_state needs no lock at all — readers take a
- * plain aligned 32-bit load and always observe a whole value. */
+/* The monitor exclusively owns alert state. Producers publish cycle-aware
+ * semantic transitions under a short spinlock, then use the ordinary queue
+ * only to wake it. START/STOP/ACK survive queue saturation and ACK is tied to
+ * its observed cycle. Config and routine messages retain their separate owner
+ * paths. Routine tasks use the application's paired create/delete hooks so
+ * PSRAM stacks and TCBs are reclaimed by its reaper. */
 
 /* ── Config ─────────────────────────────────────────────────────────── */
 /* s_cfg is written only by the owner task.  Writers stage into s_cfg_staged
  * under s_cfg_mtx and post EVT_CONFIG; the owner promotes it. */
 static therapy_alert_config_t s_cfg = ALERT_DEFAULTS;
 static therapy_alert_config_t s_cfg_staged = ALERT_DEFAULTS;
+static bool s_cfg_pending;
 static bool s_cfg_loaded = false;
 
 static StaticSemaphore_t s_cfg_mtx_buf;
@@ -129,6 +120,17 @@ static StaticQueue_t s_evt_q_buf;
 static uint8_t       s_evt_q_storage[ALERT_EVT_Q_LEN * sizeof(alert_evt_t)];
 static QueueHandle_t s_evt_q = NULL;
 
+/* Acknowledgement is safety-significant: unlike a periodic tick or duplicate
+ * transition, it cannot be reconstructed if the event queue is saturated.
+ * Keep it in a separate one-bit latch. EVT_ACK remains the wake-up message;
+ * the owner consumes this latch before ordinary queued work, and a duplicate
+ * EVT_ACK is harmless because handle_ack() is idempotent in ALERT_ACKED. */
+static StaticSemaphore_t s_ack_pending_buf;
+static SemaphoreHandle_t s_ack_pending = NULL;
+
+static portMUX_TYPE s_lifecycle_lock = portMUX_INITIALIZER_UNLOCKED;
+static alert_lifecycle_t s_lifecycle, s_lifecycle_cursor;
+
 static StaticTask_t  s_monitor_tcb;
 static StackType_t  *s_monitor_stack;
 
@@ -141,14 +143,12 @@ static void report_stack_headroom(const char *why);
 /* Post an event.  Never blocks: callers include a NimBLE host callback and
  * the button monitor, where blocking is not acceptable.  A full queue means
  * the owner is already behind with equivalent work pending, and the periodic
- * tick will reconcile state regardless. */
+ * lifecycle mailbox remains authoritative even if its wakeup is lost. */
 static void post_evt(alert_evt_type_t type, alert_state_t st, uint32_t gen)
 {
     if (!s_evt_q) return;
     alert_evt_t ev = { .type = (uint8_t)type, .state = (uint8_t)st, .gen = gen };
-    if (xQueueSend(s_evt_q, &ev, 0) != pdTRUE) {
-        ESP_LOGW(TAG, "event queue full, dropping event %d", (int)type);
-    }
+    (void)xQueueSend(s_evt_q, &ev, 0);
 }
 
 /* Snapshot the config for a reader outside the owner task. */
@@ -219,6 +219,8 @@ const char *therapy_alert_state_str(alert_state_t st)
         case ALERT_PUSH_SENT: return "push_sent";
         case ALERT_BUZZING:   return "buzzing";
         case ALERT_ACKED:     return "acked";
+        case ALERT_SCREEN_ONLY: return "screen_only";
+        case ALERT_PUSH_FAILED: return "push_failed";
         default:              return "unknown";
     }
 }
@@ -296,6 +298,18 @@ esp_err_t therapy_alert_save_config_json(const char *json_str)
     cJSON *root = cJSON_Parse(json_str);
     if (!root) return ESP_ERR_INVALID_ARG;
 
+    /* Validate JSON numbers before narrowing them to persisted integer types. */
+    static const struct { const char *name; int low, high; } limits[] = {
+        {"win_start",0,1439}, {"win_end",0,1439}, {"delay1",0,180},
+        {"delay2",0,180}, {"ntfy_prio",1,5}
+    };
+    for (size_t i = 0; i < sizeof(limits)/sizeof(limits[0]); i++) {
+        cJSON *v = cJSON_GetObjectItem(root, limits[i].name);
+        if (v && (!cJSON_IsNumber(v) || v->valuedouble < limits[i].low ||
+            v->valuedouble > limits[i].high || v->valuedouble != (int)v->valuedouble)) {
+            cJSON_Delete(root); return ESP_ERR_INVALID_ARG;
+        }
+    }
     therapy_alert_config_t cfg;
     cfg_snapshot(&cfg);
     cJSON *j;
@@ -313,6 +327,14 @@ esp_err_t therapy_alert_save_config_json(const char *json_str)
 
     cJSON_Delete(root);
 
+    return therapy_alert_save_config(&cfg);
+}
+
+esp_err_t therapy_alert_save_config(const therapy_alert_config_t *input)
+{
+    esp_err_t valid = therapy_alert_validate_config(input);
+    if (valid != ESP_OK) return valid;
+    therapy_alert_config_t cfg = *input;
     /* Persist via injected NVS executor (safe from PSRAM-stack httpd). */
     esp_err_t err = s_nvs_exec ? s_nvs_exec(do_save_config, &cfg)
                                : do_save_config(&cfg);
@@ -329,8 +351,8 @@ esp_err_t therapy_alert_save_config_json(const char *json_str)
         ESP_LOGI(TAG, "config saved: en=%d win=%d-%d d1=%d push=%d buzz=%d",
                  cfg.enabled, cfg.win_start, cfg.win_end, cfg.delay1,
                  cfg.push_en, cfg.buzz_en);
-        /* Re-evaluate state on the owner task: a schedule change may
-         * arm or disarm. */
+        /* A full event queue cannot lose the settings update. */
+        __atomic_store_n(&s_cfg_pending, true, __ATOMIC_RELEASE);
         post_evt(EVT_CONFIG, 0, 0);
     }
     return err;
@@ -357,6 +379,7 @@ esp_err_t therapy_alert_get_config_json(char **out_json)
 
     cJSON *st = cJSON_AddObjectToObject(root, "state");
     cJSON_AddStringToObject(st, "alert", therapy_alert_state_str(therapy_alert_get_state()));
+    cJSON_AddBoolToObject(st, "transport_uncertain", therapy_alert_transport_uncertain());
 
     *out_json = cJSON_Print(root);
     cJSON_Delete(root);
@@ -411,7 +434,7 @@ static esp_err_t send_ntfy_push(const char *srv, const char *topic,
 esp_err_t therapy_alert_send_test_push(const char *json_override)
 {
     therapy_alert_config_t cfg;
-    cfg_snapshot(&cfg);
+    therapy_alert_load_config(&cfg);
 
     if (json_override && json_override[0]) {
         cJSON *root = cJSON_Parse(json_override);
@@ -429,9 +452,13 @@ esp_err_t therapy_alert_send_test_push(const char *json_override)
         ESP_LOGW(TAG, "test push: push disabled or topic empty");
         return ESP_ERR_INVALID_STATE;
     }
-    return send_ntfy_push(cfg.ntfy_srv, cfg.ntfy_topic,
-                          "SomnoTrace test", "Test notification from SomnoTrace",
-                          cfg.ntfy_prio);
+    if (therapy_alert_validate_config(&cfg) != ESP_OK) return ESP_ERR_INVALID_ARG;
+    uint32_t id = alert_history_begin(true);
+    esp_err_t result = send_ntfy_push(cfg.ntfy_srv, cfg.ntfy_topic,
+                          "SomnoTrace test", "Test notification from SomnoTrace", cfg.ntfy_prio);
+    alert_history_result(id, result == ESP_OK ? ALERT_DELIVERY_ACCEPTED : ALERT_DELIVERY_FAILED, false);
+    alert_history_verify(cfg.ntfy_srv, cfg.ntfy_topic, result == ESP_OK);
+    return result;
 }
 
 /* ── Buzzer ─────────────────────────────────────────────────────────── */
@@ -439,10 +466,10 @@ esp_err_t therapy_alert_send_test_push(const char *json_override)
 /* True once this routine generation has been superseded or cancelled. */
 static inline bool routine_stale(uint32_t gen)
 {
-    return s_routine_gen != gen;
+    return __atomic_load_n(&s_routine_gen, __ATOMIC_ACQUIRE) != gen;
 }
 
-static void run_buzzer(uint32_t gen)
+static void __attribute__((unused)) run_buzzer(uint32_t gen)
 {
     if (!s_beep_fn) {
         ESP_LOGW(TAG, "buzzer: no beep function injected");
@@ -466,9 +493,18 @@ static void routine_request_state(uint32_t gen, alert_state_t st)
     post_evt(EVT_ROUTINE_STATE, st, gen);
 }
 
+static void finish_alert_routine(uint32_t gen)
+{
+    post_evt(EVT_ROUTINE_EXIT, 0, gen);
+    s_task_delete(NULL);
+}
+
 static void alert_routine_task(void *arg)
 {
-    const uint32_t gen = (uint32_t)(uintptr_t)arg;
+    const alert_routine_args_t args = *(alert_routine_args_t *)arg;
+    free(arg);
+    const uint32_t gen = args.gen;
+    const uint32_t history_id = args.history_id;
 
     /* Work from a snapshot: the config can be replaced mid-routine by an
      * httpd worker, and re-reading it field by field across a multi-minute
@@ -501,6 +537,9 @@ static void alert_routine_task(void *arg)
         goto done;
     }
 
+    if (routine_stale(gen)) goto done;
+    alert_history_result(history_id, ALERT_DELIVERY_SCREEN, false);
+    if (routine_stale(gen)) goto done;
     /* Phase 2: send push notification (if enabled) */
     if (cfg.push_en && cfg.ntfy_topic[0]) {
         char body[64];
@@ -510,10 +549,12 @@ static void alert_routine_task(void *arg)
         snprintf(body, sizeof(body), "Therapy stopped at %02d:%02d",
                  tm.tm_hour, tm.tm_min);
 
-        routine_request_state(gen, ALERT_PUSH_SENT);
         esp_err_t err = send_ntfy_push(cfg.ntfy_srv, cfg.ntfy_topic,
                                        "SomnoTrace Alert", body,
                                        cfg.ntfy_prio);
+        routine_request_state(gen, err == ESP_OK ? ALERT_PUSH_SENT : ALERT_PUSH_FAILED);
+        alert_history_result(history_id, err == ESP_OK ? ALERT_DELIVERY_ACCEPTED : ALERT_DELIVERY_FAILED, false);
+        alert_history_verify(cfg.ntfy_srv, cfg.ntfy_topic, err == ESP_OK);
         if (err != ESP_OK) {
             ESP_LOGW(TAG, "push failed, falling through to buzzer");
         }
@@ -522,7 +563,11 @@ static void alert_routine_task(void *arg)
     if (routine_stale(gen)) goto done;
 
     /* Phase 3: wait delay2 minutes before buzzer (only if both push+buzz) */
+#if CONFIG_SOMNOTRACE_BOARD_WAVESHARE_7B || CONFIG_SOMNOTRACE_BOARD_QEMU
+    if (cfg.push_en && cfg.ntfy_topic[0] && cfg.delay2 > 0) {
+#else
     if (cfg.push_en && cfg.buzz_en && cfg.delay2 > 0) {
+#endif
         int delay2_ms = cfg.delay2 * 60 * 1000;
         ESP_LOGI(TAG, "alert routine: waiting %d ms before buzzer", delay2_ms);
         for (int waited = 0; waited < delay2_ms; waited += 1000) {
@@ -545,11 +590,25 @@ static void alert_routine_task(void *arg)
         goto done;
     }
 
+#if CONFIG_SOMNOTRACE_BOARD_WAVESHARE_7B || CONFIG_SOMNOTRACE_BOARD_QEMU
+    /* The 7B has no speaker. Escalation is a second real push, with the
+     * existing cancellation generation checked before and after waiting. */
+    if (cfg.push_en && cfg.ntfy_topic[0]) {
+        if (routine_stale(gen)) goto done;
+        esp_err_t result = send_ntfy_push(cfg.ntfy_srv, cfg.ntfy_topic,
+            "SomnoTrace reminder", "Therapy interruption remains unacknowledged", cfg.ntfy_prio);
+        alert_history_result(history_id, result == ESP_OK ? ALERT_DELIVERY_ACCEPTED : ALERT_DELIVERY_FAILED, true);
+        routine_request_state(gen, result == ESP_OK ? ALERT_PUSH_SENT : ALERT_PUSH_FAILED);
+    } else {
+        routine_request_state(gen, ALERT_SCREEN_ONLY);
+    }
+#else
     /* Phase 4: buzzer (if enabled) */
     if (cfg.buzz_en) {
         routine_request_state(gen, ALERT_BUZZING);
         run_buzzer(gen);
     }
+#endif
 
 done:
     {
@@ -562,8 +621,7 @@ done:
                      (unsigned)free_bytes);
         }
     }
-    post_evt(EVT_ROUTINE_EXIT, 0, gen);
-    vTaskDelete(NULL);
+    finish_alert_routine(gen);
 }
 
 /* Owner task only. */
@@ -572,20 +630,31 @@ static void start_alert_routine(void)
     /* Bumping the generation cancels any routine still winding down; it will
      * observe the mismatch and exit on its own.  No handle is stored and no
      * sleep is needed, so there is nothing to dangle. */
-    uint32_t gen = ++s_routine_gen;
+    uint32_t gen = __atomic_add_fetch(&s_routine_gen, 1, __ATOMIC_ACQ_REL);
+    s_active_history_id = alert_history_begin(false);
     set_state(ALERT_PENDING);
+    /* ACK or a newer lifecycle edge may already be retained, or may arrive
+     * while history creation waits on NVS. Do not launch an already-obsolete
+     * push/buzzer task; the owner will apply the retained transition next. */
+    portENTER_CRITICAL(&s_lifecycle_lock);
+    bool obsolete = s_lifecycle.edge != ALERT_EDGE_STOPPED ||
+        (s_lifecycle.ack_cycle == s_lifecycle.cycle &&
+         s_lifecycle.ack_sequence > s_lifecycle.stop_sequence);
+    portEXIT_CRITICAL(&s_lifecycle_lock);
+    if (obsolete || gen != __atomic_load_n(&s_routine_gen, __ATOMIC_ACQUIRE)) return;
 
     TaskHandle_t h = NULL;
-    StackType_t *stack = heap_caps_malloc(16384, MALLOC_CAP_SPIRAM);
-    StaticTask_t *tcb  = heap_caps_malloc(sizeof(StaticTask_t), MALLOC_CAP_INTERNAL);
-    if (stack && tcb) {
-        h = xTaskCreateStaticPinnedToCore(alert_routine_task, "alert_routine",
-                                          16384, (void *)(uintptr_t)gen, 5,
-                                          stack, tcb, 0);
-    }
+    alert_routine_args_t *args = malloc(sizeof(*args));
+    if (args) *args = (alert_routine_args_t){ .gen = gen, .history_id = s_active_history_id };
+    if (args && s_task_create && s_task_delete)
+        h = s_task_create(alert_routine_task, "alert_routine", 16384,
+                          args, 5, 0, NULL, NULL);
     if (!h) {
         /* Without the routine there will be no push and no buzzer, so say so
          * rather than sitting silently in PENDING for ever. */
+        free(args);
+        alert_history_result(s_active_history_id, ALERT_DELIVERY_FAILED, false);
+        s_active_history_id = 0;
         ESP_LOGE(TAG, "failed to create alert routine task — disarming");
         set_state(ALERT_DISARMED);
         return;
@@ -596,8 +665,10 @@ static void start_alert_routine(void)
 /* Owner task only. */
 static void cancel_alert_routine(void)
 {
-    s_routine_gen++;
+    __atomic_add_fetch(&s_routine_gen, 1, __ATOMIC_ACQ_REL);
     s_routine_active = false;
+    alert_history_cancel(s_active_history_id);
+    s_active_history_id = 0;
 }
 
 /* ── State re-evaluation ────────────────────────────────────────────── */
@@ -619,14 +690,17 @@ static void reevaluate_state(void)
 
     bool in_win = currently_in_window();
     bool therapy_on = therapy_is_active();
+    portENTER_CRITICAL(&s_lifecycle_lock);
+    bool observed_active = s_lifecycle.edge == ALERT_EDGE_ACTIVE;
+    portEXIT_CRITICAL(&s_lifecycle_lock);
     alert_state_t st = therapy_alert_get_state();
 
-    if (in_win && therapy_on && st == ALERT_DISARMED) {
+    if (in_win && therapy_on && observed_active && st == ALERT_DISARMED) {
         /* Window open + therapy active + not yet armed → ARM */
         set_state(ALERT_ARMED);
         ESP_LOGI(TAG, "reevaluate: therapy active inside window — armed");
     } else if (!in_win && (st == ALERT_ARMED || st == ALERT_PENDING ||
-                            st == ALERT_PUSH_SENT || st == ALERT_BUZZING)) {
+                            st == ALERT_PUSH_SENT || st == ALERT_BUZZING || st == ALERT_SCREEN_ONLY || st == ALERT_PUSH_FAILED)) {
         /* Window closed → disarm and cancel any running routine.
          * This is the deepest path in the component and the one implicated
          * in both INT_WDT events, so measure the stack here. */
@@ -710,7 +784,7 @@ static void handle_ble_disconnect(void)
     if (!s_cfg.enabled) return;
 
     alert_state_t st = s_state;
-    if (st != ALERT_DISARMED) {
+    if (st != ALERT_DISARMED && st != ALERT_ACKED) {
         ESP_LOGI(TAG, "BLE disconnect — disarming (was %s)",
                  therapy_alert_state_str(st));
         cancel_alert_routine();
@@ -724,8 +798,29 @@ static void handle_ack(void)
     if (st == ALERT_DISARMED || st == ALERT_ACKED) return;
 
     ESP_LOGI(TAG, "acknowledged (was %s)", therapy_alert_state_str(st));
+    uint32_t id = therapy_alert_is_actionable(st) ? s_active_history_id : 0;
     cancel_alert_routine();
     set_state(ALERT_ACKED);
+    alert_history_ack(id);
+}
+
+/* Drain semantic lifecycle state before ordinary config/routine wakeups. */
+static void drain_lifecycle(void)
+{
+    alert_lifecycle_t snapshot;
+    portENTER_CRITICAL(&s_lifecycle_lock);
+    snapshot = s_lifecycle;
+    portEXIT_CRITICAL(&s_lifecycle_lock);
+    alert_action_t actions[4];
+    size_t count = alert_lifecycle_actions(&snapshot, &s_lifecycle_cursor, actions);
+    for (size_t i = 0; i < count; ++i) {
+        switch (actions[i]) {
+        case ALERT_DO_START: handle_therapy_start(); break;
+        case ALERT_DO_STOP: handle_therapy_stop(); break;
+        case ALERT_DO_DISCONNECT: handle_ble_disconnect(); break;
+        case ALERT_DO_ACK: handle_ack(); break;
+        }
+    }
 }
 
 /* ── Owner task ─────────────────────────────────────────────────────── */
@@ -743,6 +838,19 @@ static void alert_owner_task(void *arg)
     int ticks = 0;
 
     for (;;) {
+        /* Consume the sticky acknowledgement before ordinary work. If the
+         * queue was full when the user acknowledged, its queued wake-up may
+         * have been dropped, but a full queue guarantees this loop is already
+         * making progress and will observe the latch on its next iteration. */
+        if (s_ack_pending && xSemaphoreTake(s_ack_pending, 0) == pdTRUE) {
+            /* Payload and cycle are retained in s_lifecycle. */
+        }
+        drain_lifecycle();
+
+        if (__atomic_exchange_n(&s_cfg_pending, false, __ATOMIC_ACQ_REL)) {
+            promote_staged_config();
+            reevaluate_state();
+        }
         alert_evt_t ev;
         if (xQueueReceive(s_evt_q, &ev, pdMS_TO_TICKS(ALERT_TICK_MS)) != pdTRUE) {
             reevaluate_state();
@@ -758,16 +866,11 @@ static void alert_owner_task(void *arg)
             reevaluate_state();
             break;
         case EVT_THERAPY_START:
-            handle_therapy_start();
-            break;
         case EVT_THERAPY_STOP:
-            handle_therapy_stop();
-            break;
         case EVT_BLE_DISCONNECT:
-            handle_ble_disconnect();
-            break;
         case EVT_ACK:
-            handle_ack();
+            /* Queue entries are wakeups, never authoritative transitions. */
+            drain_lifecycle();
             break;
         case EVT_CONFIG:
             promote_staged_config();
@@ -775,10 +878,10 @@ static void alert_owner_task(void *arg)
             break;
         case EVT_ROUTINE_STATE:
             /* Ignore requests from a superseded routine. */
-            if (ev.gen == s_routine_gen) set_state((alert_state_t)ev.state);
+            if (ev.gen == __atomic_load_n(&s_routine_gen, __ATOMIC_ACQUIRE)) set_state((alert_state_t)ev.state);
             break;
         case EVT_ROUTINE_EXIT:
-            if (ev.gen == s_routine_gen) s_routine_active = false;
+            if (ev.gen == __atomic_load_n(&s_routine_gen, __ATOMIC_ACQUIRE)) s_routine_active = false;
             break;
         default:
             break;
@@ -796,22 +899,58 @@ static void alert_owner_task(void *arg)
 
 void therapy_alert_on_therapy_start(void)
 {
+    portENTER_CRITICAL(&s_lifecycle_lock);
+    uint64_t cycle = s_lifecycle.cycle;
+    alert_lifecycle_start(&s_lifecycle);
+    if (cycle != s_lifecycle.cycle)
+        __atomic_add_fetch(&s_routine_gen, 1, __ATOMIC_ACQ_REL);
+    portEXIT_CRITICAL(&s_lifecycle_lock);
     post_evt(EVT_THERAPY_START, 0, 0);
 }
 
 void therapy_alert_on_therapy_stop(void)
 {
+    portENTER_CRITICAL(&s_lifecycle_lock);
+    alert_lifecycle_stop(&s_lifecycle);
+    portEXIT_CRITICAL(&s_lifecycle_lock);
     post_evt(EVT_THERAPY_STOP, 0, 0);
 }
 
 void therapy_alert_on_ble_disconnect(void)
 {
+    portENTER_CRITICAL(&s_lifecycle_lock);
+    alert_lifecycle_disconnect(&s_lifecycle, false);
+    __atomic_add_fetch(&s_routine_gen, 1, __ATOMIC_ACQ_REL);
+    portEXIT_CRITICAL(&s_lifecycle_lock);
     post_evt(EVT_BLE_DISCONNECT, 0, 0);
 }
 
 void therapy_alert_acknowledge(void)
 {
+    if (!s_ack_pending) return;
+    portENTER_CRITICAL(&s_lifecycle_lock);
+    alert_lifecycle_ack(&s_lifecycle);
+    __atomic_add_fetch(&s_routine_gen, 1, __ATOMIC_ACQ_REL);
+    portEXIT_CRITICAL(&s_lifecycle_lock);
+    xSemaphoreGive(s_ack_pending);
     post_evt(EVT_ACK, 0, 0);
+}
+
+void therapy_alert_on_transport_loss(void)
+{
+    portENTER_CRITICAL(&s_lifecycle_lock);
+    alert_lifecycle_disconnect(&s_lifecycle, true);
+    __atomic_add_fetch(&s_routine_gen, 1, __ATOMIC_ACQ_REL);
+    portEXIT_CRITICAL(&s_lifecycle_lock);
+    post_evt(EVT_BLE_DISCONNECT, 0, 0);
+}
+
+bool therapy_alert_transport_uncertain(void)
+{
+    portENTER_CRITICAL(&s_lifecycle_lock);
+    bool uncertain = s_lifecycle.edge == ALERT_EDGE_UNCERTAIN;
+    portEXIT_CRITICAL(&s_lifecycle_lock);
+    return uncertain;
 }
 
 /* ── Init ───────────────────────────────────────────────────────────── */
@@ -839,6 +978,9 @@ esp_err_t therapy_alert_init(void)
     s_cfg_mtx = xSemaphoreCreateMutexStatic(&s_cfg_mtx_buf);
     if (!s_cfg_mtx) return ESP_ERR_NO_MEM;
 
+    s_ack_pending = xSemaphoreCreateBinaryStatic(&s_ack_pending_buf);
+    if (!s_ack_pending) return ESP_ERR_NO_MEM;
+
     s_evt_q = xQueueCreateStatic(ALERT_EVT_Q_LEN, sizeof(alert_evt_t),
                                  s_evt_q_storage, &s_evt_q_buf);
     if (!s_evt_q) return ESP_ERR_NO_MEM;
@@ -862,3 +1004,8 @@ esp_err_t therapy_alert_init(void)
 
     return ESP_OK;
 }
+
+void therapy_alert_config_snapshot(therapy_alert_config_t *out) { if (out) cfg_snapshot(out); }
+
+bool therapy_alert_is_actionable(alert_state_t st)
+{ return st == ALERT_PENDING || st == ALERT_PUSH_SENT || st == ALERT_BUZZING || st == ALERT_SCREEN_ONLY || st == ALERT_PUSH_FAILED; }

--- a/components/therapy_alert/therapy_alert.h
+++ b/components/therapy_alert/therapy_alert.h
@@ -65,6 +65,8 @@ typedef enum {
     ALERT_PUSH_SENT,
     ALERT_BUZZING,
     ALERT_ACKED,
+    ALERT_SCREEN_ONLY,
+    ALERT_PUSH_FAILED,
 } alert_state_t;
 
 /* ── Injection (app → component) ────────────────────────────────────── */
@@ -103,6 +105,10 @@ void therapy_alert_on_therapy_stop(void);
 
 /* Called when the BLE link drops (disconnect).  Disarms without alerting. */
 void therapy_alert_on_ble_disconnect(void);
+/* Transport fragments were lost: lifecycle state is unknown until a new START.
+ * Called by the notification owner, never decrypts in the BLE callback. */
+void therapy_alert_on_transport_loss(void);
+bool therapy_alert_transport_uncertain(void);
 
 /* Called when the PLUS button is single-clicked.  Acknowledges and silences. */
 void therapy_alert_acknowledge(void);
@@ -128,3 +134,10 @@ const char *therapy_alert_state_str(alert_state_t st);
  * If json_override is non-NULL, parse push_en/ntfy_srv/ntfy_topic/ntfy_prio
  * from it; otherwise use the saved config. */
 esp_err_t therapy_alert_send_test_push(const char *json_override);
+
+/* Typed service API for native controllers; validates before persisting. */
+esp_err_t therapy_alert_save_config(const therapy_alert_config_t *cfg);
+esp_err_t therapy_alert_validate_config(const therapy_alert_config_t *cfg);
+void therapy_alert_config_snapshot(therapy_alert_config_t *out);
+
+bool therapy_alert_is_actionable(alert_state_t state);

--- a/components/therapy_alert/therapy_alert_runtime.h
+++ b/components/therapy_alert/therapy_alert_runtime.h
@@ -1,0 +1,10 @@
+#pragma once
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+/* App-owned task allocation/reaping, injected before alert initialization. */
+typedef TaskHandle_t (*alert_task_create_fn_t)(TaskFunction_t, const char *,
+    uint32_t, void *, UBaseType_t, BaseType_t, StackType_t **, StaticTask_t **);
+typedef void (*alert_task_delete_fn_t)(TaskHandle_t);
+void therapy_alert_set_task_fns(alert_task_create_fn_t create,
+                                alert_task_delete_fn_t destroy);

--- a/components/uploader/upload_index.c
+++ b/components/uploader/upload_index.c
@@ -253,7 +253,14 @@ esp_err_t upload_index_forget_day(uint32_t day)
 {
     char path[160];
     day_path(day, path, sizeof(path));
-    unlink(path);
+    /* The durable export owner may acknowledge an invalidation only after
+     * the old on-card success state is gone. Keep the RAM owner unchanged
+     * on failure so a caller cannot mistake a failed unlink for completion.
+     * ENOENT is the idempotent retry after deletion succeeded before reset. */
+    if (unlink(path) != 0 && errno != ENOENT) {
+        ESP_LOGE(TAG, "cannot forget day %08u: %s", (unsigned)day, strerror(errno));
+        return ESP_FAIL;
+    }
 
     int i = find_day_idx(day);
     if (i >= 0) {
@@ -454,9 +461,10 @@ static void load_bundle_state(void)
     cJSON_Delete(root);
 }
 
-static void save_bundle_state(void)
+static esp_err_t save_bundle_state(void)
 {
     cJSON *root = cJSON_CreateObject();
+    if (!root) return ESP_ERR_NO_MEM;
     for (int b = 0; b < s_n_backends; b++) {
         char hex[24];
         snprintf(hex, sizeof(hex), "%016llx",
@@ -465,9 +473,10 @@ static void save_bundle_state(void)
     }
     char *json = cJSON_PrintUnformatted(root);
     cJSON_Delete(root);
-    if (!json) return;
-    write_json_atomic(UPLOAD_BUNDLE_STATE_PATH, json);
+    if (!json) return ESP_ERR_NO_MEM;
+    esp_err_t ret = write_json_atomic(UPLOAD_BUNDLE_STATE_PATH, json);
     free(json);
+    return ret;
 }
 
 uint64_t upload_index_bundle_ok_fp(int slot)
@@ -476,12 +485,15 @@ uint64_t upload_index_bundle_ok_fp(int slot)
     return s_bundle_ok_fp[slot];
 }
 
-void upload_index_set_bundle_ok(int slot, uint64_t fp)
+esp_err_t upload_index_set_bundle_ok(int slot, uint64_t fp)
 {
-    if (slot < 0 || slot >= UPLOAD_MAX_BACKENDS) return;
-    if (s_bundle_ok_fp[slot] == fp) return;
+    if (slot < 0 || slot >= UPLOAD_MAX_BACKENDS) return ESP_ERR_INVALID_ARG;
+    if (s_bundle_ok_fp[slot] == fp) return ESP_OK;
+    uint64_t previous = s_bundle_ok_fp[slot];
     s_bundle_ok_fp[slot] = fp;
-    save_bundle_state();
+    esp_err_t ret = save_bundle_state();
+    if (ret != ESP_OK) s_bundle_ok_fp[slot] = previous;
+    return ret;
 }
 
 /* ── Lifecycle ────────────────────────────────────────────────────── */

--- a/components/uploader/upload_index.h
+++ b/components/uploader/upload_index.h
@@ -143,7 +143,9 @@ upload_day_t *upload_index_day_at(int i);
 
 /* Forget one day entirely: deletes its state file and drops it from the
  * index, so every group in it is re-uploaded.  Used when a day's export is
- * regenerated (rebuild-day) and the files on the card have been replaced. */
+ * regenerated (rebuild-day) and the files on the card have been replaced.
+ * Returns failure and retains RAM state if deletion fails; an already absent
+ * state file is success. Caller owns storage access and scheduler serialization. */
 esp_err_t upload_index_forget_day(uint32_t day);
 
 /* ── Persistence ──────────────────────────────────────────────────── */
@@ -164,7 +166,7 @@ esp_err_t upload_index_save_all(void);
 uint64_t upload_index_bundle_ok_fp(int slot);
 
 /* Record that the bundle at fingerprint fp uploaded successfully. */
-void upload_index_set_bundle_ok(int slot, uint64_t fp);
+esp_err_t upload_index_set_bundle_ok(int slot, uint64_t fp);
 
 /* ── Aggregates for the progress API ────────────────────────────────── */
 

--- a/components/uploader/upload_ox.c
+++ b/components/uploader/upload_ox.c
@@ -21,6 +21,7 @@
  */
 
 #include "upload_ox.h"
+#include "uploader.h"
 #include "upload_paths.h"
 
 #include <dirent.h>
@@ -101,7 +102,7 @@ static uint64_t file_fp(uint64_t h, const char *name, const char *path)
     FILE *f = fopen(path, "rb");
     if (!f) return h;
     uint8_t buf[1024]; uint32_t crc = 0; size_t nr;
-    while ((nr = fread(buf, 1, sizeof(buf), f)) > 0) crc = esp_rom_crc32_le(crc, buf, nr);
+    while (!uploader_should_cancel() && (nr = fread(buf, 1, sizeof(buf), f)) > 0) crc = esp_rom_crc32_le(crc, buf, nr);
     fclose(f);
     h ^= crc; h *= 1099511628211ULL;
     return h;
@@ -244,6 +245,7 @@ static int scan_day(const char *day, upload_ox_ref_t *out, int max_out)
     DIR *d = opendir(day_path); if (!d) return 0;
     int n = 0; struct dirent *e;
     while ((e = readdir(d)) && n < max_out) {
+        if (uploader_should_cancel()) { closedir(d); return -1; }
         if (!safe_component(e->d_name, UPLOAD_OX_ID_LEN)) continue;
         char root[UPLOAD_OX_PATH_LEN]; if (!join2(root, sizeof(root), day_path, e->d_name)) continue;
         char pointer[UPLOAD_OX_PATH_LEN]; if (!join2(pointer, sizeof(pointer), root, "recording.json")) continue;
@@ -284,6 +286,7 @@ static int scan_day(const char *day, upload_ox_ref_t *out, int max_out)
             r->fingerprint = file_fp(r->fingerprint, all[i], local);
         }
         cJSON_Delete(p);
+        if (uploader_should_cancel()) { closedir(d); return -1; }
         if (r->n_files >= 2) n++;
     }
     closedir(d); return n;
@@ -304,7 +307,7 @@ int upload_ox_scan(upload_ox_ref_t *out, int max_out)
 
     int nd = 0;
     struct dirent *e;
-    while ((e = readdir(root)) != NULL) {
+    while (!uploader_should_cancel() && (e = readdir(root)) != NULL) {
         if (!valid_day(e->d_name)) continue;
 
         if (nd < UPLOAD_MAX_DAYS_CAP) {
@@ -332,10 +335,13 @@ int upload_ox_scan(upload_ox_ref_t *out, int max_out)
         }
     }
     closedir(root);
+    if (uploader_should_cancel()) { free(days); return -1; }
 
     int n = 0;
     for (int i = 0; i < nd && n < max_out; i++) {
-        n += scan_day(days[i], &out[n], max_out - n);
+        int got = scan_day(days[i], &out[n], max_out - n);
+        if (got < 0 || uploader_should_cancel()) { free(days); return -1; }
+        n += got;
     }
     free(days);
     return n;
@@ -344,6 +350,7 @@ int upload_ox_scan(upload_ox_ref_t *out, int max_out)
 int upload_ox_reconcile(upload_ox_ref_t *out, int max_out, int max_days)
 {
     int n = upload_ox_scan(out, max_out);
+    if (n < 0 || uploader_should_cancel()) return -1;
     if (max_days < 1) max_days = 1;
     int kept = 0, days_seen = 0; char last_day[12] = {0};
     for (int i = 0; i < n; i++) {

--- a/components/uploader/upload_scan.c
+++ b/components/uploader/upload_scan.c
@@ -23,6 +23,7 @@
  */
 
 #include "upload_scan.h"
+#include "uploader.h"
 #include "upload_paths.h"
 
 #include <stdio.h>
@@ -88,6 +89,7 @@ int upload_scan_days(uint32_t *out_days, int max_out)
     int n = 0;
     struct dirent *ent;
     while ((ent = readdir(d)) != NULL && n < max_out) {
+        if (uploader_should_cancel()) { closedir(d); return -1; }
         if (ent->d_name[0] == '.') continue;
         if (strlen(ent->d_name) != 8) continue;
         bool digits = true;
@@ -124,6 +126,7 @@ int upload_scan_day_groups(const char *day, upload_group_ref_t *out, int max_out
     int n_groups = 0;
     struct dirent *ent;
     while ((ent = readdir(d)) != NULL) {
+        if (uploader_should_cancel()) { closedir(d); return -1; }
         const char *nm = ent->d_name;
         size_t len = strlen(nm);
         if (len < 23 || len >= UPLOAD_FILENAME_LEN) continue;
@@ -206,7 +209,7 @@ static uint64_t fold_fp(uint64_t fp, const char *name, const char *path,
         if (!buf) buf = malloc(FP_CHUNK);
         if (buf) {
             size_t n;
-            while ((n = fread(buf, 1, FP_CHUNK, f)) > 0) {
+            while (!uploader_should_cancel() && (n = fread(buf, 1, FP_CHUNK, f)) > 0) {
                 crc = esp_rom_crc32_le(crc, buf, n);
             }
             free(buf);
@@ -233,6 +236,7 @@ bool upload_scan_bundle(upload_bundle_ref_t *out)
 
     bool have_str = false;
     for (int i = 0; root_names[i]; i++) {
+        if (uploader_should_cancel()) return false;
         char path[100];
         snprintf(path, sizeof(path), "%s/%s", SD_SDCARD_DIR, root_names[i]);
         struct stat st;
@@ -252,6 +256,7 @@ bool upload_scan_bundle(upload_bundle_ref_t *out)
     if (d) {
         struct dirent *ent;
         while ((ent = readdir(d)) != NULL) {
+            if (uploader_should_cancel()) { closedir(d); return false; }
             if (ent->d_name[0] == '.') continue;
             if (out->n_files >= UPLOAD_BUNDLE_MAX_FILES) break;
 
@@ -299,11 +304,12 @@ int upload_scan_reconcile_day(uint32_t day)
     if (!refs) return 0;
 
     int n = upload_scan_day_groups(daystr, refs, UPLOAD_MAX_GROUPS_PER_DAY);
+    if (n < 0 || uploader_should_cancel()) { free(refs); return -1; }
     if (n == 0) {
         /* Day folder gone or empty: forget it so state does not linger. */
         if (upload_index_day(day, false)) {
             ESP_LOGI(TAG, "day %s has no EDF groups — dropping state", daystr);
-            upload_index_forget_day(day);
+            if (upload_index_forget_day(day) != ESP_OK) { free(refs); return -1; }
         }
         free(refs);
         return 0;
@@ -369,6 +375,7 @@ int upload_scan_reconcile_all(int max_days, const int *slots, int n_slots)
     if (!days) return 0;
 
     int n_days = upload_scan_days(days, UPLOAD_MAX_DAYS_CAP);
+    if (n_days < 0 || uploader_should_cancel()) { free(days); return -1; }
 
     /* Only days that actually contain groups consume a window slot.  A folder
      * with no EDF files still gets reconciled (which drops any stale state for
@@ -376,7 +383,9 @@ int upload_scan_reconcile_all(int max_days, const int *slots, int n_slots)
      * of empty folders silently shrinks how much history is kept in sync. */
     int i = 0, with_data = 0, empty = 0;
     for (; i < n_days && with_data < max_days; i++) {
-        if (upload_scan_reconcile_day(days[i]) > 0) with_data++;
+        int count = upload_scan_reconcile_day(days[i]);
+        if (count < 0 || uploader_should_cancel()) { free(days); return -1; }
+        if (count > 0) with_data++;
         else empty++;
     }
 
@@ -384,7 +393,11 @@ int upload_scan_reconcile_all(int max_days, const int *slots, int n_slots)
      * progress denominator stay bounded. */
     int beyond = 0;
     for (; i < n_days; i++) {
-        if (upload_index_day(days[i], false)) upload_index_forget_day(days[i]);
+        if (uploader_should_cancel()) { free(days); return -1; }
+        if (upload_index_day(days[i], false) && upload_index_forget_day(days[i]) != ESP_OK) {
+            free(days);
+            return -1;
+        }
         beyond++;
     }
 
@@ -404,7 +417,7 @@ int upload_scan_reconcile_all(int max_days, const int *slots, int n_slots)
                 if (days[k] == d->day) { found = true; break; }
             }
             if (!found) {
-                upload_index_forget_day(d->day);
+                if (upload_index_forget_day(d->day) != ESP_OK) { free(days); return -1; }
                 orphaned++;
             }
         }

--- a/components/uploader/upload_sched.c
+++ b/components/uploader/upload_sched.c
@@ -48,6 +48,7 @@ static const char *TAG = "up_sched";
 
 #define SCAN_INTERVAL_MS      600000   /* 10 min self-healing scan          */
 #define FIRST_SCAN_DELAY_MS    60000   /* let Wi-Fi/NTP settle after boot   */
+#define INVALIDATION_POLL_MS    1000   /* queue loss/restart never loses work */
 #define FAILS_BEFORE_SWITCH        2   /* then move to the next backend     */
 #define LEASE_WAIT_MS           5000
 
@@ -107,15 +108,20 @@ typedef struct {
 
 static QueueHandle_t s_queue;
 static TaskHandle_t  s_task;
-static SemaphoreHandle_t s_lock;      /* guards s_rt + s_status for the API */
+static SemaphoreHandle_t s_lock;      /* guards API-visible runtime snapshots + status */
 
 static upload_sched_busy_fn_t s_busy_fn;
+static uploader_invalidation_next_fn_t s_invalidation_next;
+static uploader_invalidation_ack_fn_t s_invalidation_ack;
+static int64_t s_next_invalidation_poll_us;
 
 static int64_t s_next_scan_us;
 static bool    s_scanning;
-static int s_progress_max_days;
-static int s_summary_pending;
 static char    s_status[64] = "Starting up";
+static int     s_progress_max_days;
+/* Updated only by the scheduler after a leased reconciliation pass. Status
+ * readers must never walk or mutate the card merely to render a badge. */
+static int     s_summary_pending;
 
 /* ── Helpers ──────────────────────────────────────────────────────── */
 
@@ -281,10 +287,10 @@ static void refresh_index_progress_cache(void)
 }
 
 static void ox_mark_day_failed(upload_ox_ref_t *refs, int n_refs, int slot,
-                               const char *day)
+                               const char *day, const bool *newly_ok)
 {
     for (int i = 0; i < n_refs; i++) {
-        if (strcmp(refs[i].day, day) != 0) continue;
+        if (!newly_ok[i] || strcmp(refs[i].day, day) != 0) continue;
         if (upload_ox_status(&refs[i], slot) == UG_OK)
             upload_ox_mark(&refs[i], slot, UG_FAILED, NULL);
     }
@@ -296,6 +302,12 @@ static void ox_mark_day_failed(upload_ox_ref_t *refs, int n_refs, int slot,
 static bool run_backend(backend_rt_t *r, int max_days)
 {
     const upload_backend_t *be = r->be;
+    if (uploader_should_cancel()) return false;
+    if (be->prepare && be->prepare() != UPLOAD_OK) {
+        if (be->session_end) be->session_end();
+        if (!uploader_should_cancel()) cooldown_enter(r, "cannot prepare connection", false);
+        return false;
+    }
 
     /* Which days still have pending groups for this backend? Newest first,
      * which is the order the index already keeps. */
@@ -318,6 +330,14 @@ static bool run_backend(backend_rt_t *r, int max_days)
         }
     }
 
+    /* Protect only the card-backed discovery pass. Network setup and transfer
+     * finalization must not hold the SD lease. */
+    if (!uploader_lease_take(LEASE_WAIT_MS)) {
+        if (be->session_end) be->session_end();
+        ESP_LOGI(TAG, "%s: storage busy, deferring", be->id);
+        return false;
+    }
+
     /* Bundle changes on every export (STR.edf is cumulative), so a changed
      * bundle alone is reason enough to connect for SMB. */
     upload_bundle_ref_t bundle;
@@ -325,9 +345,22 @@ static bool run_backend(backend_rt_t *r, int max_days)
     bool bundle_changed = have_bundle &&
                           (upload_index_bundle_ok_fp(r->slot) != bundle.fp);
     upload_ox_ref_t *ox_refs = heap_caps_malloc(sizeof(upload_ox_ref_t) * UPLOAD_OX_MAX_UNITS, MALLOC_CAP_SPIRAM);
-    if (!ox_refs) { set_be_state(r, SB_IDLE); return false; }
+    if (!ox_refs) {
+        uploader_lease_give();
+        if (be->session_end) be->session_end();
+        set_be_state(r, SB_IDLE);
+        return false;
+    }
     int n_ox = upload_ox_reconcile(ox_refs, UPLOAD_OX_MAX_UNITS, max_days);
+    if (n_ox < 0 || uploader_should_cancel()) {
+        free(ox_refs);
+        uploader_lease_give();
+        if (be->session_end) be->session_end();
+        set_be_state(r, SB_IDLE);
+        return false;
+    }
     int ox_pending = upload_ox_pending(ox_refs, n_ox, r->slot);
+    uploader_lease_give();
 
     if (n_days == 0 && !bundle_changed && ox_pending == 0) {
         free(ox_refs);
@@ -335,6 +368,7 @@ static bool run_backend(backend_rt_t *r, int max_days)
         xSemaphoreTake(s_lock, portMAX_DELAY);
         r->cur_day[0] = '\0';
         xSemaphoreGive(s_lock);
+        if (be->session_end) be->session_end();
         return false;
     }
     if (!have_bundle && (n_days > 0 || bundle_changed)) {
@@ -342,6 +376,7 @@ static bool run_backend(backend_rt_t *r, int max_days)
          * packages are self-contained and may upload before any EDF exists. */
         free(ox_refs);
         set_be_state(r, SB_IDLE);
+        if (be->session_end) be->session_end();
         return false;
     }
 
@@ -355,6 +390,7 @@ static bool run_backend(backend_rt_t *r, int max_days)
                      "next session upload", be->id);
             free(ox_refs);
             set_be_state(r, SB_IDLE);
+            if (be->session_end) be->session_end();
             return false;
         }
 
@@ -376,6 +412,7 @@ static bool run_backend(backend_rt_t *r, int max_days)
                      "them to — nothing to do", be->id);
             free(ox_refs);
             set_be_state(r, SB_IDLE);
+            if (be->session_end) be->session_end();
             return false;
         }
         days[n_days++] = attach;
@@ -401,7 +438,7 @@ static bool run_backend(backend_rt_t *r, int max_days)
 
     upload_result_t res = be->session_begin ? be->session_begin() : UPLOAD_OK;
     if (res != UPLOAD_OK) {
-        cooldown_enter(r, res == UPLOAD_ERR_PERMANENT ? "auth/config rejected"
+        if (!uploader_should_cancel()) cooldown_enter(r, res == UPLOAD_ERR_PERMANENT ? "auth/config rejected"
                                                       : "cannot connect",
                        res == UPLOAD_ERR_PERMANENT);
         if (be->session_end) be->session_end();
@@ -425,7 +462,7 @@ static bool run_backend(backend_rt_t *r, int max_days)
         return false;
     }
 
-    for (int di = 0; di < n_days && fails < FAILS_BEFORE_SWITCH; di++) {
+    for (int di = 0; di < n_days && !uploader_should_cancel() && fails < FAILS_BEFORE_SWITCH; di++) {
         char daystr[12];
         snprintf(daystr, sizeof(daystr), "%08u", (unsigned)days[di]);
         /* Read by the progress endpoint on the httpd task. */
@@ -450,6 +487,10 @@ static bool run_backend(backend_rt_t *r, int max_days)
         }
 
         int n_refs = upload_scan_day_groups(daystr, refs, UPLOAD_MAX_GROUPS_PER_DAY);
+        if (n_refs < 0 || uploader_should_cancel()) {
+            uploader_lease_give();
+            break;
+        }
         if (n_refs == 0) {
             /* Files disappeared since the last scan; the next scan will drop
              * the day from the index. */
@@ -468,7 +509,8 @@ static bool run_backend(backend_rt_t *r, int max_days)
         }
 
         bool day_any = false;
-        for (int gi = 0; gi < n_refs && fails < FAILS_BEFORE_SWITCH; gi++) {
+        bool newly_ok[UPLOAD_MAX_GROUPS_PER_DAY] = {0};
+        for (int gi = 0; gi < n_refs && !uploader_should_cancel() && fails < FAILS_BEFORE_SWITCH; gi++) {
             upload_group_t *g = upload_index_group(d, refs[gi].prefix_sec, false);
             if (!g || g->be[r->slot].status == UG_OK) continue;
 
@@ -479,12 +521,11 @@ static bool run_backend(backend_rt_t *r, int max_days)
             if (res == UPLOAD_OK) {
                 /* Only now is the unit durable-good: every file landed. */
                 g->be[r->slot].status = UG_OK;
+                newly_ok[g - d->groups] = true;
                 day_any = true;
                 any_ok = true;
                 xSemaphoreTake(s_lock, portMAX_DELAY);
                 r->cur_unit++;
-                xSemaphoreGive(s_lock);
-                xSemaphoreTake(s_lock, portMAX_DELAY);
                 r->last_ok_s = now_s();
                 xSemaphoreGive(s_lock);
             } else {
@@ -504,7 +545,7 @@ static bool run_backend(backend_rt_t *r, int max_days)
          * inside the import) or when it changed (SMB). */
         bool bundle_ok = true;
         bool bundle_pushed = false;
-        if (day_any || bundle_changed) {
+        if (!uploader_should_cancel() && (day_any || bundle_changed)) {
             res = be->put_bundle ? be->put_bundle(daystr, &bundle, bundle_changed)
                                  : UPLOAD_OK;
             bundle_pushed = true;
@@ -521,7 +562,8 @@ static bool run_backend(backend_rt_t *r, int max_days)
          * (shq_wait_import can take up to 60s) does not block session exports. */
         uploader_lease_give();
 
-        res = be->day_end ? be->day_end(daystr, day_any) : UPLOAD_OK;
+        res = uploader_should_cancel() ? UPLOAD_CANCELLED :
+              (be->day_end ? be->day_end(daystr, day_any) : UPLOAD_OK);
         if (res != UPLOAD_OK) {
             /* Finalisation failed (e.g. SleepHQ process_files): the files may
              * be there but the import is not processed, so do not claim the
@@ -529,15 +571,27 @@ static bool run_backend(backend_rt_t *r, int max_days)
             ESP_LOGW(TAG, "%s: finalise failed for %s — day stays pending",
                      be->id, daystr);
             for (int g = 0; g < d->n_groups; g++) {
-                if (d->groups[g].be[r->slot].status == UG_OK)
-                    d->groups[g].be[r->slot].status = UG_PENDING;
+                if (newly_ok[g]) d->groups[g].be[r->slot].status = UG_PENDING;
             }
             bundle_ok = false;
             fails++;
             set_be_error(r, "remote finalise failed");
         }
 
-        upload_index_save_day(d);
+        bool day_state_saved = false;
+        if (uploader_lease_take(LEASE_WAIT_MS)) {
+            day_state_saved = upload_index_save_day(d) == ESP_OK;
+            uploader_lease_give();
+        }
+        if (!day_state_saved) {
+            for (int g = 0; g < d->n_groups; g++) {
+                if (newly_ok[g]) d->groups[g].be[r->slot].status = UG_PENDING;
+            }
+            d->dirty = true;
+            bundle_ok = false;
+            fails++;
+            set_be_error(r, "upload state save failed");
+        }
 
         /* The bundle counts as delivered only once a day that carried it also
          * finalised cleanly (for SleepHQ that means its import was processed). */
@@ -547,17 +601,21 @@ static bool run_backend(backend_rt_t *r, int max_days)
     /* Oximetry packages are self-contained and are tracked independently from
      * EDF groups. A backend connection is reused, but each noon-day gets its
      * own transport scope so SleepHQ can create one O2 import per day. */
-    if (ox_pending > 0 && be->put_oximetry) {
+    if (!uploader_should_cancel() && ox_pending > 0 && be->put_oximetry) {
         char ox_day[12] = {0};
+        bool newly_ok[UPLOAD_OX_MAX_UNITS] = {0};
         bool ox_day_any = false;
-        for (int oi = 0; oi < n_ox && fails < FAILS_BEFORE_SWITCH; oi++) {
+        for (int oi = 0; oi < n_ox && !uploader_should_cancel() && fails < FAILS_BEFORE_SWITCH; oi++) {
             if (upload_ox_status(&ox_refs[oi], r->slot) == UG_OK) continue;
             if (strcmp(ox_day, ox_refs[oi].day) != 0) {
                 if (ox_day_any && (be->ox_day_end || be->day_end)) {
-                    res = be->ox_day_end ? be->ox_day_end(ox_day, true) :
-                          be->day_end(ox_day, true);
+                    res = uploader_should_cancel() ? UPLOAD_CANCELLED :
+                          (be->ox_day_end ? be->ox_day_end(ox_day, true) : be->day_end(ox_day, true));
                     if (res != UPLOAD_OK) {
-                        ox_mark_day_failed(ox_refs, n_ox, r->slot, ox_day);
+                        if (uploader_lease_take(LEASE_WAIT_MS)) {
+                            ox_mark_day_failed(ox_refs, n_ox, r->slot, ox_day, newly_ok);
+                            uploader_lease_give();
+                        }
                         fails++;
                         set_be_error(r, "oximetry finalise failed");
                     }
@@ -584,16 +642,15 @@ static bool run_backend(backend_rt_t *r, int max_days)
                 continue;
             }
             res = be->put_oximetry(&ox_refs[oi]);
-            uploader_lease_give();
             upload_ox_mark(&ox_refs[oi], r->slot,
                            res == UPLOAD_OK ? UG_OK : UG_FAILED, NULL);
+            uploader_lease_give();
             if (res == UPLOAD_OK) {
+                newly_ok[oi] = true;
                 ox_day_any = true;
                 any_ok = true;
                 xSemaphoreTake(s_lock, portMAX_DELAY);
                 r->cur_unit++;
-                xSemaphoreGive(s_lock);
-                xSemaphoreTake(s_lock, portMAX_DELAY);
                 r->last_ok_s = now_s();
                 xSemaphoreGive(s_lock);
             } else {
@@ -603,10 +660,13 @@ static bool run_backend(backend_rt_t *r, int max_days)
             }
         }
         if (ox_day_any && ox_day[0] && (be->ox_day_end || be->day_end)) {
-            res = be->ox_day_end ? be->ox_day_end(ox_day, true) :
-                  be->day_end(ox_day, true);
+            res = uploader_should_cancel() ? UPLOAD_CANCELLED :
+                  (be->ox_day_end ? be->ox_day_end(ox_day, true) : be->day_end(ox_day, true));
             if (res != UPLOAD_OK) {
-                ox_mark_day_failed(ox_refs, n_ox, r->slot, ox_day);
+                if (uploader_lease_take(LEASE_WAIT_MS)) {
+                    ox_mark_day_failed(ox_refs, n_ox, r->slot, ox_day, newly_ok);
+                    uploader_lease_give();
+                }
                 fails++;
                 set_be_error(r, "oximetry finalise failed");
             }
@@ -616,16 +676,27 @@ static bool run_backend(backend_rt_t *r, int max_days)
     free(refs);
     free(ox_refs);
     if (be->session_end) be->session_end();
-
     if (bundle_committed) {
-        upload_index_set_bundle_ok(r->slot, bundle.fp);
+        if (uploader_lease_take(LEASE_WAIT_MS)) {
+            esp_err_t saved = upload_index_set_bundle_ok(r->slot, bundle.fp);
+            uploader_lease_give();
+            if (saved != ESP_OK) bundle_committed = false;
+        } else {
+            bundle_committed = false;
+        }
+        if (!bundle_committed) {
+            fails++;
+            set_be_error(r, "bundle state save deferred");
+        }
     }
 
     xSemaphoreTake(s_lock, portMAX_DELAY);
     r->cur_day[0] = '\0';
     xSemaphoreGive(s_lock);
 
-    if (fails > 0) {
+    if (uploader_should_cancel()) {
+        set_be_state(r, SB_IDLE);
+    } else if (fails > 0) {
         if (r->state != SB_COOLDOWN)
             cooldown_enter(r, r->err[0] ? r->err : "upload failed", false);
     } else if (!any_ok && !bundle_committed) {
@@ -711,19 +782,36 @@ static void run_pass(void)
 
 /* ── Task ─────────────────────────────────────────────────────────── */
 
-/* Reconcile one day's exported files against the index.  Holds the storage
- * lease: the reconcile walks the card with opendir()/readdir(), and without
- * the lease it can run while sd_storage_format() is calling f_mkfs on the same
- * volume, which corrupts the SDMMC driver and panics this task. */
-static void reconcile_day_leased(uint32_t day)
+/* One bounded metadata transaction per scheduler boundary. No backend owns
+ * index pointers here. Storage callbacks take their own short EXPORT gate;
+ * the index mutation takes a separate zero-wait UPLOAD gate. Exact tokens
+ * keep a newer publication safe between those transactions. */
+static bool service_pending_invalidation(void)
 {
-    if (!uploader_lease_take(LEASE_WAIT_MS)) {
-        ESP_LOGD(TAG, "reconcile deferred: storage busy");
-        return;
-    }
-    upload_scan_reconcile_day(day);
-    refresh_index_progress_cache();
+    if (!s_invalidation_next || !s_invalidation_ack || uploader_should_cancel())
+        return false;
+    uint32_t day = 0;
+    char token[UPLOADER_INVALIDATION_TOKEN_CAP] = {0};
+    if (!s_invalidation_next(&day, token, sizeof(token))) return false;
+    if (!day || !token[0] || !memchr(token, '\0', sizeof(token))) return false;
+    if (!uploader_lease_take(0)) return false;
+    esp_err_t ret = uploader_should_cancel() ? ESP_ERR_INVALID_STATE
+                                             : upload_index_forget_day(day);
     uploader_lease_give();
+    if (ret != ESP_OK || uploader_should_cancel()) return false;
+    ret = s_invalidation_ack(day, token);
+    if (ret != ESP_OK) return false;  /* durable owner retains this token */
+    refresh_index_progress_cache();
+    set_next_scan(0);  /* same filenames must be discovered as new groups */
+    return true;
+}
+
+static void poll_pending_invalidation(void)
+{
+    if (!s_invalidation_next || !s_invalidation_ack ||
+        now_us() < s_next_invalidation_poll_us) return;
+    service_pending_invalidation();
+    s_next_invalidation_poll_us = now_us() + (int64_t)INVALIDATION_POLL_MS * 1000;
 }
 
 static void do_scan(void)
@@ -775,8 +863,12 @@ static void sched_task(void *arg)
     set_status("Waiting for first scan");
 
     while (1) {
-        /* Sleep until the next scan or the earliest cooldown expiry. */
+        poll_pending_invalidation();
+        /* A poll-only wake must not start a network/upload scan. */
         int64_t wake_us = s_next_scan_us;
+        if (s_invalidation_next && s_invalidation_ack &&
+            s_next_invalidation_poll_us < wake_us)
+            wake_us = s_next_invalidation_poll_us;
         for (int i = 0; i < s_n_rt; i++) {
             if (s_rt[i].state == SB_COOLDOWN && s_rt[i].retry_at_us > 0 &&
                 s_rt[i].retry_at_us < wake_us) {
@@ -793,17 +885,11 @@ static void sched_task(void *arg)
         if (got) {
             switch (ev.type) {
             case EV_EXPORT:
-                ESP_LOGI(TAG, "export complete for %08u", (unsigned)ev.day);
-                reconcile_day_leased(ev.day);
-                run_pass();
-                break;
-
             case EV_INVALIDATE:
-                ESP_LOGI(TAG, "day %08u invalidated — will re-upload",
-                         (unsigned)ev.day);
-                upload_index_forget_day(ev.day);
-                reconcile_day_leased(ev.day);
-                run_pass();
+                /* Persisted work, not this lossy queue, authorizes invalidation.
+                 * Run it at the next safe boundary before any transfer. */
+                s_next_invalidation_poll_us = 0;
+                set_next_scan(0);
                 break;
 
             case EV_RESET:
@@ -831,7 +917,12 @@ static void sched_task(void *arg)
             continue;
         }
 
-        /* Timed out: either a scan is due or a cooldown expired. */
+        /* A durable-token polling deadline is independent of network work. */
+        bool run_due = false;
+        for (int i = 0; i < s_n_rt; i++) {
+            if (s_rt[i].state == SB_COOLDOWN && s_rt[i].retry_at_us > 0 &&
+                now_us() >= s_rt[i].retry_at_us) run_due = true;
+        }
         if (now_us() >= s_next_scan_us) {
             if (s_busy_fn && s_busy_fn()) {
                 /* A therapy recording has priority over a housekeeping scan;
@@ -841,13 +932,25 @@ static void sched_task(void *arg)
                 set_next_scan(now_us() + (int64_t)SCAN_INTERVAL_MS * 1000);
             } else {
                 do_scan();
+                run_due = true;
             }
         }
-        run_pass();
+        if (run_due) run_pass();
     }
 }
 
 /* ── Public API ───────────────────────────────────────────────────── */
+
+void upload_sched_set_invalidation_hooks(uploader_invalidation_next_fn_t next,
+                                         uploader_invalidation_ack_fn_t ack)
+{
+    if (s_task) {
+        ESP_LOGE(TAG, "invalidation hooks must be registered before scheduler startup");
+        return;
+    }
+    s_invalidation_next = next;
+    s_invalidation_ack = ack;
+}
 
 esp_err_t upload_sched_init(void)
 {
@@ -855,7 +958,12 @@ esp_err_t upload_sched_init(void)
 
     s_lock = xSemaphoreCreateMutex();
     s_queue = xQueueCreate(SCHED_QUEUE_LEN, sizeof(sched_ev_t));
-    upload_ox_init();
+    if (uploader_lease_take(LEASE_WAIT_MS)) {
+        upload_ox_init();
+        uploader_lease_give();
+    } else {
+        ESP_LOGW(TAG, "O2 upload state init deferred: storage busy");
+    }
     if (!s_lock || !s_queue) return ESP_ERR_NO_MEM;
 
     /* Pre-create runtime slots so the progress API can report a backend

--- a/components/uploader/upload_sched.c
+++ b/components/uploader/upload_sched.c
@@ -61,6 +61,9 @@ static const int COOLDOWN_MIN[] = { 1, 5, 15, 30, 60 };
 #define SCHED_TASK_STACK     12288
 #define SCHED_QUEUE_LEN          8
 
+_Static_assert(UPLOADER_PROGRESS_MAX_BACKENDS >= UPLOAD_MAX_BACKENDS,
+               "public progress snapshot is too small for scheduler slots");
+
 /* ── Backend runtime ──────────────────────────────────────────────── */
 
 typedef enum {
@@ -83,6 +86,11 @@ typedef struct {
     char     cur_day[12];
     int      cur_unit;
     int      n_units;
+    /* Aggregate upload-index progress is computed only by the scheduler and
+     * copied under s_lock.  API callers must not walk upload_index's mutable
+     * s_days array while a scan/reset is replacing it. */
+    int      days_done;
+    int      days_total;
 } backend_rt_t;
 
 static backend_rt_t s_rt[UPLOAD_MAX_BACKENDS];
@@ -105,6 +113,8 @@ static upload_sched_busy_fn_t s_busy_fn;
 
 static int64_t s_next_scan_us;
 static bool    s_scanning;
+static int s_progress_max_days;
+static int s_summary_pending;
 static char    s_status[64] = "Starting up";
 
 /* ── Helpers ──────────────────────────────────────────────────────── */
@@ -122,42 +132,81 @@ static void set_status(const char *fmt, ...)
     va_end(ap);
 }
 
+static void set_summary_pending(int pending)
+{
+    xSemaphoreTake(s_lock, portMAX_DELAY);
+    s_summary_pending = pending;
+    xSemaphoreGive(s_lock);
+}
+
 /* Single choke point for backend state changes so the UI can be pushed an
  * update the moment anything transitions, rather than up to one poll period
  * later.  Only real transitions notify — re-assigning the same state is
  * common in the scan loop and must not generate traffic. */
 static void set_be_state(backend_rt_t *r, sb_state_t st)
 {
-    if (r->state == st) return;
-    r->state = st;
-    uploader_notify_progress_changed();
+    bool changed = false;
+    if (s_lock) xSemaphoreTake(s_lock, portMAX_DELAY);
+    if (r->state != st) {
+        r->state = st;
+        changed = true;
+    }
+    if (s_lock) xSemaphoreGive(s_lock);
+    if (changed) uploader_notify_progress_changed();
 }
 
 static backend_rt_t *rt_for(const upload_backend_t *be)
 {
+    if (s_lock) xSemaphoreTake(s_lock, portMAX_DELAY);
     for (int i = 0; i < s_n_rt; i++) {
-        if (s_rt[i].be == be) return &s_rt[i];
+        if (s_rt[i].be == be) {
+            backend_rt_t *r = &s_rt[i];
+            if (s_lock) xSemaphoreGive(s_lock);
+            return r;
+        }
     }
-    if (s_n_rt >= UPLOAD_MAX_BACKENDS) return NULL;
+    if (s_n_rt >= UPLOAD_MAX_BACKENDS) {
+        if (s_lock) xSemaphoreGive(s_lock);
+        return NULL;
+    }
+
+    /* Slot lookup may inspect persistent upload-index state.  Do it without
+     * holding the runtime snapshot lock, then re-check before publishing the
+     * new slot in case this function ever gains a second caller. */
+    if (s_lock) xSemaphoreGive(s_lock);
+    int slot = upload_index_backend_slot(be->id);
+
+    if (s_lock) xSemaphoreTake(s_lock, portMAX_DELAY);
+    for (int i = 0; i < s_n_rt; i++) {
+        if (s_rt[i].be == be) {
+            backend_rt_t *r = &s_rt[i];
+            if (s_lock) xSemaphoreGive(s_lock);
+            return r;
+        }
+    }
+    if (s_n_rt >= UPLOAD_MAX_BACKENDS) {
+        if (s_lock) xSemaphoreGive(s_lock);
+        return NULL;
+    }
     backend_rt_t *r = &s_rt[s_n_rt++];
     memset(r, 0, sizeof(*r));
     r->be = be;
-    r->slot = upload_index_backend_slot(be->id);
+    r->slot = slot;
     r->state = SB_IDLE;
+    if (s_lock) xSemaphoreGive(s_lock);
     return r;
 }
 
 static void cooldown_enter(backend_rt_t *r, const char *why, bool permanent)
 {
     int mins = COOLDOWN_MIN[r->cooldown_idx];
+    xSemaphoreTake(s_lock, portMAX_DELAY);
     if (r->cooldown_idx < N_COOLDOWN - 1) r->cooldown_idx++;
     r->retry_at_us = now_us() + (int64_t)mins * 60 * 1000000LL;
     r->last_err_permanent = permanent;
-    if (why) {
-        xSemaphoreTake(s_lock, portMAX_DELAY);
+    if (why && why != r->err)
         strlcpy(r->err, why, sizeof(r->err));
-        xSemaphoreGive(s_lock);
-    }
+    xSemaphoreGive(s_lock);
     set_be_state(r, SB_COOLDOWN);
     ESP_LOGW(TAG, "%s: cooldown %d min (%s)", r->be->id, mins,
              why ? why : "error");
@@ -165,10 +214,70 @@ static void cooldown_enter(backend_rt_t *r, const char *why, bool permanent)
 
 static void cooldown_reset(backend_rt_t *r)
 {
+    xSemaphoreTake(s_lock, portMAX_DELAY);
     r->cooldown_idx = 0;
     r->retry_at_us = 0;
     r->err[0] = '\0';
     r->last_err_permanent = false;
+    xSemaphoreGive(s_lock);
+}
+
+static void set_be_error(backend_rt_t *r, const char *error)
+{
+    xSemaphoreTake(s_lock, portMAX_DELAY);
+    strlcpy(r->err, error ? error : "", sizeof(r->err));
+    xSemaphoreGive(s_lock);
+}
+
+static void set_next_scan(int64_t at_us)
+{
+    xSemaphoreTake(s_lock, portMAX_DELAY);
+    s_next_scan_us = at_us;
+    xSemaphoreGive(s_lock);
+}
+
+static void set_scanning(bool scanning)
+{
+    xSemaphoreTake(s_lock, portMAX_DELAY);
+    s_scanning = scanning;
+    xSemaphoreGive(s_lock);
+}
+
+/* upload_index is scheduler-owned after boot, but progress snapshots are read
+ * concurrently by the display, HTTP server, and WebSocket forwarder.  Keep
+ * the public path off the index entirely: the scheduler computes these small
+ * aggregates after each operation that can change the index, then publishes
+ * them under the same lock as the rest of the runtime snapshot. */
+static void refresh_index_progress_cache(void)
+{
+    int slots[UPLOAD_MAX_BACKENDS] = {0};
+    int done[UPLOAD_MAX_BACKENDS] = {0};
+    int total[UPLOAD_MAX_BACKENDS] = {0};
+    int n_runtime;
+    int max_days = uploader_max_days();
+
+    xSemaphoreTake(s_lock, portMAX_DELAY);
+    n_runtime = s_n_rt < UPLOAD_MAX_BACKENDS ? s_n_rt : UPLOAD_MAX_BACKENDS;
+    for (int i = 0; i < n_runtime; ++i) slots[i] = s_rt[i].slot;
+    xSemaphoreGive(s_lock);
+
+    for (int i = 0; i < n_runtime; ++i) {
+        upload_index_backend_progress(slots[i], max_days, &done[i], &total[i]);
+    }
+
+    bool changed = false;
+    xSemaphoreTake(s_lock, portMAX_DELAY);
+    if (s_progress_max_days != max_days) changed = true;
+    s_progress_max_days = max_days;
+    for (int i = 0; i < n_runtime; ++i) {
+        if (s_rt[i].days_done != done[i] || s_rt[i].days_total != total[i])
+            changed = true;
+        s_rt[i].days_done = done[i];
+        s_rt[i].days_total = total[i];
+    }
+    xSemaphoreGive(s_lock);
+
+    if (changed) uploader_notify_progress_changed();
 }
 
 static void ox_mark_day_failed(upload_ox_ref_t *refs, int n_refs, int slot,
@@ -223,7 +332,9 @@ static bool run_backend(backend_rt_t *r, int max_days)
     if (n_days == 0 && !bundle_changed && ox_pending == 0) {
         free(ox_refs);
         set_be_state(r, SB_IDLE);
+        xSemaphoreTake(s_lock, portMAX_DELAY);
         r->cur_day[0] = '\0';
+        xSemaphoreGive(s_lock);
         return false;
     }
     if (!have_bundle && (n_days > 0 || bundle_changed)) {
@@ -272,8 +383,10 @@ static bool run_backend(backend_rt_t *r, int max_days)
     }
 
     set_be_state(r, SB_UPLOADING);
+    xSemaphoreTake(s_lock, portMAX_DELAY);
     r->n_units = n_units + ox_pending;
     r->cur_unit = 0;
+    xSemaphoreGive(s_lock);
 
     /* Say plainly which of the two kinds of run this is.  The old message
      * reported "1 day(s), 0 unit(s) pending" for a root-files-only run, which
@@ -368,8 +481,12 @@ static bool run_backend(backend_rt_t *r, int max_days)
                 g->be[r->slot].status = UG_OK;
                 day_any = true;
                 any_ok = true;
+                xSemaphoreTake(s_lock, portMAX_DELAY);
                 r->cur_unit++;
+                xSemaphoreGive(s_lock);
+                xSemaphoreTake(s_lock, portMAX_DELAY);
                 r->last_ok_s = now_s();
+                xSemaphoreGive(s_lock);
             } else {
                 g->be[r->slot].status = UG_FAILED;
                 fails++;
@@ -395,7 +512,7 @@ static bool run_backend(backend_rt_t *r, int max_days)
                 bundle_ok = false;
                 fails++;
                 ESP_LOGW(TAG, "%s: bundle failed for %s", be->id, daystr);
-                strlcpy(r->err, "root files failed", sizeof(r->err));
+                set_be_error(r, "root files failed");
             }
         }
 
@@ -417,7 +534,7 @@ static bool run_backend(backend_rt_t *r, int max_days)
             }
             bundle_ok = false;
             fails++;
-            strlcpy(r->err, "remote finalise failed", sizeof(r->err));
+            set_be_error(r, "remote finalise failed");
         }
 
         upload_index_save_day(d);
@@ -442,7 +559,7 @@ static bool run_backend(backend_rt_t *r, int max_days)
                     if (res != UPLOAD_OK) {
                         ox_mark_day_failed(ox_refs, n_ox, r->slot, ox_day);
                         fails++;
-                        strlcpy(r->err, "oximetry finalise failed", sizeof(r->err));
+                        set_be_error(r, "oximetry finalise failed");
                     }
                 }
                 strlcpy(ox_day, ox_refs[oi].day, sizeof(ox_day));
@@ -451,7 +568,7 @@ static bool run_backend(backend_rt_t *r, int max_days)
                       (be->day_begin ? be->day_begin(ox_day) : UPLOAD_OK);
                 if (res != UPLOAD_OK) {
                     fails++;
-                    strlcpy(r->err, "cannot open oximetry day", sizeof(r->err));
+                    set_be_error(r, "cannot open oximetry day");
                     break;
                 }
             }
@@ -473,8 +590,12 @@ static bool run_backend(backend_rt_t *r, int max_days)
             if (res == UPLOAD_OK) {
                 ox_day_any = true;
                 any_ok = true;
+                xSemaphoreTake(s_lock, portMAX_DELAY);
                 r->cur_unit++;
+                xSemaphoreGive(s_lock);
+                xSemaphoreTake(s_lock, portMAX_DELAY);
                 r->last_ok_s = now_s();
+                xSemaphoreGive(s_lock);
             } else {
                 fails++;
                 ESP_LOGW(TAG, "%s: oximetry %s failed", be->id,
@@ -487,7 +608,7 @@ static bool run_backend(backend_rt_t *r, int max_days)
             if (res != UPLOAD_OK) {
                 ox_mark_day_failed(ox_refs, n_ox, r->slot, ox_day);
                 fails++;
-                strlcpy(r->err, "oximetry finalise failed", sizeof(r->err));
+                set_be_error(r, "oximetry finalise failed");
             }
         }
     }
@@ -537,6 +658,8 @@ static void run_pass(void)
     int max_days = uploader_max_days();
 
     if (n == 0) {
+        refresh_index_progress_cache();
+        set_summary_pending(0);
         set_status("No upload backend configured");
         return;
     }
@@ -555,12 +678,24 @@ static void run_pass(void)
         run_backend(r, max_days);
     }
 
+    refresh_index_progress_cache();
+
     /* Summarise for the UI. */
     int pending = 0;
     bool cooling = false;
     upload_ox_ref_t *ox_refs = heap_caps_malloc(sizeof(upload_ox_ref_t) * UPLOAD_OX_MAX_UNITS, MALLOC_CAP_SPIRAM);
-    if (!ox_refs) { set_status("Memory low"); return; }
+    if (!ox_refs) {
+        set_summary_pending(0);
+        set_status("Memory low");
+        return;
+    }
+    if (!uploader_lease_take(LEASE_WAIT_MS)) {
+        free(ox_refs);
+        set_status("Storage busy");
+        return;
+    }
     int n_ox = upload_ox_reconcile(ox_refs, UPLOAD_OX_MAX_UNITS, max_days);
+    uploader_lease_give();
     for (int i = 0; i < s_n_rt; i++) {
         if (s_rt[i].state == SB_DISABLED) continue;
         pending += upload_index_backend_pending(s_rt[i].slot, max_days);
@@ -568,6 +703,7 @@ static void run_pass(void)
         if (s_rt[i].state == SB_COOLDOWN) cooling = true;
     }
     free(ox_refs);
+    set_summary_pending(pending);
     if (pending == 0) set_status("All uploaded");
     else if (cooling)  set_status("%d parts pending — waiting to retry", pending);
     else               set_status("%d parts pending", pending);
@@ -586,6 +722,7 @@ static void reconcile_day_leased(uint32_t day)
         return;
     }
     upload_scan_reconcile_day(day);
+    refresh_index_progress_cache();
     uploader_lease_give();
 }
 
@@ -603,18 +740,19 @@ static void do_scan(void)
         if (r && r->slot >= 0) slots[n_slots++] = r->slot;
     }
     if (n_slots == 0) {
-        s_next_scan_us = now_us() + (int64_t)SCAN_INTERVAL_MS * 1000;
+        refresh_index_progress_cache();
+        set_next_scan(now_us() + (int64_t)SCAN_INTERVAL_MS * 1000);
         return;
     }
 
-    /* Same lease the upload pass takes — see reconcile_day_leased(). */
+    /* The card walk shares admission with upload and destructive operations. */
     if (!uploader_lease_take(LEASE_WAIT_MS)) {
         ESP_LOGD(TAG, "scan deferred: storage busy");
-        s_next_scan_us = now_us() + (int64_t)SCAN_INTERVAL_MS * 1000;
+        set_next_scan(now_us() + (int64_t)SCAN_INTERVAL_MS * 1000);
         return;
     }
 
-    s_scanning = true;
+    set_scanning(true);
     set_status("Scanning for new data");
     upload_scan_reconcile_all(max_days, slots, n_slots);
     upload_ox_ref_t *ox_refs = heap_caps_malloc(sizeof(upload_ox_ref_t) * UPLOAD_OX_MAX_UNITS, MALLOC_CAP_SPIRAM);
@@ -622,9 +760,10 @@ static void do_scan(void)
         upload_ox_reconcile(ox_refs, UPLOAD_OX_MAX_UNITS, max_days);
         free(ox_refs);
     }
-    s_scanning = false;
+    refresh_index_progress_cache();
+    set_scanning(false);
     uploader_lease_give();
-    s_next_scan_us = now_us() + (int64_t)SCAN_INTERVAL_MS * 1000;
+    set_next_scan(now_us() + (int64_t)SCAN_INTERVAL_MS * 1000);
 }
 
 static void sched_task(void *arg)
@@ -632,7 +771,7 @@ static void sched_task(void *arg)
     (void)arg;
     ESP_LOGI(TAG, "upload scheduler started on core %d", xPortGetCoreID());
 
-    s_next_scan_us = now_us() + (int64_t)FIRST_SCAN_DELAY_MS * 1000;
+    set_next_scan(now_us() + (int64_t)FIRST_SCAN_DELAY_MS * 1000);
     set_status("Waiting for first scan");
 
     while (1) {
@@ -671,10 +810,13 @@ static void sched_task(void *arg)
                 ESP_LOGW(TAG, "upload state reset — re-uploading newest %d day(s)",
                          uploader_max_days());
                 upload_index_clear();
+                refresh_index_progress_cache();
                 for (int i = 0; i < s_n_rt; i++) {
                     cooldown_reset(&s_rt[i]);
                     set_be_state(&s_rt[i], SB_IDLE);
+                    xSemaphoreTake(s_lock, portMAX_DELAY);
                     s_rt[i].last_ok_s = 0;
+                    xSemaphoreGive(s_lock);
                 }
                 do_scan();
                 run_pass();
@@ -696,7 +838,7 @@ static void sched_task(void *arg)
                  * try again on the next tick rather than competing for the
                  * card. Event-driven uploads are unaffected. */
                 ESP_LOGD(TAG, "scan deferred: storage busy");
-                s_next_scan_us = now_us() + (int64_t)SCAN_INTERVAL_MS * 1000;
+                set_next_scan(now_us() + (int64_t)SCAN_INTERVAL_MS * 1000);
             } else {
                 do_scan();
             }
@@ -721,6 +863,7 @@ esp_err_t upload_sched_init(void)
     const upload_backend_t *bes[UPLOAD_MAX_BACKENDS];
     int n = uploader_enabled_backends(bes, UPLOAD_MAX_BACKENDS);
     for (int i = 0; i < n; i++) rt_for(bes[i]);
+    refresh_index_progress_cache();
 
     StackType_t *stack = heap_caps_malloc(SCHED_TASK_STACK, MALLOC_CAP_SPIRAM);
     StaticTask_t *tcb  = heap_caps_malloc(sizeof(StaticTask_t), MALLOC_CAP_INTERNAL);
@@ -762,77 +905,167 @@ bool upload_sched_uploading(void)
 
 /* ── Progress reporting ───────────────────────────────────────────── */
 
-static const char *state_name(sb_state_t s)
+static uploader_backend_state_t public_state(sb_state_t state)
 {
-    switch (s) {
-    case SB_UPLOADING: return "uploading";
-    case SB_COOLDOWN:  return "cooldown";
-    case SB_DISABLED:  return "disabled";
-    default:           return "idle";
+    switch (state) {
+    case SB_UPLOADING: return UPLOADER_BACKEND_UPLOADING;
+    case SB_COOLDOWN:  return UPLOADER_BACKEND_COOLDOWN;
+    case SB_DISABLED:  return UPLOADER_BACKEND_DISABLED;
+    default:           return UPLOADER_BACKEND_IDLE;
     }
+}
+
+static const char *public_state_name(uploader_backend_state_t state)
+{
+    switch (state) {
+    case UPLOADER_BACKEND_UPLOADING: return "uploading";
+    case UPLOADER_BACKEND_COOLDOWN:  return "cooldown";
+    case UPLOADER_BACKEND_DISABLED:  return "disabled";
+    default:                         return "idle";
+    }
+}
+
+typedef struct {
+    const upload_backend_t *be;
+    int slot;
+    sb_state_t state;
+    int64_t retry_at_us;
+    uint32_t last_ok_s;
+    bool last_err_permanent;
+    char err[sizeof(((backend_rt_t *)0)->err)];
+    char cur_day[sizeof(((backend_rt_t *)0)->cur_day)];
+    int cur_unit;
+    int n_units;
+    int days_done;
+    int days_total;
+} backend_rt_snapshot_t;
+
+esp_err_t upload_sched_progress_snapshot(uploader_progress_snapshot_t *out)
+{
+    if (!out) return ESP_ERR_INVALID_ARG;
+    memset(out, 0, sizeof(*out));
+
+    /* s_task is assigned last, after the lock and runtime slots exist. */
+    if (!s_task) return ESP_ERR_INVALID_STATE;
+
+    backend_rt_snapshot_t runtime[UPLOAD_MAX_BACKENDS] = {0};
+    int n_runtime;
+    int64_t next_scan_us;
+    int64_t snapshot_us = now_us();
+    int progress_max_days;
+
+    xSemaphoreTake(s_lock, portMAX_DELAY);
+    strlcpy(out->status, s_status, sizeof(out->status));
+    out->scanning = s_scanning;
+    next_scan_us = s_next_scan_us;
+    progress_max_days = s_progress_max_days;
+    n_runtime = s_n_rt < UPLOAD_MAX_BACKENDS ? s_n_rt : UPLOAD_MAX_BACKENDS;
+    for (int i = 0; i < n_runtime; ++i) {
+        const backend_rt_t *src = &s_rt[i];
+        backend_rt_snapshot_t *dst = &runtime[i];
+        dst->be = src->be;
+        dst->slot = src->slot;
+        dst->state = src->state;
+        dst->retry_at_us = src->retry_at_us;
+        dst->last_ok_s = src->last_ok_s;
+        dst->last_err_permanent = src->last_err_permanent;
+        strlcpy(dst->err, src->err, sizeof(dst->err));
+        strlcpy(dst->cur_day, src->cur_day, sizeof(dst->cur_day));
+        dst->cur_unit = src->cur_unit;
+        dst->n_units = src->n_units;
+        dst->days_done = src->days_done;
+        dst->days_total = src->days_total;
+    }
+    xSemaphoreGive(s_lock);
+
+    int64_t until = next_scan_us - snapshot_us;
+    out->next_scan_s = until > 0 ? (uint32_t)(until / 1000000) : 0;
+    out->max_days = progress_max_days;
+
+    for (int i = 0; i < n_runtime; ++i) {
+        const backend_rt_snapshot_t *src = &runtime[i];
+        if (!src->be) continue;
+
+        uploader_backend_progress_t *dst =
+            &out->backends[out->backend_count++];
+        strlcpy(dst->id, src->be->id ? src->be->id : "", sizeof(dst->id));
+        strlcpy(dst->label,
+                src->be->label ? src->be->label : src->be->id,
+                sizeof(dst->label));
+        dst->configured = src->be->is_configured &&
+                          src->be->is_configured();
+        dst->state = dst->configured ? public_state(src->state)
+                                     : UPLOADER_BACKEND_DISABLED;
+
+        dst->days_done = src->days_done;
+        dst->days_total = src->days_total;
+
+        dst->last_success_valid = src->last_ok_s != 0;
+        dst->last_success_epoch_s = src->last_ok_s;
+
+        dst->current_valid = dst->state == UPLOADER_BACKEND_UPLOADING &&
+                             src->cur_day[0] != '\0';
+        if (dst->current_valid) {
+            strlcpy(dst->current_day, src->cur_day,
+                    sizeof(dst->current_day));
+            dst->current_unit = src->cur_unit;
+            dst->current_units = src->n_units;
+        }
+
+        dst->retry_valid = dst->state == UPLOADER_BACKEND_COOLDOWN;
+        if (dst->retry_valid) {
+            int64_t retry_in_us = src->retry_at_us - snapshot_us;
+            dst->retry_in_s = retry_in_us > 0
+                                  ? (uint32_t)(retry_in_us / 1000000) : 0;
+            dst->error_permanent = src->last_err_permanent;
+            dst->error_valid = src->err[0] != '\0';
+            if (dst->error_valid)
+                strlcpy(dst->error, src->err, sizeof(dst->error));
+        }
+    }
+    return ESP_OK;
 }
 
 esp_err_t upload_sched_progress_json(char **out_json)
 {
     if (!out_json) return ESP_ERR_INVALID_ARG;
+    uploader_progress_snapshot_t progress;
+    esp_err_t ret = upload_sched_progress_snapshot(&progress);
+    if (ret != ESP_OK) return ret;
 
-    /* s_task is this module's "fully constructed" sentinel: it is assigned
-     * last, after the mutex, the queue and the runtime slots.  Guarding on
-     * s_lock instead would still expose s_rt/s_n_rt while rt_for() is
-     * populating them. */
-    if (!s_task) return ESP_ERR_INVALID_STATE;
-
-    int max_days = uploader_max_days();
     cJSON *root = cJSON_CreateObject();
     if (!root) return ESP_ERR_NO_MEM;
 
-    xSemaphoreTake(s_lock, portMAX_DELAY);
-    cJSON_AddStringToObject(root, "status", s_status);
-    xSemaphoreGive(s_lock);
-
-    cJSON_AddBoolToObject(root, "scanning", s_scanning);
-    int64_t until = s_next_scan_us - now_us();
-    cJSON_AddNumberToObject(root, "next_scan_s", until > 0 ? until / 1000000 : 0);
-    cJSON_AddNumberToObject(root, "max_days", max_days);
+    cJSON_AddStringToObject(root, "status", progress.status);
+    cJSON_AddBoolToObject(root, "scanning", progress.scanning);
+    cJSON_AddNumberToObject(root, "next_scan_s", progress.next_scan_s);
+    cJSON_AddNumberToObject(root, "max_days", progress.max_days);
 
     cJSON *arr = cJSON_AddArrayToObject(root, "backends");
-    for (int i = 0; i < s_n_rt; i++) {
-        backend_rt_t *r = &s_rt[i];
-        if (!r->be) continue;
+    for (size_t i = 0; i < progress.backend_count; i++) {
+        const uploader_backend_progress_t *p = &progress.backends[i];
 
         cJSON *o = cJSON_CreateObject();
-        cJSON_AddStringToObject(o, "id", r->be->id);
-        cJSON_AddStringToObject(o, "label", r->be->label ? r->be->label : r->be->id);
+        cJSON_AddStringToObject(o, "id", p->id);
+        cJSON_AddStringToObject(o, "label", p->label);
+        cJSON_AddBoolToObject(o, "configured", p->configured);
+        cJSON_AddStringToObject(o, "state", public_state_name(p->state));
+        cJSON_AddNumberToObject(o, "days_done", p->days_done);
+        cJSON_AddNumberToObject(o, "days_total", p->days_total);
 
-        bool conf = r->be->is_configured && r->be->is_configured();
-        cJSON_AddBoolToObject(o, "configured", conf);
-        cJSON_AddStringToObject(o, "state",
-                                conf ? state_name(r->state) : "disabled");
+        if (p->last_success_valid)
+            cJSON_AddNumberToObject(o, "last_ok_s", p->last_success_epoch_s);
 
-        int done = 0, total = 0;
-        upload_index_backend_progress(r->slot, max_days, &done, &total);
-        cJSON_AddNumberToObject(o, "days_done", done);
-        cJSON_AddNumberToObject(o, "days_total", total);
-
-        if (r->last_ok_s) cJSON_AddNumberToObject(o, "last_ok_s", r->last_ok_s);
-
-        char cur_day[12], err[72];
-        xSemaphoreTake(s_lock, portMAX_DELAY);
-        strlcpy(cur_day, r->cur_day, sizeof(cur_day));
-        strlcpy(err, r->err, sizeof(err));
-        xSemaphoreGive(s_lock);
-
-        if (r->state == SB_UPLOADING && cur_day[0]) {
+        if (p->current_valid) {
             cJSON *cur = cJSON_AddObjectToObject(o, "cur");
-            cJSON_AddStringToObject(cur, "day", cur_day);
-            cJSON_AddNumberToObject(cur, "unit", r->cur_unit);
-            cJSON_AddNumberToObject(cur, "units", r->n_units);
+            cJSON_AddStringToObject(cur, "day", p->current_day);
+            cJSON_AddNumberToObject(cur, "unit", p->current_unit);
+            cJSON_AddNumberToObject(cur, "units", p->current_units);
         }
-        if (r->state == SB_COOLDOWN) {
-            int64_t left = r->retry_at_us - now_us();
-            cJSON_AddNumberToObject(o, "retry_in_s", left > 0 ? left / 1000000 : 0);
-            if (err[0]) cJSON_AddStringToObject(o, "err", err);
-            cJSON_AddBoolToObject(o, "err_permanent", r->last_err_permanent);
+        if (p->retry_valid) {
+            cJSON_AddNumberToObject(o, "retry_in_s", p->retry_in_s);
+            if (p->error_valid) cJSON_AddStringToObject(o, "err", p->error);
+            cJSON_AddBoolToObject(o, "err_permanent", p->error_permanent);
         }
         cJSON_AddItemToArray(arr, o);
     }
@@ -844,19 +1077,19 @@ esp_err_t upload_sched_progress_json(char **out_json)
 
 void upload_sched_summary(int *out_pending, const char **out_worst)
 {
-    int max_days = uploader_max_days();
     int pending = 0;
     const char *worst = "idle";
 
+    /* This getter is used by /api/status and the bedside display. Keep it a
+     * bounded in-memory snapshot: the scheduler owns all SD reconciliation. */
+    if (s_lock) xSemaphoreTake(s_lock, portMAX_DELAY);
+    pending = s_summary_pending;
     for (int i = 0; i < s_n_rt; i++) {
-        backend_rt_t *r = &s_rt[i];
-        if (!r->be || !r->be->is_configured || !r->be->is_configured()) continue;
-        pending += upload_index_backend_pending(r->slot, max_days);
-        pending += upload_ox_cached_pending(r->slot);
-        if (r->state == SB_COOLDOWN) worst = "cooldown";
-        else if (r->state == SB_UPLOADING && strcmp(worst, "cooldown") != 0)
+        if (s_rt[i].state == SB_COOLDOWN) worst = "cooldown";
+        else if (s_rt[i].state == SB_UPLOADING && strcmp(worst, "cooldown") != 0)
             worst = "uploading";
     }
+    if (s_lock) xSemaphoreGive(s_lock);
     if (out_pending) *out_pending = pending;
     if (out_worst) *out_worst = worst;
 }

--- a/components/uploader/upload_sched.h
+++ b/components/uploader/upload_sched.h
@@ -69,9 +69,13 @@ esp_err_t upload_sched_init(void);
 /* Trigger 1: an export finished for this day (numeric YYYYMMDD). */
 void upload_sched_notify_export(uint32_t day);
 
-/* The day's exported files were replaced (rebuild / recreate), so whatever
- * was uploaded before is stale.  Drops the day's state and re-uploads. */
+/* The day's exported files were replaced. Wake durable-token polling; the
+ * event is only a nudge and may be dropped without losing persisted work. */
 void upload_sched_notify_invalidate(uint32_t day);
+
+/* App hooks are immutable after scheduler startup; see uploader.h. */
+void upload_sched_set_invalidation_hooks(uploader_invalidation_next_fn_t next,
+                                         uploader_invalidation_ack_fn_t ack);
 
 /* Trigger 3: rescan now, or clear all state and re-upload from scratch. */
 void upload_sched_request_scan(void);

--- a/components/uploader/upload_sched.h
+++ b/components/uploader/upload_sched.h
@@ -90,6 +90,12 @@ bool upload_sched_uploading(void);
 /* Compact progress for the Web UI.  Caller frees. */
 esp_err_t upload_sched_progress_json(char **out_json);
 
+/* Allocation-free structured form used by the public uploader snapshot API
+ * and as the single source for progress JSON serialization. Index aggregates
+ * are scheduler-owned RAM caches, so callers never traverse mutable index
+ * storage from the display/httpd/WebSocket tasks. */
+esp_err_t upload_sched_progress_snapshot(uploader_progress_snapshot_t *out);
+
 /* One-line summary for /api/status: number of units not yet uploaded across
  * configured backends, and the worst backend state as a short string. */
 void upload_sched_summary(int *out_pending, const char **out_worst);

--- a/components/uploader/uploader.c
+++ b/components/uploader/uploader.c
@@ -22,6 +22,8 @@
  */
 
 #include "uploader.h"
+#include <netdb.h>
+#include <arpa/inet.h>
 #include "upload_index.h"
 #include "upload_scan.h"
 #include "upload_sched.h"
@@ -162,6 +164,22 @@ esp_err_t uploader_load_config(uploader_config_t *cfg)
 }
 
 /* Injected storage-lease hooks (the app's sd_storage arbitration). */
+static uploader_cancel_fn_t s_should_cancel;
+void uploader_set_cancel_fn(uploader_cancel_fn_t fn) { s_should_cancel = fn; }
+bool uploader_should_cancel(void) { return s_should_cancel && s_should_cancel(); }
+
+bool uploader_resolve_host(const char *host, char *out, size_t out_size)
+{
+    if (uploader_should_cancel()) return false;
+    struct addrinfo hints = { .ai_family = AF_INET, .ai_socktype = SOCK_STREAM };
+    struct addrinfo *result = NULL;
+    if (getaddrinfo(host, NULL, &hints, &result) != 0) return false;
+    bool ok = result && inet_ntop(AF_INET,
+        &((struct sockaddr_in *)result->ai_addr)->sin_addr, out, out_size);
+    freeaddrinfo(result);
+    return ok && !uploader_should_cancel();
+}
+
 static uploader_lease_acquire_fn_t s_lease_acquire = NULL;
 static uploader_lease_release_fn_t s_lease_release = NULL;
 
@@ -449,7 +467,8 @@ int uploader_enabled_backends(const upload_backend_t **out, int max_out)
 
 bool uploader_lease_take(uint32_t timeout_ms)
 {
-    return s_lease_acquire ? s_lease_acquire(timeout_ms) : true;
+    return !uploader_should_cancel() &&
+           (s_lease_acquire ? s_lease_acquire(timeout_ms) : true);
 }
 
 void uploader_lease_give(void)
@@ -520,8 +539,14 @@ void uploader_on_day_invalidated(const char *day_folder)
     if (!s_initialised) return;
     uint32_t day = day_to_num(day_folder);
     if (!day) return;
-    ESP_LOGI(TAG, "day %s invalidated", day_folder);
+    ESP_LOGI(TAG, "day %s invalidation pending", day_folder);
     upload_sched_notify_invalidate(day);
+}
+
+void uploader_set_invalidation_hooks(uploader_invalidation_next_fn_t next,
+                                      uploader_invalidation_ack_fn_t ack)
+{
+    upload_sched_set_invalidation_hooks(next, ack);
 }
 
 void uploader_request_scan(void)

--- a/components/uploader/uploader.c
+++ b/components/uploader/uploader.c
@@ -566,3 +566,11 @@ esp_err_t uploader_test_connection(const char *backend_id, bool *out_ok,
              *out_ok ? "passed" : "failed", msg);
     return ESP_OK;
 }
+
+esp_err_t uploader_get_progress_snapshot(uploader_progress_snapshot_t *out)
+{
+    if (!out) return ESP_ERR_INVALID_ARG;
+    memset(out, 0, sizeof(*out));
+    if (!s_initialised) return ESP_ERR_INVALID_STATE;
+    return upload_sched_progress_snapshot(out);
+}

--- a/components/uploader/uploader.h
+++ b/components/uploader/uploader.h
@@ -58,6 +58,7 @@
 
 typedef enum {
     UPLOAD_OK = 0,          /* transferred, or deliberately skipped         */
+    UPLOAD_CANCELLED,       /* recording admission requested; leave pending */
     UPLOAD_NOT_CONFIGURED,  /* backend has no valid config — skipped        */
     UPLOAD_ERR_TRANSIENT,   /* timeout / unreachable / 5xx — retry later    */
     UPLOAD_ERR_PERMANENT,   /* auth rejected / 4xx — retry, but surface it  */
@@ -85,6 +86,9 @@ typedef struct {
 
     /* Check if this backend has valid configuration (config keys in NVS). */
     bool (*is_configured)(void);
+
+    /* Resolve names before taking any SD lease. No card access here. */
+    upload_result_t (*prepare)(void);
 
     /* Open the connection: TCP/SMB session or TLS + auth. */
     upload_result_t (*session_begin)(void);
@@ -160,17 +164,35 @@ typedef struct {
  * Call once at boot after nvs_flash_init() and sd_storage_init(). */
 esp_err_t uploader_init(void);
 
-/* ── Event triggers ───────────────────────────────────────────────────
- * All are safe to call from any task; they only post to the scheduler. */
+/* Durable export invalidation handoff. Register before uploader_init().
+ * The app owns persisted work and stable generation tokens (not RAM queue
+ * entries). next returns one pending day/token without consuming it; ack
+ * retires only that exact token and returns failure if it cannot do so.
+ * Both callbacks run on the scheduler outside its storage lease and must
+ * use bounded, nonblocking storage admission of their own. They must not
+ * perform network work or wait for this scheduler. The scheduler takes a
+ * separate zero-wait lease to delete old index state, releases it, then ack's.
+ * A reset at any boundary repeats invalidation safely before acknowledgement. */
+#define UPLOADER_INVALIDATION_TOKEN_CAP 128
+typedef bool (*uploader_invalidation_next_fn_t)(uint32_t *day, char *token,
+                                               size_t token_cap);
+typedef esp_err_t (*uploader_invalidation_ack_fn_t)(uint32_t day, const char *token);
+void uploader_set_invalidation_hooks(uploader_invalidation_next_fn_t next,
+                                      uploader_invalidation_ack_fn_t ack);
 
-/* An export finished for this noon-day.  The day is rescanned and only the
- * groups that are new (or previously failed) are uploaded — unlike the old
- * day-level tracker, an already-uploaded session is not re-sent. */
+/* ── Event triggers ───────────────────────────────────────────────────
+ * All are safe to call from any task; they only nudge the scheduler.
+ * Persist invalidation work before posting. A full queue or restart is
+ * repaired by periodic polling of the durable handoff, not by queue replay. */
+
+/* An export finished for this noon-day. Rescan after servicing the persisted
+ * invalidation token, so changed samples under existing filenames are offered
+ * again as well as new groups. Delivery is intentionally at least once. */
 void uploader_on_export_complete(const char *day_folder);
 
-/* This day's exported files were replaced (rebuild-day / recreate-edfs), so
- * whatever a backend holds for it is stale.  Drops the day's tracking state
- * so every group in it is uploaded again. */
+/* This day's exported files were replaced (rebuild-day / recreate-edfs).
+ * Nudge the durable handoff; the event itself never authorizes deletion or
+ * acknowledgement. The persisted day token causes every group to be offered. */
 void uploader_on_day_invalidated(const char *day_folder);
 
 /* Ask for an immediate reconciliation of the card against the tracking state
@@ -195,6 +217,13 @@ esp_err_t uploader_save_config(const uploader_config_t *cfg);
 typedef esp_err_t (*uploader_nvs_task_fn_t)(void *arg);
 typedef esp_err_t (*uploader_nvs_exec_fn_t)(uploader_nvs_task_fn_t fn, void *arg);
 void uploader_set_nvs_executor(uploader_nvs_exec_fn_t exec);
+
+/* Nonblocking recording-intent predicate, injected by the app. */
+typedef bool (*uploader_cancel_fn_t)(void);
+void uploader_set_cancel_fn(uploader_cancel_fn_t fn);
+bool uploader_should_cancel(void);
+/* Resolve to a numeric IPv4 address, only before storage admission. */
+bool uploader_resolve_host(const char *host, char *out, size_t out_size);
 
 /* Storage-lease hooks (injected for the same reason as the NVS executor:
  * this component does not depend on the app).

--- a/components/uploader/uploader.h
+++ b/components/uploader/uploader.h
@@ -26,6 +26,7 @@
 #include "esp_err.h"
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 #include "upload_scan.h"
 #include "upload_ox.h"
 
@@ -227,16 +228,73 @@ bool uploader_is_sleephq_enabled(void);
 /* Check if FTP server is enabled in config. */
 bool uploader_is_ftp_enabled(void);
 
+/* Fixed-size upload progress for memory-constrained callers such as the
+ * bedside display.  The snapshot owns all of its strings and the getter does
+ * not allocate.  Entries include every registered backend, including ones
+ * that are disabled or do not yet have complete configuration. */
+#define UPLOADER_PROGRESS_MAX_BACKENDS  4
+#define UPLOADER_PROGRESS_ID_LEN        12
+#define UPLOADER_PROGRESS_LABEL_LEN     32
+#define UPLOADER_PROGRESS_DAY_LEN       12
+#define UPLOADER_PROGRESS_ERROR_LEN     72
+#define UPLOADER_PROGRESS_STATUS_LEN    64
+
+typedef enum {
+    UPLOADER_BACKEND_DISABLED = 0,
+    UPLOADER_BACKEND_IDLE,
+    UPLOADER_BACKEND_UPLOADING,
+    UPLOADER_BACKEND_COOLDOWN,
+} uploader_backend_state_t;
+
+typedef struct {
+    char id[UPLOADER_PROGRESS_ID_LEN];
+    char label[UPLOADER_PROGRESS_LABEL_LEN];
+    bool configured;
+    uploader_backend_state_t state;
+    int days_done;
+    int days_total;
+
+    bool current_valid;
+    char current_day[UPLOADER_PROGRESS_DAY_LEN];
+    int current_unit;
+    int current_units;
+
+    bool last_success_valid;
+    uint32_t last_success_epoch_s;
+
+    bool retry_valid;
+    uint32_t retry_in_s;
+    bool error_valid;
+    bool error_permanent;
+    char error[UPLOADER_PROGRESS_ERROR_LEN];
+} uploader_backend_progress_t;
+
+typedef struct {
+    char status[UPLOADER_PROGRESS_STATUS_LEN];
+    bool scanning;
+    uint32_t next_scan_s;
+    int max_days;
+    size_t backend_count;
+    uploader_backend_progress_t backends[UPLOADER_PROGRESS_MAX_BACKENDS];
+} uploader_progress_snapshot_t;
+
+/* Populate a caller-owned, bounded RAM snapshot without heap allocation or
+ * SD/index traversal. Returns ESP_ERR_INVALID_STATE before uploader_init()
+ * has completed. */
+esp_err_t uploader_get_progress_snapshot(uploader_progress_snapshot_t *out);
+
 /* Compact upload progress for the web UI: one entry per backend with its
  * state, days done/total and, while uploading, the current day and unit.
- * Bounded in size regardless of how much history exists.
+ * Bounded in size regardless of how much history exists. Progress is
+ * serialized from the scheduler's RAM snapshot rather than the mutable index.
  * Returns ESP_ERR_INVALID_STATE before uploader_init() has completed.
  * Caller must free() the returned string. */
 esp_err_t uploader_get_progress_json(char **out_json);
 
-/* One-line summary for /api/status (header badge): how many units are still
- * outstanding across configured backends, and the worst backend state
- * ("idle" | "uploading" | "cooldown"). */
+/* Cached one-line summary for /api/status (header badge): how many units are
+ * still outstanding across configured backends, and the worst backend state
+ * ("idle" | "uploading" | "cooldown"). This is a bounded RAM-only snapshot;
+ * callers never scan or mutate the SD card. */
 void uploader_get_summary(int *out_pending, const char **out_worst);
 
 /* Debug: the parsed tracking state for one day ("YYYYMMDD").

--- a/components/uploader/uploader_sleephq.c
+++ b/components/uploader/uploader_sleephq.c
@@ -40,6 +40,8 @@
 #include "esp_system.h"
 #include "esp_random.h"
 #include "esp_tls.h"
+#include <fcntl.h>
+#include <arpa/inet.h>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "cJSON.h"
@@ -82,30 +84,35 @@ static bool shq_token_ready(void)
 
 /* ── TLS socket layer ───────────────────────────────────────────────── */
 
+/* Once storage is leased, all TLS I/O uses a nonblocking socket. A request
+ * deadline is not renewed by trickle progress; cancellation is checked before
+ * every transport call and at most 20ms apart while waiting for readiness. */
+static int64_t s_request_deadline;
+static bool shq_io_allowed(void)
+{
+    return !uploader_should_cancel() && esp_timer_get_time() < s_request_deadline;
+}
+static ssize_t shq_tls_read(esp_tls_t *tls, void *data, size_t len)
+{
+    while (shq_io_allowed()) {
+        ssize_t n = esp_tls_conn_read(tls, data, len);
+        if (n != ESP_TLS_ERR_SSL_WANT_READ && n != ESP_TLS_ERR_SSL_WANT_WRITE) return n;
+        vTaskDelay(pdMS_TO_TICKS(20));
+    }
+    return -1;
+}
 static int shq_tls_write_all(esp_tls_t *tls, const void *data, size_t len)
 {
-    const char *p = (const char *)data;
     size_t total = 0;
-    int write_calls = 0;
-    while (total < len) {
-        ssize_t w = esp_tls_conn_write(tls, p + total, len - total);
-        write_calls++;
-        if (w < 0) {
-            ESP_LOGE(TAG, "TLS write error: %d (after %u/%u bytes, %d calls)",
-                     (int)w, (unsigned)total, (unsigned)len, write_calls);
-            return -1;
+    while (total < len && shq_io_allowed()) {
+        ssize_t w = esp_tls_conn_write(tls, (const char *)data + total, len - total);
+        if (w == ESP_TLS_ERR_SSL_WANT_READ || w == ESP_TLS_ERR_SSL_WANT_WRITE) {
+            vTaskDelay(pdMS_TO_TICKS(20)); continue;
         }
-        if (w == 0) {
-            if (write_calls > 100) {
-                ESP_LOGE(TAG, "TLS write stuck: 0 return after %d calls", write_calls);
-                return -1;
-            }
-            vTaskDelay(pdMS_TO_TICKS(10));
-            continue;
-        }
+        if (w <= 0) return -1;
         total += w;
     }
-    return (int)total;
+    return total == len ? (int)total : -1;
 }
 
 /* Read a complete HTTP response from the TLS socket.
@@ -132,7 +139,7 @@ static int shq_http_read_response(esp_tls_t *tls, char **body_out, size_t *body_
             free(buf);
             return -1;
         }
-        ssize_t n = esp_tls_conn_read(tls, buf + buf_len, buf_cap - buf_len - 1);
+        ssize_t n = shq_tls_read(tls, buf + buf_len, buf_cap - buf_len - 1);
         if (n < 0) {
             ESP_LOGE(TAG, "TLS read error during headers: %d", (int)n);
             free(buf);
@@ -197,7 +204,7 @@ static int shq_http_read_response(esp_tls_t *tls, char **body_out, size_t *body_
             if (buf_len >= buf_cap - 1) break;
             size_t to_read = remaining < (buf_cap - buf_len - 1) ?
                              remaining : (buf_cap - buf_len - 1);
-            ssize_t n = esp_tls_conn_read(tls, buf + buf_len, to_read);
+            ssize_t n = shq_tls_read(tls, buf + buf_len, to_read);
             if (n < 0) {
                 ESP_LOGE(TAG, "TLS read error during body: %d", (int)n);
                 free(buf);
@@ -211,7 +218,7 @@ static int shq_http_read_response(esp_tls_t *tls, char **body_out, size_t *body_
         /* Read until we see 0\r\n\r\n or connection closes */
         while (1) {
             if (buf_len >= buf_cap - 1) break;
-            ssize_t n = esp_tls_conn_read(tls, buf + buf_len, buf_cap - buf_len - 1);
+            ssize_t n = shq_tls_read(tls, buf + buf_len, buf_cap - buf_len - 1);
             if (n < 0) { free(buf); return -1; }
             if (n == 0) break;
             buf_len += n;
@@ -222,7 +229,7 @@ static int shq_http_read_response(esp_tls_t *tls, char **body_out, size_t *body_
         /* No Content-Length, no chunked — read until connection closes */
         while (1) {
             if (buf_len >= buf_cap - 1) break;
-            ssize_t n = esp_tls_conn_read(tls, buf + buf_len, buf_cap - buf_len - 1);
+            ssize_t n = shq_tls_read(tls, buf + buf_len, buf_cap - buf_len - 1);
             if (n <= 0) break;
             buf_len += n;
         }
@@ -301,6 +308,7 @@ static int shq_http_request(esp_tls_t *tls, const char *method,
                             const char *body, const char *content_type,
                             char **body_out, size_t *body_len)
 {
+    s_request_deadline = esp_timer_get_time() + (int64_t)SHQ_TIMEOUT_MS * 1000;
     /* Build request line + headers */
     char req[2048];
     int pos = 0;
@@ -574,7 +582,10 @@ static esp_err_t shq_wait_import(esp_tls_t *tls, const char *import_id)
         cJSON_Delete(root);
         if (complete) return ESP_OK;
         if (failed) return ESP_FAIL;
-        vTaskDelay(pdMS_TO_TICKS(2000));
+        for (int slice = 0; slice < 100; ++slice) {
+            if (uploader_should_cancel()) return ESP_ERR_INVALID_STATE;
+            vTaskDelay(pdMS_TO_TICKS(20));
+        }
     }
     return ESP_ERR_TIMEOUT;
 }
@@ -593,6 +604,7 @@ static upload_result_t shq_upload_file(esp_tls_t *tls,
                                        const char *filename,
                                        bool filename_first)
 {
+    s_request_deadline = esp_timer_get_time() + (int64_t)SHQ_TIMEOUT_MS * 1000;
     FILE *f = fopen(local_path, "rb");
     if (!f) {
         ESP_LOGW(TAG, "  cannot open %s", local_path);
@@ -781,6 +793,7 @@ static upload_result_t shq_upload_file(esp_tls_t *tls,
  * The root bundle is sent for every import, not just when it changed: without
  * STR.edf the sessions in that import cannot be interpreted. */
 
+static uploader_config_t s_prepared_config;
 static esp_tls_t *s_tls;                  /* live for the whole run */
 static char s_import_id[32];
 static int  s_day_files;                  /* files sent in the current import */
@@ -790,16 +803,21 @@ static bool shq_is_configured(void)
     return uploader_is_sleephq_configured();
 }
 
-static upload_result_t shq_session_begin(void)
+/* DNS and TLS handshake can contain synchronous SDK work. Prepare performs
+ * both before the SD lease, so even a stalled handshake cannot deny recording.
+ * Retries under a lease are forbidden; the next pass prepares a new session. */
+static upload_result_t shq_prepare(void)
 {
-    uploader_config_t cfg;
-    uploader_load_config(&cfg);
-    if (!cfg.shq_client_id[0] || !cfg.shq_client_secret[0])
+    uploader_load_config(&s_prepared_config);
+    if (!s_prepared_config.shq_client_id[0] || !s_prepared_config.shq_client_secret[0])
         return UPLOAD_NOT_CONFIGURED;
-
+    char server_ip[INET_ADDRSTRLEN];
+    if (!uploader_resolve_host(SHQ_HOST, server_ip, sizeof(server_ip)))
+        return UPLOAD_ERR_TRANSIENT;
     esp_tls_cfg_t tls_cfg = {
         .crt_bundle_attach = esp_crt_bundle_attach,
         .timeout_ms = SHQ_TIMEOUT_MS,
+        .common_name = SHQ_HOST,
     };
 
     s_tls = esp_tls_init();
@@ -808,15 +826,27 @@ static upload_result_t shq_session_begin(void)
         return UPLOAD_ERR_TRANSIENT;
     }
 
-    char url[128];
-    snprintf(url, sizeof(url), "https://%s", SHQ_HOST);
-    if (esp_tls_conn_http_new_sync(url, &tls_cfg, s_tls) != 1) {
+    if (esp_tls_conn_new_sync(server_ip, strlen(server_ip), SHQ_PORT, &tls_cfg, s_tls) != 1) {
         ESP_LOGE(TAG, "TLS connect to %s failed", SHQ_HOST);
         esp_tls_conn_destroy(s_tls);
         s_tls = NULL;
         return UPLOAD_ERR_TRANSIENT;
     }
+    int fd = -1;
+    if (esp_tls_get_conn_sockfd(s_tls, &fd) != ESP_OK || fd < 0 ||
+        fcntl(fd, F_SETFL, fcntl(fd, F_GETFL, 0) | O_NONBLOCK) < 0 ||
+        uploader_should_cancel()) {
+        esp_tls_conn_destroy(s_tls); s_tls = NULL; return UPLOAD_CANCELLED;
+    }
+    return UPLOAD_OK;
+}
+
+static upload_result_t shq_session_begin(void)
+{
+    const uploader_config_t cfg = s_prepared_config;
+    if (!s_tls || uploader_should_cancel()) return UPLOAD_CANCELLED;
     ESP_LOGI(TAG, "TLS connected to %s", SHQ_HOST);
+
 
     if (shq_authenticate(s_tls, &cfg) != ESP_OK) {
         ESP_LOGE(TAG, "authentication failed");
@@ -903,46 +933,21 @@ static bool shq_test(char *msg, size_t msg_len)
 
 static upload_result_t shq_day_begin(const char *day)
 {
-    if (!s_tls) {
-        if (shq_session_begin() != UPLOAD_OK)
-            return UPLOAD_ERR_TRANSIENT;
-    }
-    s_import_id[0] = '\0';
-    s_day_files = 0;
-
-    if (shq_create_import(s_tls, s_import_id, sizeof(s_import_id), false) != ESP_OK) {
-        /* TLS connection may have been closed by remote server. Try reconnecting once. */
-        ESP_LOGW(TAG, "import creation failed on existing TLS connection, reconnecting...");
-        shq_session_end();
-        if (shq_session_begin() != UPLOAD_OK ||
-            shq_create_import(s_tls, s_import_id, sizeof(s_import_id), false) != ESP_OK) {
-            ESP_LOGE(TAG, "import creation failed for day %s", day);
-            return UPLOAD_ERR_TRANSIENT;
-        }
-    }
-    ESP_LOGI(TAG, "day %s -> import %s", day, s_import_id);
+    (void)day;
+    if (!s_tls || uploader_should_cancel()) return UPLOAD_CANCELLED;
+    s_import_id[0] = '\0'; s_day_files = 0;
+    if (shq_create_import(s_tls, s_import_id, sizeof(s_import_id), false) != ESP_OK)
+        return UPLOAD_ERR_TRANSIENT;
     return UPLOAD_OK;
 }
 
 static upload_result_t shq_ox_day_begin(const char *day)
 {
-    if (!s_tls) {
-        if (shq_session_begin() != UPLOAD_OK)
-            return UPLOAD_ERR_TRANSIENT;
-    }
-    s_import_id[0] = '\0';
-    s_day_files = 0;
-    if (shq_create_import(s_tls, s_import_id, sizeof(s_import_id), true) != ESP_OK) {
-        /* TLS connection may have been closed by remote server. Try reconnecting once. */
-        ESP_LOGW(TAG, "O2 import creation failed on existing TLS connection, reconnecting...");
-        shq_session_end();
-        if (shq_session_begin() != UPLOAD_OK ||
-            shq_create_import(s_tls, s_import_id, sizeof(s_import_id), true) != ESP_OK) {
-            ESP_LOGE(TAG, "O2 import creation failed for day %s", day);
-            return UPLOAD_ERR_TRANSIENT;
-        }
-    }
-    ESP_LOGI(TAG, "O2 day %s -> import %s", day, s_import_id);
+    (void)day;
+    if (!s_tls || uploader_should_cancel()) return UPLOAD_CANCELLED;
+    s_import_id[0] = '\0'; s_day_files = 0;
+    if (shq_create_import(s_tls, s_import_id, sizeof(s_import_id), true) != ESP_OK)
+        return UPLOAD_ERR_TRANSIENT;
     return UPLOAD_OK;
 }
 
@@ -1039,6 +1044,7 @@ const upload_backend_t sleephq_backend = {
     .label = "SleepHQ Cloud",
     .bundle_only_ok = false,    /* would create an import with no sessions */
     .is_configured = shq_is_configured,
+    .prepare = shq_prepare,
     .session_begin = shq_session_begin,
     .day_begin = shq_day_begin,
     .put_group = shq_put_group,
@@ -1050,3 +1056,6 @@ const upload_backend_t sleephq_backend = {
     .session_end = shq_session_end,
     .test = shq_test,
 };
+
+/* Runs only on the scheduler owner, so its token/session cache cannot race an
+ * upload. OAuth and team lookup only: never creates an import or uploads data. */

--- a/components/uploader/uploader_smb.c
+++ b/components/uploader/uploader_smb.c
@@ -20,7 +20,6 @@
  * attribution "Based on SomnoTrace, originally created by Ilya Kruchinin
  * (https://github.com/ilyakruchinin)." See the NOTICE file for details.
  */
-
 #include "uploader.h"
 #include "upload_paths.h"
 
@@ -40,6 +39,7 @@
 #include "libsmb2-raw.h"
 #include <sys/time.h>
 #include <sys/poll.h>
+#include <arpa/inet.h>
 
 /* SD card paths — must match sd_storage.h */
 
@@ -50,18 +50,92 @@ static const char *TAG = "upload_smb";
 
 /* ── Helpers ────────────────────────────────────────────────────────── */
 
-/* Sync callback for smb2_cmd_set_info_async */
-struct set_info_sync {
-    int is_finished;
-    int status;
-};
-
-static void set_info_cb(struct smb2_context *smb2, int status,
-                        void *command_data, void *private_data)
+/* The scheduler owns this context. Abort destroys queued PDUs before returning
+ * to callers that own their write buffers or file handles. Callback storage
+ * lives through destruction, including libsmb2's cancellation callbacks. */
+static struct smb2_context *s_smb;
+static struct { bool finished; int status; void *data; } s_wait;
+static void smb_wait_cb(struct smb2_context *ctx, int status, void *data, void *arg)
 {
-    struct set_info_sync *sync = private_data;
-    sync->is_finished = 1;
-    sync->status = status;
+    (void)ctx; (void)arg;
+    s_wait.status = status; s_wait.data = data; s_wait.finished = true;
+}
+static void smb_abort(void)
+{
+    struct smb2_context *ctx = s_smb;
+    s_smb = NULL;
+    if (ctx) smb2_destroy_context(ctx);
+}
+static const char *smb_error(struct smb2_context *ctx)
+{
+    return ctx && ctx == s_smb ? smb2_get_error(ctx) : "operation cancelled/expired";
+}
+static bool smb_wait_begin(struct smb2_context *ctx)
+{
+    if (!ctx || ctx != s_smb) return false;
+    if (uploader_should_cancel()) { smb_abort(); return false; }
+    memset(&s_wait, 0, sizeof(s_wait));
+    return true;
+}
+static int smb_wait_result(struct smb2_context *ctx, int submitted)
+{
+    if (submitted < 0) { smb_abort(); return submitted; }
+    const int64_t deadline = esp_timer_get_time() + 5000000;
+    while (!s_wait.finished) {
+        if (uploader_should_cancel() || esp_timer_get_time() >= deadline) {
+            smb_abort(); return -ECANCELED;
+        }
+        struct pollfd pfd = { .fd = smb2_get_fd(ctx), .events = smb2_which_events(ctx) };
+        int rc = poll(&pfd, 1, 20);
+        if (rc < 0 && errno == EINTR) continue;
+        /* Service idle polls as well, so libsmb2's own timeout machinery runs. */
+        if (rc < 0 || smb2_service(ctx, pfd.revents) < 0) {
+            smb_abort(); return -EIO;
+        }
+    }
+    return s_wait.status;
+}
+static int smb_connect(struct smb2_context *ctx, const char *host, const char *share, const char *user)
+{
+    if (!smb_wait_begin(ctx)) return -ECANCELED;
+    return smb_wait_result(ctx, smb2_connect_share_async(ctx, host, share, user, smb_wait_cb, NULL));
+}
+static int smb_mkdir(struct smb2_context *ctx, const char *path)
+{
+    if (!smb_wait_begin(ctx)) return -ECANCELED;
+    return smb_wait_result(ctx, smb2_mkdir_async(ctx, path, smb_wait_cb, NULL));
+}
+static struct smb2fh *smb_open(struct smb2_context *ctx, const char *path, int flags)
+{
+    if (!smb_wait_begin(ctx)) return NULL;
+    return smb_wait_result(ctx, smb2_open_async(ctx, path, flags, smb_wait_cb, NULL)) < 0
+           ? NULL : s_wait.data;
+}
+static int smb_write(struct smb2_context *ctx, struct smb2fh *fh, const uint8_t *buf, uint32_t len, uint64_t off)
+{
+    if (!smb_wait_begin(ctx)) return -ECANCELED;
+    return smb_wait_result(ctx, smb2_pwrite_async(ctx, fh, buf, len, off, smb_wait_cb, NULL));
+}
+static int smb_write_all(struct smb2_context *ctx, struct smb2fh *fh,
+                         const uint8_t *buf, uint32_t len, uint64_t off)
+{
+    uint32_t sent = 0;
+    while (sent < len) {
+        int n = smb_write(ctx, fh, buf + sent, len - sent, off + sent);
+        if (n <= 0 || (uint32_t)n > len - sent) return -EIO;
+        sent += (uint32_t)n;
+    }
+    return (int)sent;
+}
+static int smb_close(struct smb2_context *ctx, struct smb2fh *fh)
+{
+    if (!smb_wait_begin(ctx)) return -ECANCELED;
+    return smb_wait_result(ctx, smb2_close_async(ctx, fh, smb_wait_cb, NULL));
+}
+static int smb_disconnect(struct smb2_context *ctx)
+{
+    if (!smb_wait_begin(ctx)) return -ECANCELED;
+    return smb_wait_result(ctx, smb2_disconnect_share_async(ctx, smb_wait_cb, NULL));
 }
 
 /* Set the last-write and change timestamps on an open SMB file handle
@@ -72,7 +146,7 @@ static int smb_set_mtime(struct smb2_context *smb2, struct smb2fh *fh,
 {
     struct smb2_file_basic_info bi;
     struct smb2_set_info_request si_req;
-    struct set_info_sync sync = {0, 0};
+    if (!smb_wait_begin(smb2)) return -ECANCELED;
     struct smb2_pdu *pdu;
 
     memset(&bi, 0, sizeof(bi));
@@ -95,7 +169,7 @@ static int smb_set_mtime(struct smb2_context *smb2, struct smb2fh *fh,
     memcpy(si_req.file_id, fid, SMB2_FD_SIZE);
     si_req.input_data = &bi;
 
-    pdu = smb2_cmd_set_info_async(smb2, &si_req, set_info_cb, &sync);
+    pdu = smb2_cmd_set_info_async(smb2, &si_req, smb_wait_cb, NULL);
     if (!pdu) {
         ESP_LOGW(TAG, "  smb2_cmd_set_info_async failed: %s",
                  smb2_get_error(smb2));
@@ -103,25 +177,7 @@ static int smb_set_mtime(struct smb2_context *smb2, struct smb2fh *fh,
     }
     smb2_queue_pdu(smb2, pdu);
 
-    /* Poll loop — same pattern as libsmb2's sync.c wait_for_reply() */
-    while (!sync.is_finished) {
-        struct pollfd pfd;
-        memset(&pfd, 0, sizeof(pfd));
-        pfd.fd = smb2_get_fd(smb2);
-        pfd.events = smb2_which_events(smb2);
-        if (poll(&pfd, 1, 1000) < 0) {
-            ESP_LOGW(TAG, "  set_info poll failed");
-            return -1;
-        }
-        if (pfd.revents == 0) continue;
-        if (smb2_service(smb2, pfd.revents) < 0) {
-            ESP_LOGW(TAG, "  set_info smb2_service failed: %s",
-                     smb2_get_error(smb2));
-            return -1;
-        }
-    }
-
-    return sync.status;
+    return smb_wait_result(smb2, 0);
 }
 
 /* Upload a single local file to an SMB path. */
@@ -141,10 +197,10 @@ static upload_result_t smb_upload_file(struct smb2_context *smb2,
     fseek(f, 0, SEEK_SET);
 
     /* Open remote file for writing */
-    struct smb2fh *fh = smb2_open(smb2, remote_path, O_WRONLY | O_CREAT);
+    struct smb2fh *fh = smb_open(smb2, remote_path, O_WRONLY | O_CREAT | O_TRUNC);
     if (!fh) {
-        ESP_LOGW(TAG, "  smb2_open(%s) failed: %s", remote_path,
-                 smb2_get_error(smb2));
+        ESP_LOGW(TAG, "  smb_open(%s) failed: %s", remote_path,
+                 smb_error(smb2));
         /* Try creating parent directory and retry */
         char dir_path[512];
         strlcpy(dir_path, remote_path, sizeof(dir_path));
@@ -152,12 +208,12 @@ static upload_result_t smb_upload_file(struct smb2_context *smb2,
         if (slash) {
             *slash = '\0';
             ESP_LOGI(TAG, "  trying mkdir %s", dir_path);
-            smb2_mkdir(smb2, dir_path);
+            smb_mkdir(smb2, dir_path);
             *slash = '/';
         }
-        fh = smb2_open(smb2, remote_path, O_WRONLY | O_CREAT);
+        fh = smb_open(smb2, remote_path, O_WRONLY | O_CREAT | O_TRUNC);
         if (!fh) {
-            ESP_LOGE(TAG, "  smb2_open retry failed: %s", smb2_get_error(smb2));
+            ESP_LOGE(TAG, "  smb2_open retry failed: %s", smb_error(smb2));
             fclose(f);
             return UPLOAD_FAILED;
         }
@@ -170,7 +226,7 @@ static upload_result_t smb_upload_file(struct smb2_context *smb2,
     }
     if (!buf) {
         ESP_LOGE(TAG, "  buffer alloc failed");
-        smb2_close(smb2, fh);
+        smb_close(smb2, fh);
         fclose(f);
         return UPLOAD_FAILED;
     }
@@ -186,12 +242,12 @@ static upload_result_t smb_upload_file(struct smb2_context *smb2,
         size_t rd = fread(buf, 1, to_read, f);
         if (rd == 0) break;
 
-        int wr = smb2_pwrite(smb2, fh, buf, rd, total_written);
-        if (wr < 0) {
+        int wr = smb_write_all(smb2, fh, buf, rd, total_written);
+        if (wr <= 0) {
             ESP_LOGE(TAG, "  smb2_pwrite failed at offset %u: %s",
-                     (unsigned)total_written, smb2_get_error(smb2));
+                     (unsigned)total_written, smb_error(smb2));
             free(buf);
-            smb2_close(smb2, fh);
+            smb_close(smb2, fh);
             fclose(f);
             return UPLOAD_FAILED;
         }
@@ -209,6 +265,10 @@ static upload_result_t smb_upload_file(struct smb2_context *smb2,
 
     free(buf);
 
+    if (total_written != file_size || uploader_should_cancel()) {
+        smb_close(smb2, fh); fclose(f); return UPLOAD_FAILED;
+    }
+
     /* Set remote file timestamps to match local file mtime */
     struct stat local_st;
     if (stat(local_path, &local_st) == 0) {
@@ -218,8 +278,9 @@ static upload_result_t smb_upload_file(struct smb2_context *smb2,
         }
     }
 
-    smb2_close(smb2, fh);
+    int close_rc = smb_close(smb2, fh);
     fclose(f);
+    if (close_rc != 0 || uploader_should_cancel()) return UPLOAD_FAILED;
 
     ESP_LOGI(TAG, "  uploaded %s (%u bytes)", remote_path, (unsigned)total_written);
     return UPLOAD_OK;
@@ -232,7 +293,15 @@ static upload_result_t smb_upload_file(struct smb2_context *smb2,
  * remote folder exists.  Group transfers are all-or-nothing so the scheduler
  * can mark a unit uploaded only when every file in it landed. */
 
-static struct smb2_context *s_smb;      /* live for the whole run */
+static char s_server_ip[INET_ADDRSTRLEN];
+static uploader_config_t s_prepared_config;
+
+static upload_result_t smb_prepare(void)
+{
+    uploader_load_config(&s_prepared_config);
+    return uploader_resolve_host(s_prepared_config.smb_host, s_server_ip, sizeof(s_server_ip))
+        ? UPLOAD_OK : UPLOAD_ERR_TRANSIENT;
+}
 static char s_remote_base[256];
 
 static bool smb_is_configured(void)
@@ -242,10 +311,10 @@ static bool smb_is_configured(void)
 
 static upload_result_t smb_session_begin(void)
 {
-    uploader_config_t cfg;
-    uploader_load_config(&cfg);
+    const uploader_config_t cfg = s_prepared_config;
     if (!cfg.smb_host[0] || !cfg.smb_share[0]) return UPLOAD_NOT_CONFIGURED;
 
+    if (uploader_should_cancel() || !s_server_ip[0]) return UPLOAD_CANCELLED;
     s_smb = smb2_init_context();
     if (!s_smb) {
         ESP_LOGE(TAG, "smb2_init_context failed");
@@ -259,11 +328,10 @@ static upload_result_t smb_session_begin(void)
     ESP_LOGI(TAG, "connecting to %s/%s as %s", cfg.smb_host, cfg.smb_share,
              cfg.smb_user[0] ? cfg.smb_user : "Guest");
 
-    if (smb2_connect_share(s_smb, cfg.smb_host, cfg.smb_share,
+    if (smb_connect(s_smb, s_server_ip, cfg.smb_share,
                            cfg.smb_user[0] ? cfg.smb_user : "Guest") != 0) {
-        ESP_LOGE(TAG, "smb2_connect_share failed: %s", smb2_get_error(s_smb));
-        smb2_destroy_context(s_smb);
-        s_smb = NULL;
+        ESP_LOGE(TAG, "smb2_connect_share failed: %s", smb_error(s_smb));
+        smb_abort();
         /* Unreachable host and bad credentials are indistinguishable here
          * without parsing the error text, so treat as transient and let the
          * cooldown ladder slow it down. */
@@ -279,16 +347,15 @@ static upload_result_t smb_session_begin(void)
 
     char remote_datalog[400];
     snprintf(remote_datalog, sizeof(remote_datalog), "%s/DATALOG", s_remote_base);
-    smb2_mkdir(s_smb, remote_datalog);
+    smb_mkdir(s_smb, remote_datalog);
     return UPLOAD_OK;
 }
 
 static void smb_session_end(void)
 {
     if (!s_smb) return;
-    smb2_disconnect_share(s_smb);
-    smb2_destroy_context(s_smb);
-    s_smb = NULL;
+    smb_disconnect(s_smb);
+    smb_abort();
 }
 
 /* ── "Test connection" (web UI) ───────────────────────────────────────
@@ -359,7 +426,7 @@ static upload_result_t smb_day_begin(const char *day)
     if (!s_smb) return UPLOAD_ERR_TRANSIENT;
     char remote_day[512];
     snprintf(remote_day, sizeof(remote_day), "%s/DATALOG/%s", s_remote_base, day);
-    smb2_mkdir(s_smb, remote_day);   /* EEXIST is fine */
+    smb_mkdir(s_smb, remote_day);   /* EEXIST is fine */
     return UPLOAD_OK;
 }
 
@@ -396,7 +463,7 @@ static upload_result_t smb_put_bundle(const char *day,
     char remote_settings[400];
     snprintf(remote_settings, sizeof(remote_settings), "%s/SETTINGS",
              s_remote_base);
-    smb2_mkdir(s_smb, remote_settings);
+    smb_mkdir(s_smb, remote_settings);
 
     int count = 0;
     for (int i = 0; i < b->n_files; i++) {
@@ -420,8 +487,8 @@ static upload_result_t smb_ox_day_begin(const char *day)
 {
     if (!s_smb || !day) return UPLOAD_ERR_TRANSIENT;
     char path[640];
-    snprintf(path, sizeof(path), "%s/OXYMETRY", s_remote_base); smb2_mkdir(s_smb, path);
-    snprintf(path, sizeof(path), "%s/OXYMETRY/%s", s_remote_base, day); smb2_mkdir(s_smb, path);
+    snprintf(path, sizeof(path), "%s/OXYMETRY", s_remote_base); smb_mkdir(s_smb, path);
+    snprintf(path, sizeof(path), "%s/OXYMETRY/%s", s_remote_base, day); smb_mkdir(s_smb, path);
     return UPLOAD_OK;
 }
 
@@ -453,6 +520,7 @@ const upload_backend_t smb_backend = {
     .label = "SMB Network Share",
     .bundle_only_ok = true,     /* plain file copy, no side effects */
     .is_configured = smb_is_configured,
+    .prepare = smb_prepare,
     .session_begin = smb_session_begin,
     .day_begin = smb_day_begin,
     .put_group = smb_put_group,

--- a/docs/flashing.md
+++ b/docs/flashing.md
@@ -9,7 +9,9 @@
 1. **Waveshare ESP32-S3-Touch-LCD-1.54** board (Touch variant with battery preferred — [Buy on Waveshare](https://www.waveshare.com/esp32-s3-lcd-1.54.htm?sku=33869)).
 2. **USB-C Data Cable** (make sure it is a *data* cable, not a charge-only cable).
 3. **Computer with a modern browser**: Google Chrome, Microsoft Edge, Brave, or Opera (these browsers support Web Serial).
-4. **MicroSD card** (formatted as FAT32 or exFAT, 8 GB to 32 GB recommended) inserted into the board's SD slot.
+4. **MicroSD card** (8 GB to 32 GB recommended), prepared as one FAT32 volume
+   using a Master Boot Record (MBR) partition scheme and inserted while the
+   board is powered off.
 
 ---
 
@@ -102,4 +104,7 @@ Once Wi-Fi is configured, the next step is to pair SomnoTrace with your CPAP ove
   - Try another USB-C cable (many cables included with phones/vapes are power-only and cannot transfer data).
   - Hold the **BOOT** button while plugging the board into your computer.
 - **SD Card Error on screen?**  
-  Ensure your MicroSD card is inserted securely into the slot before powering on, and that it is formatted as FAT32 or exFAT.
+  Power the board off, ensure the MicroSD card is seated securely, and then
+  restart it. The firmware detects and mounts the card only during boot. The
+  card must contain one FAT32 volume using a Master Boot Record (MBR) partition
+  scheme; exFAT and GUID Partition Map (GPT) cards will not mount.

--- a/docs/hardware/waveshare-7b.md
+++ b/docs/hardware/waveshare-7b.md
@@ -1,0 +1,11 @@
+# Waveshare ESP32-S3-Touch-LCD-7B
+
+Select `CONFIG_SOMNOTRACE_BOARD_WAVESHARE_7B` or run `scripts/build-7b.sh` for the 1024×600 RGB target. The original 240×240 SPI display remains the default board. Use a 16 MB flash / 8 MB octal PSRAM module.
+
+The RGB timing is 30.85 MHz, with two PSRAM framebuffers and a ten-line bounce buffer. LVGL renders on the RGB interrupt core and waits for positive frame retirement before reusing scanout memory. These constraints protect ownership; physical tearing and timing still require board testing.
+
+GT911 uses SDA8, SCL9 and INT4; the CH32V003 controller at address 0x24 owns reset, panel power, backlight and TF chip select. Touch observation runs separately from rendering and cancels gestures after errors or stale input. Visibility recovery reasserts the output controller, and a failed wake retries. The status screen consumes the public display APIs and includes a wake-only Screen off control.
+
+The TF socket uses one-bit SDMMC with CLK12, CMD11 and D0=13. The hardware has no supported alert speaker or battery telemetry. Do not use the compact board GPIO2/GPIO0 power/button controls: those pins carry RGB data on this board.
+
+The 1–200 stored brightness range maps to 1–100% on 7B. The default is the steady 100% endpoint. `scripts/test-platform4.sh` exercises host allocation, input recovery, and framebuffer contracts; its first run resolves the exact hash-verified LVGL 8.4.0 input source if IDF has not populated managed components.

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,14 +1,21 @@
-idf_component_register(SRCS "main.c" "bsp_power.c" "bsp_display.c" "net_provision.c" "as11_ble.c"
+set(SOMNOTRACE_BSP_SRCS "bsp_power.c" "bsp_display.c" "bsp_audio.c" "bsp_i2c.c" "bsp_touch.c")
+set(SOMNOTRACE_DISPLAY_REQUIRES)
+if(CONFIG_SOMNOTRACE_BOARD_WAVESHARE_7B)
+    set(SOMNOTRACE_BSP_SRCS "board_waveshare_7b.c" "bsp_power_7b.c" "bsp_display_7b.c" "bsp_audio_7b.c" "touch_observation.c" "controller_diagnostics.c")
+    set(SOMNOTRACE_DISPLAY_REQUIRES lvgl esp_lcd_touch_gt911)
+endif()
+
+idf_component_register(SRCS "main.c" ${SOMNOTRACE_BSP_SRCS} "net_provision.c" "as11_ble.c"
                            "sd_storage.c" "session_writer.c" "time_sync.c"
                            "post_therapy.c" "edf_gen.c" "edf_header.c" "edf_waveform.c" "edf_annotations.c" "edf_summary.c" "log_stream.c" "device_settings.c"
-                           "psram_task.c" "bsp_audio.c" "bsp_i2c.c" "bsp_touch.c" "session_graph.c" "nvs_writer.c"
+                           "psram_task.c" "session_graph.c" "nvs_writer.c"
                            "as11_time.c"
                            "crash_diag.c"
                            "oximeter.c" "oximeter_oxyii.c" "oximeter_legacy.c" "oximeter_store.c" "oximetry_vld3.c" "oximetry_canonical.c" "oximetry_http.c"
                        INCLUDE_DIRS "."
                        REQUIRES esp_lcd driver esp_wifi esp_netif esp_event nvs_flash esp_http_server json esp_app_format
                                 bt mbedtls esp_rom fatfs sdmmc esp-idf-ftpServer uploader esp_http_client
-                                esp_driver_i2c esp_driver_i2s esp_adc app_update espcoredump esp_https_ota therapy_alert esp_coex)
+                                esp_driver_i2c esp_driver_i2s esp_adc app_update espcoredump esp_https_ota therapy_alert esp_coex ${SOMNOTRACE_DISPLAY_REQUIRES})
 
 # Download zones.json (IANA-to-POSIX timezone database) if not present.
 # Source: https://github.com/nayarsystems/posix_tz_db (MIT License)

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -1,0 +1,15 @@
+menu "SomnoTrace hardware"
+
+choice SOMNOTRACE_BOARD
+    prompt "Target board"
+    default SOMNOTRACE_BOARD_WAVESHARE_154
+
+config SOMNOTRACE_BOARD_WAVESHARE_154
+    bool "Waveshare ESP32-S3-Touch-LCD-1.54"
+
+config SOMNOTRACE_BOARD_WAVESHARE_7B
+    bool "Waveshare ESP32-S3-Touch-LCD-7B (1024x600)"
+
+endchoice
+
+endmenu

--- a/main/as11_ble.c
+++ b/main/as11_ble.c
@@ -224,6 +224,7 @@ static int s_rx_len;
 typedef struct {
     uint8_t *data;
     int      len;
+    uint32_t epoch;
 } notif_item_t;
 static QueueHandle_t s_notif_queue = NULL;
 /* Backlog metrics — see BLE_GAP_EVENT_NOTIFY_RX. */
@@ -232,6 +233,22 @@ static uint32_t    s_notif_dropped = 0;
 static uint32_t    s_notif_dropped_bytes = 0;
 static uint32_t    s_notif_alloc_fail = 0;
 static TaskHandle_t  s_notif_task  = NULL;
+static uint32_t s_notif_epoch;
+static bool s_notif_loss_pending, s_notif_drop_until_connect;
+
+/* Host callback publishes uncertainty without decrypting or waiting. The owner
+ * drops partial FIG state and retained samples before accepting a new link. */
+static void notif_mark_loss(void)
+{
+    __atomic_add_fetch(&s_notif_epoch, 1, __ATOMIC_ACQ_REL);
+    __atomic_store_n(&s_notif_loss_pending, true, __ATOMIC_RELEASE);
+    bool first = !__atomic_exchange_n(&s_notif_drop_until_connect, true, __ATOMIC_ACQ_REL);
+    therapy_alert_on_transport_loss();
+    if (first && s_conn_handle != BLE_HS_CONN_HANDLE_NONE)
+        ble_gap_terminate(s_conn_handle, BLE_ERR_REM_USER_CONN_TERM);
+}
+
+
 /* Spool publication and fragment mutation are serialized by a dedicated
  * mutex, never held while waiting for BLE/network responses. Withdrawal waits
  * for any in-flight decoder before freeing the collector or its semaphore. */
@@ -752,15 +769,70 @@ static void rpc_accept_response(cJSON *msg)
 
 static void handle_notify(const uint8_t *data, int len);
 
+/* Only the notification owner accesses this bounded decoded queue. No
+ * admission retry waits; later lifecycle notifications continue to dispatch. */
+#define PENDING_STREAM_COUNT 32
+#define PENDING_STREAM_BYTES (64 * 1024)
+static struct { char *json; int len; } s_pending_stream[PENDING_STREAM_COUNT];
+static unsigned s_pending_head, s_pending_count;
+static size_t s_pending_bytes;
+static void pending_stream_clear(void)
+{
+    while (s_pending_count) {
+        free(s_pending_stream[s_pending_head].json);
+        s_pending_head = (s_pending_head + 1) % PENDING_STREAM_COUNT;
+        --s_pending_count;
+    }
+    s_pending_bytes = 0;
+}
+static void pending_stream_replay(void)
+{
+    /* Four decoded batches per turn bounds work ahead of a queued STOP. */
+    for (unsigned i = 0; i < 4 && s_pending_count; ++i) {
+        char *json = s_pending_stream[s_pending_head].json;
+        int len = s_pending_stream[s_pending_head].len;
+        if (!session_writer_try_stream_data_raw(json, len)) break;
+        free(json); s_pending_bytes -= len;
+        s_pending_head = (s_pending_head + 1) % PENDING_STREAM_COUNT;
+        --s_pending_count;
+    }
+}
+static void pending_stream_submit(const char *json, int len)
+{
+    if (!s_pending_count && session_writer_try_stream_data_raw(json, len)) return;
+    if (len <= 0 || s_pending_count == PENDING_STREAM_COUNT ||
+        (size_t)len > PENDING_STREAM_BYTES - s_pending_bytes) {
+        pending_stream_clear(); notif_mark_loss(); return;
+    }
+    char *copy = heap_caps_malloc((size_t)len + 1, MALLOC_CAP_SPIRAM);
+    if (!copy) { pending_stream_clear(); notif_mark_loss(); return; }
+    memcpy(copy, json, len); copy[len] = '\0';
+    unsigned tail = (s_pending_head + s_pending_count) % PENDING_STREAM_COUNT;
+    s_pending_stream[tail].json = copy; s_pending_stream[tail].len = len;
+    ++s_pending_count; s_pending_bytes += len;
+}
+
 static void notif_proc_task(void *arg)
 {
     (void)arg;
     notif_item_t item;
-    while (1) {
-        if (xQueueReceive(s_notif_queue, &item, portMAX_DELAY) == pdTRUE) {
-            handle_notify(item.data, item.len);
-            free(item.data);
+    uint32_t owner_epoch = 0;
+    for (;;) {
+        if (__atomic_exchange_n(&s_notif_loss_pending, false, __ATOMIC_ACQ_REL)) {
+            pending_stream_clear(); s_rx_len = 0;
+            session_writer_on_transport_loss();
         }
+        if (xQueueReceive(s_notif_queue, &item, pdMS_TO_TICKS(20)) == pdTRUE) {
+            uint32_t epoch = __atomic_load_n(&s_notif_epoch, __ATOMIC_ACQUIRE);
+            if (owner_epoch != epoch) { s_rx_len = 0; owner_epoch = epoch; }
+            if (item.epoch == epoch &&
+                !__atomic_load_n(&s_notif_drop_until_connect, __ATOMIC_ACQUIRE))
+                handle_notify(item.data, item.len);
+            free(item.data);
+            bsp_display_note_as11_notification_processed();
+        }
+        if (!__atomic_load_n(&s_notif_loss_pending, __ATOMIC_ACQUIRE))
+            pending_stream_replay();
     }
 }
 
@@ -769,6 +841,7 @@ static void handle_notify(const uint8_t *data, int len)
     ESP_LOGD(TAG, "handle_notify: len=%d", len);
     if (s_rx_len + len > RX_BUF_MAX) {
         ESP_LOGW(TAG, "rx buffer overflow, resetting");
+        notif_mark_loss();
         s_rx_len = 0;
         return;
     }
@@ -781,12 +854,16 @@ static void handle_notify(const uint8_t *data, int len)
     if (!decrypted) decrypted = heap_caps_malloc(RX_BUF_MAX, MALLOC_CAP_SPIRAM);
     if (!payload || !decrypted) {
         ESP_LOGE(TAG, "handle_notify: failed to allocate PSRAM decrypt buffers");
+        notif_mark_loss();
         s_rx_len = 0;
         return;
     }
     uint16_t vcid;
     int n;
     while ((n = fig_take_packet(payload, RX_BUF_MAX - 1, &vcid)) >= 0) {
+        if (__atomic_load_n(&s_notif_drop_until_connect, __ATOMIC_ACQUIRE)) {
+            s_rx_len = 0; break;
+        }
         ESP_LOGD(TAG, "FIG packet received: vcid=0x%04x len=%d", vcid, n);
         ESP_LOG_BUFFER_HEX_LEVEL(TAG, payload, n > 64 ? 64 : n, ESP_LOG_DEBUG);
 
@@ -798,6 +875,7 @@ static void handle_notify(const uint8_t *data, int len)
             int dlen = aes_cbc_decrypt(s_session_key, payload, n,
                                        decrypted, RX_BUF_MAX - 1);
             if (dlen < 0) {
+                notif_mark_loss();
                 ESP_LOGW(TAG, "AES decrypt failed for vcid=0x%04x len=%d", vcid, n);
                 continue;
             }
@@ -817,7 +895,7 @@ static void handle_notify(const uint8_t *data, int len)
             /* Ensure null-terminated for strstr */
             ((char *)parse_ptr)[parse_len] = '\0';
             if (strstr((const char *)parse_ptr, "\"method\":\"StreamData\"") != NULL) {
-                session_writer_on_stream_data_raw((const char *)parse_ptr, parse_len);
+                pending_stream_submit((const char *)parse_ptr, parse_len);
                 continue;
             }
         }
@@ -937,7 +1015,9 @@ static void handle_notify(const uint8_t *data, int len)
             /* Normal notification (HeartBeat, therapy events, data).
              * Forward to session writer for therapy detection and data logging. */
             ESP_LOGD(TAG, "notification: %s", m);
-            session_writer_on_notification(session_writer_get_active(), msg);
+            uint32_t stream_epoch = session_writer_stream_epoch();
+            session_writer_on_notification(NULL, msg);
+            if (stream_epoch != session_writer_stream_epoch()) pending_stream_clear();
             cJSON_Delete(msg);
             continue;
         }
@@ -1051,6 +1131,8 @@ static int gap_event(struct ble_gap_event *event, void *arg)
         s_connect_status = event->connect.status;
         if (event->connect.status == 0) {
             s_conn_handle = event->connect.conn_handle;
+            __atomic_add_fetch(&s_notif_epoch, 1, __ATOMIC_ACQ_REL);
+            __atomic_store_n(&s_notif_drop_until_connect, false, __ATOMIC_RELEASE);
             s_manual_disconnect = false;
         }
         xSemaphoreGive(s_connect_sem);
@@ -1104,7 +1186,13 @@ static int gap_event(struct ble_gap_event *event, void *arg)
     case BLE_GAP_EVENT_NOTIFY_RX: {
         uint16_t notif_len = OS_MBUF_PKTLEN(event->notify_rx.om);
         ESP_LOGD(TAG, "Notification RX: handle=%d len=%d", event->notify_rx.attr_handle, notif_len);
-        if (notif_len > 0 && s_notif_queue) {
+        /* Close the raw-RX-to-worker race before allocation, copy, or queue
+         * publication. Every failure path below gives this accounting back. */
+        bool lifecycle_accounted = notif_len > 0;
+        if (lifecycle_accounted)
+            bsp_display_note_as11_notification_queued();
+        if (notif_len > 0 && s_notif_queue &&
+            !__atomic_load_n(&s_notif_drop_until_connect, __ATOMIC_ACQUIRE)) {
             /* Queue-depth metrics.  Each element owns a separately malloc'd
              * payload, so depth translates into a real worst-case backlog —
              * the right way to size NOTIF_QUEUE_LEN is from the observed
@@ -1124,34 +1212,50 @@ static int gap_event(struct ble_gap_event *event, void *arg)
             if (notif_data) {
                 int rc = os_mbuf_copydata(event->notify_rx.om, 0, notif_len, notif_data);
                 if (rc == 0) {
-                    notif_item_t item = { .data = notif_data, .len = notif_len };
+                    notif_item_t item = { .data = notif_data, .len = notif_len,
+                        .epoch = __atomic_load_n(&s_notif_epoch, __ATOMIC_ACQUIRE) };
                     if (xQueueSend(s_notif_queue, &item, 0) != pdTRUE) {
-                        /* Queue full — drop oldest, then enqueue */
+                        notif_mark_loss();
+                        /* Queue full: account/discard queued old-generation data. */
                         notif_item_t dropped;
-                        xQueueReceive(s_notif_queue, &dropped, 0);
-                        s_notif_dropped++;
-                        s_notif_dropped_bytes += (uint32_t)dropped.len;
-                        free(dropped.data);
-                        xQueueSend(s_notif_queue, &item, 0);
-                        notif_data = NULL;  /* owned by queue now */
-                        ESP_LOGW(TAG, "notif queue full, dropped 1 item "
-                                 "(total %u items / %u bytes)",
-                                 (unsigned)s_notif_dropped,
-                                 (unsigned)s_notif_dropped_bytes);
+                        if (xQueueReceive(s_notif_queue, &dropped, 0) == pdTRUE) {
+                            bsp_display_note_as11_notification_processed();
+                            s_notif_dropped++;
+                            s_notif_dropped_bytes += (uint32_t)dropped.len;
+                            free(dropped.data);
+                        }
+                        if (xQueueSend(s_notif_queue, &item, 0) == pdTRUE) {
+                            notif_data = NULL;  /* owned by queue now */
+                            lifecycle_accounted = false;
+                            ESP_LOGW(TAG, "notif queue full, dropped 1 item "
+                                     "(total %u items / %u bytes)",
+                                     (unsigned)s_notif_dropped,
+                                     (unsigned)s_notif_dropped_bytes);
+                        } else {
+                            /* Undo this frame's pre-publication accounting if
+                             * the retry could not transfer queue ownership. */
+                            bsp_display_note_as11_notification_processed();
+                            lifecycle_accounted = false;
+                        }
                     } else {
                         notif_data = NULL;  /* owned by queue now */
+                        lifecycle_accounted = false;
                     }
                 } else {
+                    notif_mark_loss();
                     ESP_LOGE(TAG, "os_mbuf_copydata failed: %d", rc);
                 }
                 if (notif_data) free(notif_data);
             } else {
                 s_notif_alloc_fail++;
+                notif_mark_loss();
                 ESP_LOGE(TAG, "failed to allocate notif_data (%u bytes, "
                          "%u alloc failures)", (unsigned)notif_len,
                          (unsigned)s_notif_alloc_fail);
             }
         }
+        if (lifecycle_accounted)
+            bsp_display_note_as11_notification_processed();
         return 0;
     }
 
@@ -3196,101 +3300,87 @@ cJSON *as11_ble_get_values(const char *const *keys, int n_keys)
     return result;
 }
 
-static esp_err_t as11_ble_stop_therapy_locked(void)
+static esp_err_t therapy_command(const char *operation, const char *rpc,
+                                 bool *may_have_run)
 {
-    if (!s_session_encrypted) {
-        ESP_LOGW(TAG, "stop_therapy: no encrypted session");
+    if (may_have_run) *may_have_run = false;
+    if (!s_session_encrypted || strcmp(as11_ble_get_status(), AS11_STATUS_PAIRED) != 0) {
+        ESP_LOGW(TAG, "%s: encrypted session is not ready", operation);
         return ESP_ERR_INVALID_STATE;
     }
 
-    const char *rpc = "{\"id\":50,\"jsonrpc\":\"1.0\",\"method\":\"EnterStandby\"}";
+    if (!s_cmd_mtx ||
+        xSemaphoreTake(s_cmd_mtx, pdMS_TO_TICKS(10000)) != pdTRUE) {
+        ESP_LOGW(TAG, "%s: BLE command bus busy", operation);
+        return ESP_ERR_TIMEOUT;
+    }
+
     clear_response();
-    if (send_rpc_encrypted(rpc) != ESP_OK) {
-        ESP_LOGW(TAG, "stop_therapy: send failed");
-        return ESP_FAIL;
+    bool request_may_have_run = false;
+    esp_err_t send_result =
+        send_rpc_encrypted_tracked(rpc, &request_may_have_run);
+    if (may_have_run) *may_have_run = request_may_have_run;
+    if (send_result != ESP_OK) {
+        ESP_LOGW(TAG, "%s: send failed", operation);
+        xSemaphoreGive(s_cmd_mtx);
+        return send_result;
     }
 
     cJSON *resp = wait_response(10000);
     if (!resp) {
-        ESP_LOGW(TAG, "stop_therapy: timeout");
+        ESP_LOGW(TAG, "%s: timeout", operation);
+        xSemaphoreGive(s_cmd_mtx);
         return ESP_ERR_TIMEOUT;
     }
 
     cJSON *err = cJSON_GetObjectItem(resp, "error");
     if (err) {
+        /* A received JSON-RPC error is a definitive rejection, not an
+         * indeterminate post-send outcome. */
+        if (may_have_run) *may_have_run = false;
         char *s = cJSON_Print(err);
-        ESP_LOGW(TAG, "stop_therapy: RPC error: %s", s ? s : "?");
+        ESP_LOGW(TAG, "%s: RPC error: %s", operation, s ? s : "?");
         if (s) free(s);
         cJSON_Delete(resp);
+        xSemaphoreGive(s_cmd_mtx);
         return ESP_FAIL;
     }
 
-    ESP_LOGI(TAG, "stop_therapy: EnterStandby accepted");
+    ESP_LOGI(TAG, "%s: command accepted", operation);
     cJSON_Delete(resp);
+    xSemaphoreGive(s_cmd_mtx);
     return ESP_OK;
 }
 
 esp_err_t as11_ble_stop_therapy(void)
 {
-    if (!s_cmd_mtx || xSemaphoreTake(s_cmd_mtx, pdMS_TO_TICKS(10000)) != pdTRUE)
-        return ESP_ERR_TIMEOUT;
-    esp_err_t result = as11_ble_stop_therapy_locked();
-    clear_response();
-    xSemaphoreGive(s_cmd_mtx);
-    return result;
+    return therapy_command(
+        "stop_therapy",
+        "{\"id\":50,\"jsonrpc\":\"1.0\",\"method\":\"EnterStandby\"}",
+        NULL);
 }
 
-static esp_err_t as11_ble_start_therapy_locked(void)
+esp_err_t as11_ble_start_therapy_tracked(bool *may_have_started)
 {
-    if (!s_session_encrypted) {
-        ESP_LOGW(TAG, "start_therapy: no encrypted session");
-        return ESP_ERR_INVALID_STATE;
-    }
-
-    const char *rpc = "{\"id\":51,\"jsonrpc\":\"1.0\",\"method\":\"EnterTherapy\"}";
-    clear_response();
-    if (send_rpc_encrypted(rpc) != ESP_OK) {
-        ESP_LOGW(TAG, "start_therapy: send failed");
-        return ESP_FAIL;
-    }
-
-    cJSON *resp = wait_response(10000);
-    if (!resp) {
-        ESP_LOGW(TAG, "start_therapy: timeout");
-        return ESP_ERR_TIMEOUT;
-    }
-
-    cJSON *err = cJSON_GetObjectItem(resp, "error");
-    if (err) {
-        char *s = cJSON_Print(err);
-        ESP_LOGW(TAG, "start_therapy: RPC error: %s", s ? s : "?");
-        if (s) free(s);
-        cJSON_Delete(resp);
-        return ESP_FAIL;
-    }
-
-    ESP_LOGI(TAG, "start_therapy: EnterTherapy accepted");
-    cJSON_Delete(resp);
-    return ESP_OK;
+    if (!may_have_started) return ESP_ERR_INVALID_ARG;
+    return therapy_command(
+        "start_therapy",
+        "{\"id\":51,\"jsonrpc\":\"1.0\",\"method\":\"EnterTherapy\"}",
+        may_have_started);
 }
 
-esp_err_t as11_ble_start_therapy(void)
+esp_err_t as11_ble_passthrough_rpc_tracked(const char *json_in,
+                                           char **json_out,
+                                           uint32_t timeout_ms,
+                                           bool *may_have_run)
 {
-    if (!s_cmd_mtx || xSemaphoreTake(s_cmd_mtx, pdMS_TO_TICKS(10000)) != pdTRUE)
-        return ESP_ERR_TIMEOUT;
-    esp_err_t result = as11_ble_start_therapy_locked();
-    clear_response();
-    xSemaphoreGive(s_cmd_mtx);
-    return result;
-}
-
-esp_err_t as11_ble_passthrough_rpc(const char *json_in, char **json_out, uint32_t timeout_ms)
-{
+    if (!may_have_run) return ESP_ERR_INVALID_ARG;
+    *may_have_run = false;
     if (!json_in || !*json_in || !json_out) return ESP_ERR_INVALID_ARG;
     *json_out = NULL;
 
-    if (!s_session_encrypted) {
-        ESP_LOGW(TAG, "passthrough_rpc: no active encrypted BLE session");
+    if (!s_session_encrypted || strcmp(as11_ble_get_status(), AS11_STATUS_PAIRED) != 0) {
+        ESP_LOGW(TAG, "passthrough_rpc: encrypted BLE session is not ready");
         return ESP_ERR_INVALID_STATE;
     }
 
@@ -3300,10 +3390,12 @@ esp_err_t as11_ble_passthrough_rpc(const char *json_in, char **json_out, uint32_
     }
 
     clear_response();
-    if (send_rpc_encrypted(json_in) != ESP_OK) {
+    esp_err_t send_result =
+        send_rpc_encrypted_tracked(json_in, may_have_run);
+    if (send_result != ESP_OK) {
         ESP_LOGE(TAG, "passthrough_rpc: send_rpc_encrypted failed");
         xSemaphoreGive(s_cmd_mtx);
-        return ESP_FAIL;
+        return send_result;
     }
 
     cJSON *resp = wait_response((int)timeout_ms);

--- a/main/as11_ble.c
+++ b/main/as11_ble.c
@@ -143,9 +143,58 @@ static uint16_t s_mtu = 23;
 
 /* AS11 device clock captured before stream starts (epoch ms).
  * Used to compute clock_drift_ms at session stop without sending
- * RPCs during active streaming (which congests BLE buffers). */
-static int64_t s_as11_clock_ms = 0;
-static int64_t s_as11_clock_capture_ntp_ms = 0;
+ * RPCs during active streaming (which congests BLE buffers).  The two
+ * 64-bit timestamps and their wall-clock provenance are one atomic snapshot:
+ * readers must never observe fields from different reconnect attempts. */
+typedef struct {
+    int64_t as11_ms;
+    int64_t wall_ms;
+    time_source_t wall_source;
+    bool available;
+} as11_clock_capture_t;
+
+static as11_clock_capture_t s_as11_clock_capture = {
+    .wall_source = TIME_SRC_NONE,
+};
+static uint32_t s_as11_clock_generation;
+static portMUX_TYPE s_as11_clock_lock = portMUX_INITIALIZER_UNLOCKED;
+
+static uint32_t as11_clock_capture_invalidate(void)
+{
+    portENTER_CRITICAL(&s_as11_clock_lock);
+    uint32_t generation = ++s_as11_clock_generation;
+    s_as11_clock_capture.as11_ms = 0;
+    s_as11_clock_capture.wall_ms = 0;
+    s_as11_clock_capture.wall_source = TIME_SRC_NONE;
+    s_as11_clock_capture.available = false;
+    portEXIT_CRITICAL(&s_as11_clock_lock);
+    return generation;
+}
+
+static bool as11_clock_capture_store(uint32_t generation, int64_t as11_ms,
+                                     int64_t wall_ms,
+                                     time_source_t wall_source)
+{
+    portENTER_CRITICAL(&s_as11_clock_lock);
+    bool stored = generation == s_as11_clock_generation;
+    if (stored) {
+        s_as11_clock_capture.as11_ms = as11_ms;
+        s_as11_clock_capture.wall_ms = wall_ms;
+        s_as11_clock_capture.wall_source = wall_source;
+        s_as11_clock_capture.available = true;
+    }
+    portEXIT_CRITICAL(&s_as11_clock_lock);
+    return stored;
+}
+
+static as11_clock_capture_t as11_clock_capture_load(void)
+{
+    as11_clock_capture_t capture;
+    portENTER_CRITICAL(&s_as11_clock_lock);
+    capture = s_as11_clock_capture;
+    portEXIT_CRITICAL(&s_as11_clock_lock);
+    return capture;
+}
 
 /* Handles for characteristics discovered during full GATT scan.
  * The AS11 btmon trace shows BlueZ reads these by handle (ATT Read Request
@@ -160,6 +209,9 @@ static SemaphoreHandle_t s_connect_sem;
 static volatile int s_connect_status;
 static SemaphoreHandle_t s_resp_sem;  /* JSON RPC response arrived */
 static cJSON *s_resp_json;            /* owned; freed by waiter */
+static portMUX_TYPE s_response_lock = portMUX_INITIALIZER_UNLOCKED;
+static uint32_t s_rpc_serial, s_expected_response_id;
+static cJSON *s_response_original_id;
 static SemaphoreHandle_t s_cmd_mtx;   /* serialization mutex for RPC requests */
 
 static uint8_t *s_rx_buf;          /* PSRAM-allocated, RX_BUF_MAX bytes */
@@ -180,15 +232,11 @@ static uint32_t    s_notif_dropped = 0;
 static uint32_t    s_notif_dropped_bytes = 0;
 static uint32_t    s_notif_alloc_fail = 0;
 static TaskHandle_t  s_notif_task  = NULL;
-
-/* ── Spool fragment collector ────────────────────────────────────────
- * When a spool pull is in progress, s_spool_collector is non-NULL and
- * handle_notify() routes SpoolFragment notifications to it instead of
- * the normal notification dispatch.  This is set/cleared only by
- * as11_ble_spool_pull() which runs in the same notif_proc_task context
- * (via stop_task → post_therapy), so no extra locking is needed — the
- * collector pointer is written before PullSpoolFragments is sent and
- * cleared after the last fragment is received. */
+/* Spool publication and fragment mutation are serialized by a dedicated
+ * mutex, never held while waiting for BLE/network responses. Withdrawal waits
+ * for any in-flight decoder before freeing the collector or its semaphore. */
+static SemaphoreHandle_t s_spool_mtx;
+static bool s_spool_tainted;
 #define SPOOL_MAX_FRAGS   32
 #define SPOOL_FRAG_MAX    2808          /* matches AS11 max fragment size */
 
@@ -204,6 +252,7 @@ typedef struct {
     char     status[48];                /* SPOOL_INCOMPLETE / SPOOL_COMPLETE / ... */
     char     next_addr_json[256];       /* nextSpoolAddress for multi-round pulls */
     bool     done;                      /* set when status != SPOOL_INCOMPLETE */
+    bool     failed;
     SemaphoreHandle_t sem;              /* given when done */
 } spool_collector_t;
 
@@ -686,10 +735,23 @@ static int on_dsc(uint16_t conn, const struct ble_gatt_error *err,
     return 0;
 }
 
+/* Takes ownership, including mismatched or duplicate responses. */
+static void rpc_accept_response(cJSON *msg)
+{
+    cJSON *id = cJSON_GetObjectItemCaseSensitive(msg, "id");
+    bool accepted = false;
+    portENTER_CRITICAL(&s_response_lock);
+    if (cJSON_IsNumber(id) && s_expected_response_id &&
+        id->valuedouble == (double)s_expected_response_id && !s_resp_json) {
+        s_resp_json = msg; accepted = true;
+    }
+    portEXIT_CRITICAL(&s_response_lock);
+    if (accepted) xSemaphoreGive(s_resp_sem);
+    else cJSON_Delete(msg);
+}
+
 static void handle_notify(const uint8_t *data, int len);
 
-/* Notification processing task — drains the queue and does the heavy
- * FIG/AES/cJSON work off the NimBLE host task. */
 static void notif_proc_task(void *arg)
 {
     (void)arg;
@@ -785,15 +847,26 @@ static void handle_notify(const uint8_t *data, int len)
              * the normal notification dispatch.  The collector buffers
              * decoded base64 fragments and signals completion when the
              * device reports SPOOL_COMPLETE or SPOOL_COMPLETE_MORE_DATA_PENDING. */
-            if (s_spool_collector && strcmp(m, "SpoolFragment") == 0) {
+            if (strcmp(m, "SpoolFragment") == 0) {
+                xSemaphoreTake(s_spool_mtx, portMAX_DELAY);
+                spool_collector_t *collector = s_spool_collector;
+                if (!collector) {
+                    xSemaphoreGive(s_spool_mtx);
+                    cJSON_Delete(msg);
+                    continue;
+                }
                 cJSON *params = cJSON_GetObjectItem(msg, "params");
                 if (params) {
                     cJSON *seq_j = cJSON_GetObjectItem(params, "seq");
                     cJSON *data_j = cJSON_GetObjectItem(params, "data");
                     cJSON *status_j = cJSON_GetObjectItem(params, "status");
 
+                    if (cJSON_IsString(data_j) && data_j->valuestring[0] &&
+                        (collector->frag_count >= SPOOL_MAX_FRAGS ||
+                         strlen(data_j->valuestring) > ((SPOOL_FRAG_MAX + 2) / 3) * 4))
+                        collector->failed = true;
                     if (data_j && cJSON_IsString(data_j) &&
-                        s_spool_collector->frag_count < SPOOL_MAX_FRAGS) {
+                        collector->frag_count < SPOOL_MAX_FRAGS) {
 
                         /* Base64-decode the fragment data.
                          * An empty base64 string (dec_len=0) is valid —
@@ -805,7 +878,7 @@ static void handle_notify(const uint8_t *data, int len)
                          * times out. */
                         const char *b64 = data_j->valuestring;
                         size_t b64_len = strlen(b64);
-                        if (b64_len > 0) {
+                        if (b64_len > 0 && b64_len <= ((SPOOL_FRAG_MAX + 2) / 3) * 4) {
                             size_t dec_max = (b64_len / 4) * 3 + 4;
                             uint8_t *frag = heap_caps_malloc(dec_max, MALLOC_CAP_SPIRAM);
                             if (!frag) frag = malloc(dec_max);
@@ -815,46 +888,48 @@ static void handle_notify(const uint8_t *data, int len)
                                     frag, dec_max, &dec_len,
                                     (const unsigned char *)b64, b64_len);
                                 if (rc == 0 && dec_len > 0) {
-                                    int idx = s_spool_collector->frag_count++;
-                                    s_spool_collector->frags[idx].seq =
+                                    int idx = collector->frag_count++;
+                                    collector->frags[idx].seq =
                                         seq_j ? seq_j->valueint : idx;
-                                    s_spool_collector->frags[idx].data = frag;
-                                    s_spool_collector->frags[idx].len = (int)dec_len;
+                                    collector->frags[idx].data = frag;
+                                    collector->frags[idx].len = (int)dec_len;
                                     ESP_LOGI(TAG, "spool frag %d: seq=%d len=%d",
-                                             idx, s_spool_collector->frags[idx].seq,
+                                             idx, collector->frags[idx].seq,
                                              (int)dec_len);
                                 } else if (rc != 0) {
+                                    collector->failed = true;
                                     ESP_LOGW(TAG, "base64 decode failed rc=%d", rc);
                                     free(frag);
                                 } else {
                                     /* rc == 0 but dec_len == 0 — empty payload */
                                     free(frag);
                                 }
-                            }
+                            } else collector->failed = true;
                         }
                     }
 
                     /* Check completion status */
                     if (status_j && cJSON_IsString(status_j)) {
-                        strlcpy(s_spool_collector->status,
+                        strlcpy(collector->status,
                                 status_j->valuestring,
-                                sizeof(s_spool_collector->status));
+                                sizeof(collector->status));
                         /* Capture nextSpoolAddress for multi-round pulls */
                         cJSON *next_j = cJSON_GetObjectItem(params, "nextSpoolAddress");
                         if (next_j) {
                             char *ns = cJSON_PrintUnformatted(next_j);
                             if (ns) {
-                                strlcpy(s_spool_collector->next_addr_json, ns,
-                                        sizeof(s_spool_collector->next_addr_json));
+                                strlcpy(collector->next_addr_json, ns,
+                                        sizeof(collector->next_addr_json));
                                 free(ns);
                             }
                         }
                         if (strcmp(status_j->valuestring, "SPOOL_INCOMPLETE") != 0) {
-                            s_spool_collector->done = true;
-                            xSemaphoreGive(s_spool_collector->sem);
+                            collector->done = true;
+                            xSemaphoreGive(collector->sem);
                         }
                     }
                 }
+                xSemaphoreGive(s_spool_mtx);
                 cJSON_Delete(msg);
                 continue;
             }
@@ -866,10 +941,7 @@ static void handle_notify(const uint8_t *data, int len)
             cJSON_Delete(msg);
             continue;
         }
-        /* RPC response */
-        if (s_resp_json) cJSON_Delete(s_resp_json);
-        s_resp_json = msg;
-        xSemaphoreGive(s_resp_sem);
+        rpc_accept_response(msg);
     }
 }
 
@@ -986,6 +1058,7 @@ static int gap_event(struct ble_gap_event *event, void *arg)
 
     case BLE_GAP_EVENT_DISCONNECT:
         ESP_LOGW(TAG, "disconnected (reason=%d)", event->disconnect.reason);
+        as11_clock_capture_invalidate();
         s_conn_handle = BLE_HS_CONN_HANDLE_NONE;
         s_session_encrypted = false;
         therapy_alert_on_ble_disconnect();
@@ -1121,15 +1194,45 @@ static uint8_t *fig_tx_pkt(void)
     return pkt;
 }
 
+/* Unique wire IDs fence delayed replies across repeated calls. Preserve the
+ * caller's original ID in the returned JSON (including passthrough strings). */
+static void clear_response(void);
+static char *rpc_prepare(const char *json)
+{
+    clear_response();
+    cJSON *request = cJSON_Parse(json);
+    if (!cJSON_IsObject(request)) { cJSON_Delete(request); return NULL; }
+    cJSON *id = cJSON_GetObjectItemCaseSensitive(request, "id");
+    cJSON *original = id ? cJSON_Duplicate(id, true) : NULL;
+    if (id && !original) { cJSON_Delete(request); return NULL; }
+    uint32_t wire_id = ++s_rpc_serial;
+    if (!wire_id || wire_id > INT32_MAX) wire_id = s_rpc_serial = 1;
+    cJSON_DeleteItemFromObjectCaseSensitive(request, "id");
+    if (!cJSON_AddNumberToObject(request, "id", wire_id)) {
+        cJSON_Delete(original); cJSON_Delete(request); return NULL;
+    }
+    char *wire = cJSON_PrintUnformatted(request);
+    cJSON_Delete(request);
+    if (!wire) { cJSON_Delete(original); return NULL; }
+    portENTER_CRITICAL(&s_response_lock);
+    s_expected_response_id = wire_id;
+    s_response_original_id = original;
+    portEXIT_CRITICAL(&s_response_lock);
+    return wire;
+}
+
 static esp_err_t send_fig(uint16_t vcid, const char *json)
 {
     uint8_t *pkt = fig_tx_pkt();
     if (!pkt) return ESP_ERR_NO_MEM;
-    uint16_t plen = (uint16_t)strlen(json);
-    if (plen > TX_PAYLOAD_MAX) return ESP_ERR_INVALID_SIZE;
-    int total = fig_encode(vcid, (const uint8_t *)json, plen, pkt);
+    char *wire = rpc_prepare(json);
+    if (!wire) return ESP_ERR_NO_MEM;
+    size_t plen = strlen(wire);
+    if (plen > TX_PAYLOAD_MAX) { free(wire); return ESP_ERR_INVALID_SIZE; }
+    int total = fig_encode(vcid, (const uint8_t *)wire, (uint16_t)plen, pkt);
+    free(wire);
 
-    ESP_LOGI(TAG, "send_fig: VCID=0x%04x payload=%d total=%d", vcid, plen, total);
+    ESP_LOGI(TAG, "send_fig: VCID=0x%04x payload=%u total=%d", vcid, (unsigned)plen, total);
     ESP_LOG_BUFFER_HEX(TAG, pkt, total);
 
     /* Stream the FIG packet as chunked Write Requests, exactly like the
@@ -1156,9 +1259,13 @@ static esp_err_t send_fig(uint16_t vcid, const char *json)
     return ESP_OK;
 }
 
-/* Send a raw binary FIG packet (for encrypted payloads). */
-static esp_err_t send_fig_raw(uint16_t vcid, const uint8_t *data, int len)
+/* Send a raw binary FIG packet (for encrypted payloads).  Once a GATT write
+ * has been accepted locally, a later timeout/error is indeterminate: the AS11
+ * may already have received enough of the request to act on it. */
+static esp_err_t send_fig_raw(uint16_t vcid, const uint8_t *data, int len,
+                              bool *may_have_reached_peer)
 {
+    if (may_have_reached_peer) *may_have_reached_peer = false;
     uint8_t *pkt = fig_tx_pkt();
     if (!pkt) return ESP_ERR_NO_MEM;
     if (len > TX_PAYLOAD_MAX) return ESP_ERR_INVALID_SIZE;
@@ -1176,6 +1283,7 @@ static esp_err_t send_fig_raw(uint16_t vcid, const uint8_t *data, int len)
             ESP_LOGE(TAG, "write chunk failed rc=%d off=%d", rc, off);
             return ESP_FAIL;
         }
+        if (may_have_reached_peer) *may_have_reached_peer = true;
         if (wait_op(5000) != 0) {
             ESP_LOGE(TAG, "write chunk timeout off=%d", off);
             return ESP_FAIL;
@@ -1187,13 +1295,14 @@ static esp_err_t send_fig_raw(uint16_t vcid, const uint8_t *data, int len)
 /* Send an encrypted JSON-RPC request on VCID 0x0397.
  * Encrypts with AES-256-CBC using the session key, then sends via send_fig_raw.
  * Returns ESP_OK on success. Caller should call wait_response() to get reply. */
-static esp_err_t send_rpc_encrypted(const char *json)
+static esp_err_t send_rpc_encrypted_tracked(const char *json,
+                                             bool *may_have_reached_peer)
 {
+    if (may_have_reached_peer) *may_have_reached_peer = false;
     if (!s_session_encrypted) {
         ESP_LOGE(TAG, "send_rpc_encrypted: no session key");
         return ESP_ERR_INVALID_STATE;
     }
-    int plen = (int)strlen(json);
     uint8_t *enc = heap_caps_malloc(TX_PAYLOAD_MAX, MALLOC_CAP_SPIRAM);
     if (!enc) {
         enc = malloc(TX_PAYLOAD_MAX);
@@ -1201,35 +1310,65 @@ static esp_err_t send_rpc_encrypted(const char *json)
         ESP_LOGW(TAG, "send_rpc_encrypted: fell back to default malloc (PSRAM?)");
     }
 
-    int enc_len = aes_cbc_encrypt(s_session_key, (const uint8_t *)json, plen,
-                                  enc, TX_PAYLOAD_MAX);
+    char *wire = rpc_prepare(json);
+    if (!wire) { free(enc); return ESP_ERR_NO_MEM; }
+    int enc_len = aes_cbc_encrypt(s_session_key, (const uint8_t *)wire,
+                                  (int)strlen(wire), enc, TX_PAYLOAD_MAX);
+    free(wire);
     if (enc_len < 0) {
         free(enc);
         ESP_LOGE(TAG, "AES encrypt failed");
         return ESP_FAIL;
     }
 
-    esp_err_t ret = send_fig_raw(FIG_VCID_TX_ENC, enc, enc_len);
+    esp_err_t ret = send_fig_raw(FIG_VCID_TX_ENC, enc, enc_len,
+                                 may_have_reached_peer);
     free(enc);
     return ret;
+}
+
+static esp_err_t send_rpc_encrypted(const char *json)
+{
+    return send_rpc_encrypted_tracked(json, NULL);
 }
 
 /* Clear any stale RPC response state before sending a new RPC. */
 static void clear_response(void)
 {
-    while (xSemaphoreTake(s_resp_sem, 0) == pdTRUE) { /* drain */ }
-    if (s_resp_json) { cJSON_Delete(s_resp_json); s_resp_json = NULL; }
+    portENTER_CRITICAL(&s_response_lock);
+    cJSON *old = s_resp_json, *id = s_response_original_id;
+    s_resp_json = NULL;
+    s_response_original_id = NULL;
+    s_expected_response_id = 0;
+    portEXIT_CRITICAL(&s_response_lock);
+    cJSON_Delete(old); cJSON_Delete(id);
+    while (xSemaphoreTake(s_resp_sem, 0) == pdTRUE) { }
 }
 
-/* Wait for an RPC response; returns parsed cJSON (caller frees) or NULL. */
+/* A wakeup may belong to a withdrawn request. Only the protected response
+ * pointer is authoritative; keep the original absolute timeout across wakes. */
 static cJSON *wait_response(int timeout_ms)
 {
-    if (xSemaphoreTake(s_resp_sem, pdMS_TO_TICKS(timeout_ms)) != pdTRUE) {
-        return NULL;
+    int64_t deadline = esp_timer_get_time() + (int64_t)timeout_ms * 1000;
+    for (;;) {
+        portENTER_CRITICAL(&s_response_lock);
+        cJSON *result = s_resp_json;
+        cJSON *id = NULL;
+        if (result) {
+            s_resp_json = NULL;
+            s_expected_response_id = 0;
+            id = s_response_original_id;
+            s_response_original_id = NULL;
+        }
+        portEXIT_CRITICAL(&s_response_lock);
+        if (result) {
+            if (id) cJSON_ReplaceItemInObjectCaseSensitive(result, "id", id);
+            return result;
+        }
+        int64_t remaining = deadline - esp_timer_get_time();
+        if (remaining <= 0) { clear_response(); return NULL; }
+        xSemaphoreTake(s_resp_sem, pdMS_TO_TICKS((remaining + 999) / 1000));
     }
-    cJSON *j = s_resp_json;
-    s_resp_json = NULL;
-    return j;
 }
 
 /* ------------------------------------------------------------------ */
@@ -1613,7 +1752,7 @@ static void pair_task(void *arg)
         if (s_conn_handle != BLE_HS_CONN_HANDLE_NONE) {
             ble_gap_terminate(s_conn_handle, BLE_ERR_REM_USER_CONN_TERM);
         }
-        vTaskDelete(NULL);
+        psram_task_delete(NULL);
         return;
     }
 
@@ -1623,7 +1762,7 @@ static void pair_task(void *arg)
     if (srp_begin() != ESP_OK) {
         set_error("SRP keygen failed");
         ble_gap_terminate(s_conn_handle, BLE_ERR_REM_USER_CONN_TERM);
-        vTaskDelete(NULL);
+        psram_task_delete(NULL);
         return;
     }
     ESP_LOGI(TAG, "pair_task: srp_begin took %lld ms", (esp_timer_get_time() - pair_t0) / 1000);
@@ -1638,7 +1777,7 @@ static void pair_task(void *arg)
     if (!json) {
         set_error("StartKeyExchange: out of memory");
         ble_gap_terminate(s_conn_handle, BLE_ERR_REM_USER_CONN_TERM);
-        vTaskDelete(NULL);
+        psram_task_delete(NULL);
         return;
     }
     snprintf(json, 800,
@@ -1650,7 +1789,7 @@ static void pair_task(void *arg)
     if (se != ESP_OK) {
         set_error("StartKeyExchange send failed");
         ble_gap_terminate(s_conn_handle, BLE_ERR_REM_USER_CONN_TERM);
-        vTaskDelete(NULL);
+        psram_task_delete(NULL);
         return;
     }
 
@@ -1668,7 +1807,7 @@ static void pair_task(void *arg)
     if (!resp) {
         set_error("no StartKeyExchange response");
         ble_gap_terminate(s_conn_handle, BLE_ERR_REM_USER_CONN_TERM);
-        vTaskDelete(NULL);
+        psram_task_delete(NULL);
         return;
     }
     cJSON *result = cJSON_GetObjectItem(resp, "result");
@@ -1678,7 +1817,7 @@ static void pair_task(void *arg)
         cJSON_Delete(resp);
         set_error("bad StartKeyExchange response");
         ble_gap_terminate(s_conn_handle, BLE_ERR_REM_USER_CONN_TERM);
-        vTaskDelete(NULL);
+        psram_task_delete(NULL);
         return;
     }
     /* stash serverPk + salt for the confirm step */
@@ -1688,7 +1827,7 @@ static void pair_task(void *arg)
     cJSON_Delete(resp);
 
     ESP_LOGI(TAG, "StartKeyExchange OK - device should show a 4-digit passkey");
-    vTaskDelete(NULL);
+    psram_task_delete(NULL);
 }
 
 static void confirm_task(void *arg)
@@ -1697,7 +1836,7 @@ static void confirm_task(void *arg)
     set_state(AS11_STATUS_CONFIRMING);
 
     if (s_conn_handle == BLE_HS_CONN_HANDLE_NONE) {
-        set_error("not connected"); vTaskDelete(NULL); return;
+        set_error("not connected"); psram_task_delete(NULL); return;
     }
     /* The StartKeyExchange response may still be arriving if the user
      * entered the PIN quickly.  Wait up to 5 s for s_kex_ready. */
@@ -1705,7 +1844,7 @@ static void confirm_task(void *arg)
         vTaskDelay(pdMS_TO_TICKS(100));
     }
     if (!s_kex_ready || !s_server_pk || !s_salt) {
-        set_error("no key-exchange state"); vTaskDelete(NULL); return;
+        set_error("no key-exchange state"); psram_task_delete(NULL); return;
     }
 
     char m1_hex[65];
@@ -1715,7 +1854,7 @@ static void confirm_task(void *arg)
                     m1_hex, m2_expected) != ESP_OK) {
         set_error("SRP computation failed");
         ble_gap_terminate(s_conn_handle, BLE_ERR_REM_USER_CONN_TERM);
-        vTaskDelete(NULL);
+        psram_task_delete(NULL);
         return;
     }
     ESP_LOGI(TAG, "confirm_task: srp_compute took %lld ms", (esp_timer_get_time() - conf_t0) / 1000);
@@ -1728,7 +1867,7 @@ static void confirm_task(void *arg)
     if (send_fig(FIG_VCID_TX, json) != ESP_OK) {
         set_error("ConfirmKeyExchange send failed");
         ble_gap_terminate(s_conn_handle, BLE_ERR_REM_USER_CONN_TERM);
-        vTaskDelete(NULL);
+        psram_task_delete(NULL);
         return;
     }
     vTaskDelay(pdMS_TO_TICKS(100));
@@ -1739,7 +1878,7 @@ static void confirm_task(void *arg)
     if (!resp) {
         set_error("no ConfirmKeyExchange response");
         ble_gap_terminate(s_conn_handle, BLE_ERR_REM_USER_CONN_TERM);
-        vTaskDelete(NULL);
+        psram_task_delete(NULL);
         return;
     }
     cJSON *err = cJSON_GetObjectItem(resp, "error");
@@ -1747,7 +1886,7 @@ static void confirm_task(void *arg)
         cJSON_Delete(resp);
         set_error("device rejected passkey");
         ble_gap_terminate(s_conn_handle, BLE_ERR_REM_USER_CONN_TERM);
-        vTaskDelete(NULL);
+        psram_task_delete(NULL);
         return;
     }
     cJSON *result = cJSON_GetObjectItem(resp, "result");
@@ -1757,7 +1896,7 @@ static void confirm_task(void *arg)
         cJSON_Delete(resp);
         set_error("bad ConfirmKeyExchange response");
         ble_gap_terminate(s_conn_handle, BLE_ERR_REM_USER_CONN_TERM);
-        vTaskDelete(NULL);
+        psram_task_delete(NULL);
         return;
     }
     /* verify server proof (M2) */
@@ -1767,7 +1906,7 @@ static void confirm_task(void *arg)
         cJSON_Delete(resp);
         set_error("server proof mismatch");
         ble_gap_terminate(s_conn_handle, BLE_ERR_REM_USER_CONN_TERM);
-        vTaskDelete(NULL);
+        psram_task_delete(NULL);
         return;
     }
 
@@ -1785,7 +1924,7 @@ static void confirm_task(void *arg)
     if (ns != ESP_OK) {
         set_error("NVS save failed");
         ble_gap_terminate(s_conn_handle, BLE_ERR_REM_USER_CONN_TERM);
-        vTaskDelete(NULL);
+        psram_task_delete(NULL);
         return;
     }
 
@@ -1799,13 +1938,14 @@ static void confirm_task(void *arg)
      * Without this, therapy data never flows until a manual reboot.
      * Set s_manual_disconnect so the GAP disconnect event doesn't
      * launch a duplicate auto_reconnect_task. */
+    as11_clock_capture_invalidate();
     s_manual_disconnect = true;
     if (s_conn_handle != BLE_HS_CONN_HANDLE_NONE) {
         ble_gap_terminate(s_conn_handle, BLE_ERR_REM_USER_CONN_TERM);
     }
     vTaskDelay(pdMS_TO_TICKS(500));
     psram_task_create(reconnect_task, "as11_reconn", 8192, NULL, 5, tskNO_AFFINITY, NULL, NULL);
-    vTaskDelete(NULL);
+    psram_task_delete(NULL);
 }
 
 /* ------------------------------------------------------------------ */
@@ -1937,6 +2077,7 @@ static esp_err_t do_setup_encrypted_session(const char *cid_str,
         sha256_segs(segs, lens, 2, s_session_key);
     }
     s_session_encrypted = true;
+    __atomic_store_n(&s_spool_tainted, false, __ATOMIC_RELEASE);
     ESP_LOGI(TAG, "reconnect: session key derived");
     return ESP_OK;
 }
@@ -1956,14 +2097,14 @@ static void reconnect_task(void *arg)
     }
     if (!s_host_ready) {
         ESP_LOGW(TAG, "reconnect: host not ready, aborting");
-        vTaskDelete(NULL);
+        psram_task_delete(NULL);
         return;
     }
 
     /* Use cached pairing info (loaded at init or after pairing). */
     if (!s_pair_cache.valid) {
         ESP_LOGD(TAG, "reconnect: no cached pairing");
-        vTaskDelete(NULL);
+        psram_task_delete(NULL);
         return;
     }
 
@@ -1978,7 +2119,7 @@ static void reconnect_task(void *arg)
 
     if (addr_str[0] == '\0' || cid_str[0] == '\0' || pair_key_hex[0] == '\0') {
         ESP_LOGD(TAG, "reconnect: incomplete pairing cache");
-        vTaskDelete(NULL);
+        psram_task_delete(NULL);
         return;
     }
 
@@ -1988,7 +2129,7 @@ static void reconnect_task(void *arg)
     s_own_addr_type = BLE_OWN_ADDR_PUBLIC;
     if (!str_to_addr(addr_str, &s_target_addr)) {
         ESP_LOGE(TAG, "reconnect: bad addr '%s'", addr_str);
-        vTaskDelete(NULL);
+        psram_task_delete(NULL);
         return;
     }
     strlcpy(s_target_name, name_str, sizeof(s_target_name));
@@ -1999,7 +2140,7 @@ static void reconnect_task(void *arg)
             ESP_LOGI(TAG, "reconnect: aborted (pairing=%d manual=%d)",
                      s_pair_cache.valid, s_manual_disconnect);
             set_state(AS11_STATUS_IDLE);
-            vTaskDelete(NULL);
+            psram_task_delete(NULL);
             return;
         }
 
@@ -2024,7 +2165,7 @@ static void reconnect_task(void *arg)
                 ESP_LOGI(TAG, "reconnect: aborted (pairing=%d manual=%d)",
                          s_pair_cache.valid, s_manual_disconnect);
                 set_state(AS11_STATUS_IDLE);
-                vTaskDelete(NULL);
+                psram_task_delete(NULL);
                 return;
             }
             if (do_connect_and_discover() == ESP_OK) {
@@ -2047,7 +2188,7 @@ static void reconnect_task(void *arg)
                              "(pairing=%d manual=%d)",
                          s_pair_cache.valid, s_manual_disconnect);
                 set_state(AS11_STATUS_IDLE);
-                vTaskDelete(NULL);
+                psram_task_delete(NULL);
                 return;
             }
             slow_attempt++;
@@ -2059,7 +2200,7 @@ static void reconnect_task(void *arg)
             if (!s_pair_cache.valid || s_manual_disconnect) {
                 ESP_LOGI(TAG, "reconnect: aborted during slow retry wait");
                 set_state(AS11_STATUS_IDLE);
-                vTaskDelete(NULL);
+                psram_task_delete(NULL);
                 return;
             }
             set_state(AS11_STATUS_CONNECTING);
@@ -2079,7 +2220,7 @@ static void reconnect_task(void *arg)
         if (!connected) {
             ESP_LOGE(TAG, "reconnect: all connect attempts failed");
             set_state(AS11_STATUS_IDLE);
-            vTaskDelete(NULL);
+            psram_task_delete(NULL);
             return;
         }
 
@@ -2105,7 +2246,7 @@ static void reconnect_task(void *arg)
         if (hard_fail && setup_failures >= 3) {
             ESP_LOGE(TAG, "reconnect: persistent session setup rejection, latching error state");
             set_state(AS11_STATUS_ERROR);
-            vTaskDelete(NULL);
+            psram_task_delete(NULL);
             return;
         }
 
@@ -2220,12 +2361,30 @@ after_subscribe:
      * GetDateTime must be sent before StartStream because active streaming
      * congests BLE ACL buffers, making subsequent RPCs fail. */
     {
+        /* A failed recapture must not leave a measurement from the previous
+         * connection looking current. */
+        uint32_t capture_generation = as11_clock_capture_invalidate();
         int64_t as11_ms = 0;
         if (as11_ble_get_datetime(&as11_ms) == ESP_OK) {
-            s_as11_clock_ms = as11_ms;
-            s_as11_clock_capture_ntp_ms = (int64_t)time(NULL) * 1000;
-            ESP_LOGI(TAG, "reconnect: AS11 clock captured: %lld ms (NTP=%lld)",
-                     (long long)as11_ms, (long long)s_as11_clock_capture_ntp_ms);
+            /* Read provenance before wall time.  If NTP synchronises between
+             * the two reads we conservatively retain the older, degraded
+             * provenance; the next reconnect can produce a measured drift. */
+            time_source_t wall_source = time_source_get();
+            int64_t wall_ms = (int64_t)time(NULL) * 1000;
+            bool stored = as11_clock_capture_store(capture_generation,
+                                                   as11_ms, wall_ms,
+                                                   wall_source);
+            if (!stored) {
+                ESP_LOGW(TAG, "reconnect: link changed during AS11 clock "
+                              "capture; discarding stale result");
+            } else if (wall_source == TIME_SRC_NTP) {
+                ESP_LOGI(TAG, "reconnect: AS11 clock captured: %lld ms (NTP=%lld)",
+                         (long long)as11_ms, (long long)wall_ms);
+            } else {
+                ESP_LOGW(TAG, "reconnect: AS11 clock captured against "
+                              "non-NTP source=%d; measured drift unavailable",
+                         (int)wall_source);
+            }
         } else {
             ESP_LOGW(TAG, "reconnect: GetDateTime failed — clock_drift_ms will be unavailable");
         }
@@ -2278,7 +2437,7 @@ after_start_stream:
     #endif
     ESP_LOGI(TAG, "reconnect: connected to %s, session established, streams started", addr_str);
 
-    vTaskDelete(NULL);
+    psram_task_delete(NULL);
 }
 
 /* ------------------------------------------------------------------
@@ -2302,13 +2461,13 @@ static void auto_reconnect_task(void *arg)
             ESP_LOGI(TAG, "auto-reconnect: aborted during wait "
                          "(pairing=%d manual=%d)",
                      s_pair_cache.valid, s_manual_disconnect);
-            vTaskDelete(NULL);
+            psram_task_delete(NULL);
             return;
         }
     }
 
     /* reconnect_task handles the full connect + encrypted session +
-     * stream setup.  It calls vTaskDelete(NULL) internally, so this
+     * stream setup.  It calls psram_task_delete(NULL) internally, so this
      * task is cleaned up when reconnect_task finishes. */
     reconnect_task(arg);
 }
@@ -2352,11 +2511,12 @@ esp_err_t as11_ble_init(void)
 {
     s_state_mtx  = xSemaphoreCreateMutex();
     s_cmd_mtx    = xSemaphoreCreateMutex();
+    s_spool_mtx = xSemaphoreCreateMutex();
     s_op_sem     = xSemaphoreCreateBinary();
     s_connect_sem = xSemaphoreCreateBinary();
     s_resp_sem   = xSemaphoreCreateBinary();
     s_scan_done  = xSemaphoreCreateBinary();
-    if (!s_state_mtx || !s_cmd_mtx || !s_op_sem || !s_connect_sem || !s_resp_sem || !s_scan_done) {
+    if (!s_state_mtx || !s_cmd_mtx || !s_spool_mtx || !s_op_sem || !s_connect_sem || !s_resp_sem || !s_scan_done) {
         return ESP_ERR_NO_MEM;
     }
 
@@ -2549,6 +2709,7 @@ static esp_err_t do_forget_nvs(void *arg)
 
 esp_err_t as11_ble_forget(void)
 {
+    as11_clock_capture_invalidate();
     /* Delegate the NVS erase so callers on a PSRAM stack (httpd forget handler)
      * are safe; the BLE teardown below stays on the caller (no flash). */
     esp_err_t e = nvs_writer_run(do_forget_nvs, NULL);
@@ -2565,6 +2726,7 @@ esp_err_t as11_ble_forget(void)
 
 esp_err_t as11_ble_disconnect(void)
 {
+    as11_clock_capture_invalidate();
     s_manual_disconnect = true;
     if (s_conn_handle != BLE_HS_CONN_HANDLE_NONE) {
         ESP_LOGI(TAG, "disconnecting BLE (conn_handle=%d)", s_conn_handle);
@@ -2592,15 +2754,21 @@ esp_err_t as11_ble_stop_stream(void)
 esp_err_t as11_ble_get_clock_drift(int64_t *out_drift_ms)
 {
     if (!out_drift_ms) return ESP_ERR_INVALID_ARG;
-    if (s_as11_clock_ms == 0 || s_as11_clock_capture_ntp_ms == 0) {
+    as11_clock_capture_t capture = as11_clock_capture_load();
+    if (!capture.available) {
         ESP_LOGW(TAG, "get_clock_drift: no AS11 clock capture available");
         return ESP_ERR_INVALID_STATE;
     }
-    *out_drift_ms = s_as11_clock_capture_ntp_ms - s_as11_clock_ms;
+    if (capture.wall_source != TIME_SRC_NTP) {
+        ESP_LOGW(TAG, "get_clock_drift: capture wall source=%d is not NTP",
+                 (int)capture.wall_source);
+        return ESP_ERR_INVALID_STATE;
+    }
+    *out_drift_ms = capture.wall_ms - capture.as11_ms;
     ESP_LOGI(TAG, "get_clock_drift: drift=%lld ms (NTP=%lld AS11=%lld)",
              (long long)*out_drift_ms,
-             (long long)s_as11_clock_capture_ntp_ms,
-             (long long)s_as11_clock_ms);
+             (long long)capture.wall_ms,
+             (long long)capture.as11_ms);
     return ESP_OK;
 }
 
@@ -2608,7 +2776,7 @@ esp_err_t as11_ble_get_clock_drift(int64_t *out_drift_ms)
  * Returns ESP_OK and stores epoch milliseconds in *out_epoch_ms.
  * The response format is {"result":{"dateTime":"2026-06-25T15:08:00.000Z"}}.
  * Returns ESP_FAIL if the RPC fails or the response can't be parsed. */
-esp_err_t as11_ble_get_datetime(int64_t *out_epoch_ms)
+static esp_err_t get_datetime_locked(int64_t *out_epoch_ms)
 {
     if (!out_epoch_ms) return ESP_ERR_INVALID_ARG;
     if (!s_session_encrypted) {
@@ -2679,6 +2847,17 @@ esp_err_t as11_ble_get_datetime(int64_t *out_epoch_ms)
     return ret;
 }
 
+esp_err_t as11_ble_get_datetime(int64_t *out_epoch_ms)
+{
+    if (!s_cmd_mtx || xSemaphoreTake(s_cmd_mtx, pdMS_TO_TICKS(10000)) != pdTRUE)
+        return ESP_ERR_TIMEOUT;
+    esp_err_t result = get_datetime_locked(out_epoch_ms);
+    clear_response();
+    xSemaphoreGive(s_cmd_mtx);
+    return result;
+}
+
+
 /* ── Spool RPC ────────────────────────────────────────────────────────
  *
  * Post-therapy data collection.  The AS11 stores session summaries, event
@@ -2687,10 +2866,9 @@ esp_err_t as11_ble_get_datetime(int64_t *out_epoch_ms)
  * asynchronously on the same BLE characteristic as StreamData and RPC
  * responses; handle_notify() intercepts them when s_spool_collector is set.
  *
- * The pull function runs in the notif_proc_task context (via stop_task →
- * post_therapy), which is the same task that processes notifications.  This
- * is intentional: it allows SpoolFragment notifications to be handled
- * synchronously while we wait on the collector semaphore.
+ * The pull function runs on the post worker (via stop_task →
+ * post_therapy), while notif_proc decodes fragments concurrently. A dedicated
+ * mutex joins any in-flight decoder before a collector or semaphore is freed.
  *
  * Multi-round pulls: if the device returns SPOOL_COMPLETE_MORE_DATA_PENDING,
  * the last fragment includes a nextSpoolAddress JSON object.  We loop with
@@ -2710,6 +2888,25 @@ static int frag_cmp(const void *a, const void *b)
  * SPOOL_COMPLETE_MORE_DATA_PENDING, *next_addr_out is set to the
  * nextSpoolAddress JSON string (caller uses it for the next round).
  * Otherwise *next_addr_out is set to empty string. */
+static void spool_withdraw(spool_collector_t *collector, bool aborting)
+{
+    xSemaphoreTake(s_spool_mtx, portMAX_DELAY);
+    if (s_spool_collector == collector) s_spool_collector = NULL;
+    xSemaphoreGive(s_spool_mtx);
+    vSemaphoreDelete(collector->sem);
+    collector->sem = NULL;
+    if (aborting) {
+        for (int i = 0; i < collector->frag_count; ++i)
+            free(collector->frags[i].data);
+        collector->frag_count = 0;
+        /* Fragments carry no trustworthy request generation. End this link
+         * before admitting another collector, rather than mixing late data. */
+        __atomic_store_n(&s_spool_tainted, true, __ATOMIC_RELEASE);
+        if (s_conn_handle != BLE_HS_CONN_HANDLE_NONE)
+            ble_gap_terminate(s_conn_handle, BLE_ERR_REM_USER_CONN_TERM);
+    }
+}
+
 static esp_err_t spool_one_round(const char *spool_addr_json,
                                  uint8_t **round_data, size_t *round_len,
                                  char *next_addr_out, size_t next_addr_max)
@@ -2718,12 +2915,11 @@ static esp_err_t spool_one_round(const char *spool_addr_json,
     *round_len = 0;
     next_addr_out[0] = '\0';
 
-    /* Set up collector before sending RPCs so we don't miss fragments. */
+    /* Own the collector locally until StartSpool responds; publish before
+     * PullSpoolFragments can generate any fragments for this round. */
     spool_collector_t coll = {0};
     coll.sem = xSemaphoreCreateBinary();
     if (!coll.sem) return ESP_ERR_NO_MEM;
-    s_spool_collector = &coll;
-
     /* 1. StartSpool RPC */
     char rpc[512];
     snprintf(rpc, sizeof(rpc),
@@ -2733,16 +2929,14 @@ static esp_err_t spool_one_round(const char *spool_addr_json,
     clear_response();
     if (send_rpc_encrypted(rpc) != ESP_OK) {
         ESP_LOGE(TAG, "spool: StartSpool send failed");
-        vSemaphoreDelete(coll.sem);
-        s_spool_collector = NULL;
+        spool_withdraw(&coll, true);
         return ESP_FAIL;
     }
 
     cJSON *resp = wait_response(10000);
     if (!resp) {
         ESP_LOGE(TAG, "spool: StartSpool timeout");
-        vSemaphoreDelete(coll.sem);
-        s_spool_collector = NULL;
+        spool_withdraw(&coll, true);
         return ESP_FAIL;
     }
     cJSON *result = cJSON_GetObjectItem(resp, "result");
@@ -2752,13 +2946,16 @@ static esp_err_t spool_one_round(const char *spool_addr_json,
         ESP_LOGE(TAG, "spool: StartSpool bad response: %s", s ? s : "?");
         if (s) free(s);
         cJSON_Delete(resp);
-        vSemaphoreDelete(coll.sem);
-        s_spool_collector = NULL;
+        spool_withdraw(&coll, true);
         return ESP_FAIL;
     }
     int spool_id = spool_id_j->valueint;
     cJSON_Delete(resp);
     ESP_LOGI(TAG, "spool: StartSpool ok, spoolId=%d", spool_id);
+
+    xSemaphoreTake(s_spool_mtx, portMAX_DELAY);
+    s_spool_collector = &coll;
+    xSemaphoreGive(s_spool_mtx);
 
     /* 2. PullSpoolFragments RPC — triggers SpoolFragment notifications */
     snprintf(rpc, sizeof(rpc),
@@ -2768,8 +2965,7 @@ static esp_err_t spool_one_round(const char *spool_addr_json,
     clear_response();
     if (send_rpc_encrypted(rpc) != ESP_OK) {
         ESP_LOGE(TAG, "spool: PullSpoolFragments send failed");
-        vSemaphoreDelete(coll.sem);
-        s_spool_collector = NULL;
+        spool_withdraw(&coll, true);
         return ESP_FAIL;
     }
 
@@ -2780,19 +2976,8 @@ static esp_err_t spool_one_round(const char *spool_addr_json,
 
     /* 3. Wait for all fragments to arrive */
     if (xSemaphoreTake(coll.sem, pdMS_TO_TICKS(30000)) != pdTRUE) {
-        ESP_LOGE(TAG, "spool: fragment collection timeout (%d frags received)",
-                 coll.frag_count);
-        /* Detach first: a SpoolFragment notification arriving late must not
-         * append to a collector that is being torn down. */
-        s_spool_collector = NULL;
-        vSemaphoreDelete(coll.sem);
-        /* Fragments already received were malloc'd by the notification
-         * handler.  The success and out-of-memory paths free them; this one
-         * did not, leaking up to SPOOL_MAX_FRAGS x maxFragmentSize per
-         * timed-out round. */
-        for (int i = 0; i < coll.frag_count; i++) {
-            free(coll.frags[i].data);
-        }
+        ESP_LOGE(TAG, "spool: fragment collection timeout");
+        spool_withdraw(&coll, true);
         /* Clear any stale RPC response state so subsequent RPCs
          * don't pick up a leftover response from the timed-out pull. */
         clear_response();
@@ -2800,8 +2985,11 @@ static esp_err_t spool_one_round(const char *spool_addr_json,
     }
 
     /* Clear collector before processing (new fragments would be lost) */
-    s_spool_collector = NULL;
-    vSemaphoreDelete(coll.sem);
+    spool_withdraw(&coll, false);
+    if (coll.failed) {
+        for (int i = 0; i < coll.frag_count; ++i) free(coll.frags[i].data);
+        return ESP_FAIL;
+    }
 
     ESP_LOGI(TAG, "spool: collected %d fragments, status=%s",
              coll.frag_count, coll.status);
@@ -2845,7 +3033,7 @@ static esp_err_t spool_one_round(const char *spool_addr_json,
     return ESP_OK;
 }
 
-esp_err_t as11_ble_spool_pull(const char *spool_type, const char *from_dt,
+static esp_err_t spool_pull_locked(const char *spool_type, const char *from_dt,
                               uint8_t **out_data, size_t *out_len)
 {
     if (!spool_type || !from_dt || !out_data || !out_len) {
@@ -2924,11 +3112,25 @@ esp_err_t as11_ble_spool_pull(const char *spool_type, const char *from_dt,
     return ESP_OK;
 }
 
+esp_err_t as11_ble_spool_pull(const char *spool_type, const char *from_dt,
+                            uint8_t **out_data, size_t *out_len)
+{
+    if (!out_data || !out_len) return ESP_ERR_INVALID_ARG;
+    *out_data = NULL; *out_len = 0;
+    if (!s_cmd_mtx || xSemaphoreTake(s_cmd_mtx, pdMS_TO_TICKS(10000)) != pdTRUE)
+        return ESP_ERR_TIMEOUT;
+    esp_err_t result = __atomic_load_n(&s_spool_tainted, __ATOMIC_ACQUIRE) ? ESP_ERR_INVALID_STATE
+        : spool_pull_locked(spool_type, from_dt, out_data, out_len);
+    clear_response();
+    xSemaphoreGive(s_cmd_mtx);
+    return result;
+}
+
 cJSON *as11_ble_get_values(const char *const *keys, int n_keys)
 {
     if (!keys || n_keys <= 0) return NULL;
-    if (!s_session_encrypted) {
-        ESP_LOGW(TAG, "get_values: no encrypted session");
+    if (!s_session_encrypted || strcmp(as11_ble_get_status(), AS11_STATUS_PAIRED) != 0) {
+        ESP_LOGW(TAG, "get_values: encrypted session is not ready");
         return NULL;
     }
 
@@ -2954,15 +3156,23 @@ cJSON *as11_ble_get_values(const char *const *keys, int n_keys)
              params);
     free(params);
 
+    if (!s_cmd_mtx ||
+        xSemaphoreTake(s_cmd_mtx, pdMS_TO_TICKS(10000)) != pdTRUE) {
+        ESP_LOGW(TAG, "get_values: BLE command bus busy");
+        return NULL;
+    }
+
     clear_response();
     if (send_rpc_encrypted(rpc) != ESP_OK) {
         ESP_LOGW(TAG, "get_values: send failed");
+        xSemaphoreGive(s_cmd_mtx);
         return NULL;
     }
 
     cJSON *resp = wait_response(10000);
     if (!resp) {
         ESP_LOGW(TAG, "get_values: timeout");
+        xSemaphoreGive(s_cmd_mtx);
         return NULL;
     }
 
@@ -2972,6 +3182,7 @@ cJSON *as11_ble_get_values(const char *const *keys, int n_keys)
         ESP_LOGW(TAG, "get_values: RPC error: %s", s ? s : "?");
         if (s) free(s);
         cJSON_Delete(resp);
+        xSemaphoreGive(s_cmd_mtx);
         return NULL;
     }
 
@@ -2981,10 +3192,11 @@ cJSON *as11_ble_get_values(const char *const *keys, int n_keys)
         result = cJSON_DetachItemFromObject(resp, "result");
     }
     cJSON_Delete(resp);
+    xSemaphoreGive(s_cmd_mtx);
     return result;
 }
 
-esp_err_t as11_ble_stop_therapy(void)
+static esp_err_t as11_ble_stop_therapy_locked(void)
 {
     if (!s_session_encrypted) {
         ESP_LOGW(TAG, "stop_therapy: no encrypted session");
@@ -3018,7 +3230,17 @@ esp_err_t as11_ble_stop_therapy(void)
     return ESP_OK;
 }
 
-esp_err_t as11_ble_start_therapy(void)
+esp_err_t as11_ble_stop_therapy(void)
+{
+    if (!s_cmd_mtx || xSemaphoreTake(s_cmd_mtx, pdMS_TO_TICKS(10000)) != pdTRUE)
+        return ESP_ERR_TIMEOUT;
+    esp_err_t result = as11_ble_stop_therapy_locked();
+    clear_response();
+    xSemaphoreGive(s_cmd_mtx);
+    return result;
+}
+
+static esp_err_t as11_ble_start_therapy_locked(void)
 {
     if (!s_session_encrypted) {
         ESP_LOGW(TAG, "start_therapy: no encrypted session");
@@ -3050,6 +3272,16 @@ esp_err_t as11_ble_start_therapy(void)
     ESP_LOGI(TAG, "start_therapy: EnterTherapy accepted");
     cJSON_Delete(resp);
     return ESP_OK;
+}
+
+esp_err_t as11_ble_start_therapy(void)
+{
+    if (!s_cmd_mtx || xSemaphoreTake(s_cmd_mtx, pdMS_TO_TICKS(10000)) != pdTRUE)
+        return ESP_ERR_TIMEOUT;
+    esp_err_t result = as11_ble_start_therapy_locked();
+    clear_response();
+    xSemaphoreGive(s_cmd_mtx);
+    return result;
 }
 
 esp_err_t as11_ble_passthrough_rpc(const char *json_in, char **json_out, uint32_t timeout_ms)

--- a/main/as11_ble.h
+++ b/main/as11_ble.h
@@ -142,14 +142,21 @@ cJSON *as11_ble_get_values(const char *const *keys, int n_keys);
  * Returns ESP_OK on success. */
 esp_err_t as11_ble_stop_therapy(void);
 
-/* Send EnterTherapy RPC to start therapy on the AS11.
- * Requires an active encrypted BLE session.
- * Returns ESP_OK on success. */
-esp_err_t as11_ble_start_therapy(void);
+/* Send EnterTherapy RPC to start therapy on the AS11. Requires an active
+ * encrypted BLE session. Returns ESP_OK on success and additionally reports
+ * whether the request may have reached the AS11. The outcome pointer is
+ * required so lifecycle-changing callers cannot silently ignore ambiguity.
+ * The flag remains true for indeterminate post-send failures/timeouts and is
+ * false before any accepted GATT write or after an explicit RPC rejection. */
+esp_err_t as11_ble_start_therapy_tracked(bool *may_have_started);
 
 /* Generic BLE JSON-RPC passthrough interface.
  * Transmits json_in over the encrypted BLE session, awaits the AS11 response,
- * and returns the decrypted response string in *json_out (malloc'd, caller frees).
- * Requires an active encrypted BLE session. */
-esp_err_t as11_ble_passthrough_rpc(const char *json_in, char **json_out, uint32_t timeout_ms);
-
+ * and returns the decrypted response string in *json_out (malloc'd, caller
+ * frees). Requires an active encrypted BLE session. may_have_run is required
+ * and distinguishes a definitely-unsent request from
+ * an indeterminate post-send failure. */
+esp_err_t as11_ble_passthrough_rpc_tracked(const char *json_in,
+                                           char **json_out,
+                                           uint32_t timeout_ms,
+                                           bool *may_have_run);

--- a/main/board_waveshare_7b.c
+++ b/main/board_waveshare_7b.c
@@ -1,0 +1,708 @@
+/*
+ * SomnoTrace board support for Waveshare ESP32-S3-Touch-LCD-7B.
+ *
+ * The RGB timings, GPIO map, and CH32V003 controller assignments are adapted
+ * from the Waveshare ESP32-S3-Touch-LCD-7B examples (Apache-2.0). This
+ * adaptation is part of SomnoTrace and distributed under GPL-3.0-or-later.
+ */
+
+#include "board_waveshare_7b.h"
+
+#include <inttypes.h>
+#include <stdbool.h>
+#include "driver/gpio.h"
+#include "driver/i2c_master.h"
+#include "esp_check.h"
+#include "esp_lcd_panel_io.h"
+#include "esp_lcd_panel_rgb.h"
+#include "esp_lcd_touch_gt911.h"
+#include "controller_diagnostics.h"
+#include "psram_task.h"
+#include "esp_log.h"
+#include "esp_timer.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+#include "freertos/task.h"
+
+#define I2C_SDA GPIO_NUM_8
+#define I2C_SCL GPIO_NUM_9
+#define I2C_HZ  400000
+
+#define IOX_ADDR       0x24
+#define IOX_REG_MODE   0x02
+#define IOX_REG_OUTPUT 0x03
+#define IOX_REG_PWM    0x05
+#define IOX_TOUCH_RST  1
+#define IOX_BACKLIGHT  2
+#define IOX_SD_CS      4
+#define IOX_LCD_POWER  6
+#define IOX_USB_SELECT 5
+#define BOARD_I2C_TIMEOUT_MS 20
+#define BOARD_LOCK_TIMEOUT_MS 25
+#define BOARD_VISIBILITY_RETRY_US 250000LL
+#define BOARD_TOUCH_OFF_RESET_DELAY_US 50000LL
+#define GT911_ADDR 0x5d
+#define GT911_STATUS_REG 0x814e
+#define GT911_ID_REG 0x8140
+
+static const char *TAG = "board_7b";
+static i2c_master_bus_handle_t s_i2c;
+static i2c_master_dev_handle_t s_iox;
+static SemaphoreHandle_t s_lock;
+static uint8_t s_output = 0xff;
+static esp_lcd_panel_handle_t s_panel;
+static esp_lcd_touch_handle_t s_touch;
+static i2c_master_dev_handle_t s_touch_device;
+static TaskHandle_t s_touch_task;
+static portMUX_TYPE s_touch_lock = portMUX_INITIALIZER_UNLOCKED;
+static touch_observation_t s_touch_observation;
+static uint8_t s_attenuation;
+/* The output byte is desired state. Only an acknowledged ON operation may
+ * suppress a fresh touch's visibility check. This is not physical readback. */
+static bool s_backlight_on_acked;
+static bool s_backlight_off_acked;
+/* OFF acceptance and a pending retry's generation check share s_lock. */
+static uint32_t s_backlight_off_generation;
+typedef enum {
+    TOUCH_VISIBILITY_IDLE,
+    TOUCH_VISIBILITY_CHECK,
+    TOUCH_VISIBILITY_ASSERT,
+} touch_visibility_work_t;
+/* Only the touch worker owns this obligation and its retry deadline. */
+static touch_visibility_work_t s_touch_visibility_work;
+static uint32_t s_touch_visibility_generation;
+static int64_t s_touch_visibility_retry_at;
+static int64_t s_touch_visibility_requested_us;
+/* A successful physical ON->OFF transition queues one dark maintenance reset.
+ * ON cancels pending work; the touch task alone performs the reset. */
+static uint32_t s_touch_off_reset_generation;
+static int64_t s_touch_off_reset_due_us;
+static uint32_t s_touch_off_reset_requests;
+static bool s_touch_off_reset_pending;
+static bool s_touch_off_reset_active;
+static bool s_touch_off_reset_cancelled;
+
+static esp_err_t iox_write(uint8_t reg, uint8_t value)
+{
+    if (!s_iox) return ESP_ERR_INVALID_STATE;
+    uint8_t bytes[2] = { reg, value };
+    esp_err_t result = i2c_master_transmit(s_iox, bytes, sizeof(bytes), BOARD_I2C_TIMEOUT_MS);
+    if (result != ESP_OK) {
+        s_backlight_on_acked = false;
+        s_backlight_off_acked = false;
+    }
+    return result;
+}
+
+static esp_err_t iox_output(unsigned pin, bool high)
+{
+    if (!s_lock) return ESP_ERR_INVALID_STATE;
+    if (xSemaphoreTake(s_lock, pdMS_TO_TICKS(BOARD_LOCK_TIMEOUT_MS)) != pdTRUE)
+        return ESP_ERR_TIMEOUT;
+    if (pin == IOX_BACKLIGHT && high &&
+        __atomic_load_n(&s_touch_off_reset_active, __ATOMIC_ACQUIRE)) {
+        /* Keep the panel dark until an already-asserted touch reset is safe to
+         * release. The BSP retains ON as desired state and retries shortly. */
+        __atomic_store_n(&s_touch_off_reset_cancelled, true, __ATOMIC_RELEASE);
+        xSemaphoreGive(s_lock);
+        return ESP_ERR_TIMEOUT;
+    }
+    if (pin == IOX_BACKLIGHT && !high &&
+        __atomic_load_n(&s_touch_off_reset_active, __ATOMIC_ACQUIRE)) {
+        /* OFF is now the newest intent. Withdraw an earlier ON cancellation
+         * and let the already-claimed dark reset satisfy this transition. */
+        __atomic_store_n(&s_touch_off_reset_cancelled, false, __ATOMIC_RELEASE);
+    }
+    bool was_off_acked = s_backlight_off_acked;
+    uint32_t off_generation = s_backlight_off_generation;
+    if (pin == IOX_BACKLIGHT && !high)
+        off_generation = __atomic_add_fetch(&s_backlight_off_generation, 1U,
+                                            __ATOMIC_RELAXED);
+    if (high) s_output |= (uint8_t)(1U << pin);
+    else s_output &= (uint8_t)~(1U << pin);
+    esp_err_t ret = iox_write(IOX_REG_OUTPUT, s_output);
+    if (pin == IOX_BACKLIGHT) {
+        s_backlight_on_acked = ret == ESP_OK && high;
+        s_backlight_off_acked = ret == ESP_OK && !high;
+        if (ret == ESP_OK && !high && !was_off_acked) {
+            s_touch_off_reset_generation = off_generation;
+            s_touch_off_reset_due_us = esp_timer_get_time() +
+                                       BOARD_TOUCH_OFF_RESET_DELAY_US;
+            __atomic_store_n(&s_touch_off_reset_pending, true, __ATOMIC_RELEASE);
+            __atomic_add_fetch(&s_touch_off_reset_requests, 1U,
+                               __ATOMIC_RELAXED);
+        } else if (ret == ESP_OK && !high &&
+                   __atomic_load_n(&s_touch_off_reset_pending, __ATOMIC_ACQUIRE)) {
+            /* Preserve one already-queued reset across a duplicate OFF write,
+             * while advancing its ordering fence to the newest generation. */
+            s_touch_off_reset_generation = off_generation;
+        } else if (ret == ESP_OK && high) {
+            s_touch_off_reset_generation = 0;
+            __atomic_store_n(&s_touch_off_reset_pending, false, __ATOMIC_RELEASE);
+        }
+    }
+    xSemaphoreGive(s_lock);
+    return ret;
+}
+
+static esp_err_t init_i2c_and_expander(void)
+{
+    if (s_i2c) return ESP_OK;
+
+    i2c_master_bus_config_t bus_cfg = {
+        .i2c_port = I2C_NUM_0,
+        .sda_io_num = I2C_SDA,
+        .scl_io_num = I2C_SCL,
+        .clk_source = I2C_CLK_SRC_DEFAULT,
+        .glitch_ignore_cnt = 7,
+        .flags.enable_internal_pullup = true,
+    };
+    ESP_RETURN_ON_ERROR(i2c_new_master_bus(&bus_cfg, &s_i2c), TAG,
+                        "create board I2C bus");
+
+    i2c_device_config_t dev_cfg = {
+        .device_address = IOX_ADDR,
+        .scl_speed_hz = I2C_HZ,
+    };
+    ESP_RETURN_ON_ERROR(i2c_master_bus_add_device(s_i2c, &dev_cfg, &s_iox), TAG,
+                        "attach CH32V003 I/O controller");
+
+    s_lock = xSemaphoreCreateMutex();
+    ESP_RETURN_ON_FALSE(s_lock, ESP_ERR_NO_MEM, TAG, "create expander mutex");
+    ESP_RETURN_ON_ERROR(iox_write(IOX_REG_MODE, 0xff), TAG,
+                        "configure CH32V003 outputs");
+    ESP_RETURN_ON_ERROR(iox_write(IOX_REG_OUTPUT, s_output), TAG,
+                        "initialize CH32V003 outputs");
+    return ESP_OK;
+}
+
+static esp_err_t init_rgb_panel(void)
+{
+    if (s_panel) return ESP_OK;
+
+    esp_lcd_rgb_panel_config_t cfg = {
+        .clk_src = LCD_CLK_SRC_DEFAULT,
+        .timings = {
+            /* Physical testing accepted Waveshare's 30.85 MHz scan clock as
+             * the no-shimmer/no-tearing default when paired with the
+             * cache-sized ten-line bounce buffer below.  Keep this boot value
+             * aligned with the accepted runtime A/B result so a later flash
+             * cannot silently restore the visibly shimmering 18 MHz mode. */
+            .pclk_hz = 30850000,
+            .h_res = WAVESHARE_7B_H_RES,
+            .v_res = WAVESHARE_7B_V_RES,
+            .hsync_pulse_width = 162,
+            .hsync_back_porch = 152,
+            .hsync_front_porch = 48,
+            .vsync_pulse_width = 45,
+            .vsync_back_porch = 13,
+            .vsync_front_porch = 3,
+            .flags.pclk_active_neg = true,
+        },
+        .data_width = 16,
+        .bits_per_pixel = 16,
+        .num_fbs = 2,
+        /* Ten lines matches Waveshare's older 30.85 MHz 7B configuration.
+         * Each RGB565 refill is 20 KiB, comfortably inside the configured
+         * 64 KiB data cache, so scanout does not evict LVGL's entire working
+         * set on every DMA EOF. The two buffers also use 40 KiB less internal
+         * RAM than the previous twenty-line configuration. */
+        .bounce_buffer_size_px = WAVESHARE_7B_H_RES * 10,
+        .sram_trans_align = 4,
+        .psram_trans_align = 64,
+        .hsync_gpio_num = GPIO_NUM_46,
+        .vsync_gpio_num = GPIO_NUM_3,
+        .de_gpio_num = GPIO_NUM_5,
+        .pclk_gpio_num = GPIO_NUM_7,
+        .disp_gpio_num = GPIO_NUM_NC,
+        .data_gpio_nums = {
+            GPIO_NUM_14, GPIO_NUM_38, GPIO_NUM_18, GPIO_NUM_17, GPIO_NUM_10,
+            GPIO_NUM_39, GPIO_NUM_0, GPIO_NUM_45, GPIO_NUM_48, GPIO_NUM_47,
+            GPIO_NUM_21, GPIO_NUM_1, GPIO_NUM_2, GPIO_NUM_42, GPIO_NUM_41,
+            GPIO_NUM_40,
+        },
+        .flags.fb_in_psram = true,
+    };
+
+    ESP_RETURN_ON_ERROR(esp_lcd_new_rgb_panel(&cfg, &s_panel), TAG,
+                        "create RGB panel");
+    ESP_RETURN_ON_ERROR(esp_lcd_panel_init(s_panel), TAG, "initialize RGB panel");
+    return ESP_OK;
+}
+
+static esp_err_t init_touch(void)
+{
+    if (s_touch) return ESP_OK;
+
+    /* Select the GT911's 0x5d address while releasing reset through EXIO1. */
+    ESP_RETURN_ON_ERROR(iox_output(IOX_TOUCH_RST, false), TAG, "hold touch reset");
+    gpio_config_t int_out = {
+        .pin_bit_mask = 1ULL << GPIO_NUM_4,
+        .mode = GPIO_MODE_OUTPUT,
+        .pull_up_en = GPIO_PULLUP_ENABLE,
+    };
+    ESP_RETURN_ON_ERROR(gpio_config(&int_out), TAG, "configure touch interrupt");
+    vTaskDelay(pdMS_TO_TICKS(100));
+    gpio_set_level(GPIO_NUM_4, 0);
+    vTaskDelay(pdMS_TO_TICKS(100));
+    ESP_RETURN_ON_ERROR(iox_output(IOX_TOUCH_RST, true), TAG, "release touch reset");
+    vTaskDelay(pdMS_TO_TICKS(200));
+
+    esp_lcd_panel_io_i2c_config_t io_cfg = ESP_LCD_TOUCH_IO_I2C_GT911_CONFIG();
+    io_cfg.scl_speed_hz = I2C_HZ;
+    esp_lcd_panel_io_handle_t touch_io = NULL;
+    ESP_RETURN_ON_ERROR(esp_lcd_new_panel_io_i2c(s_i2c, &io_cfg, &touch_io), TAG,
+                        "create GT911 I2C IO");
+
+    static esp_lcd_touch_io_gt911_config_t gt_cfg;
+    gt_cfg.dev_addr = io_cfg.dev_addr;
+    esp_lcd_touch_config_t touch_cfg = {
+        .x_max = WAVESHARE_7B_H_RES,
+        .y_max = WAVESHARE_7B_V_RES,
+        .rst_gpio_num = GPIO_NUM_NC,
+        .int_gpio_num = GPIO_NUM_4,
+        .levels = { .reset = 0, .interrupt = 0 },
+        .flags = { .swap_xy = 0, .mirror_x = 0, .mirror_y = 0 },
+        .driver_data = &gt_cfg,
+    };
+    esp_err_t result = esp_lcd_touch_new_i2c_gt911(touch_io, &touch_cfg, &s_touch);
+    if (result != ESP_OK) {
+        /* The vendor deletes its touch object on failure, but leaves the
+         * caller-owned panel IO allocated. Runtime recovery uses its own IO. */
+        esp_lcd_panel_io_del(touch_io);
+        s_touch = NULL;
+    }
+    return result;
+}
+
+esp_err_t waveshare_7b_init(esp_lcd_panel_handle_t *panel,
+                            esp_lcd_touch_handle_t *touch)
+{
+    ESP_RETURN_ON_ERROR(init_i2c_and_expander(), TAG, "board control init");
+    ESP_RETURN_ON_ERROR(iox_output(IOX_LCD_POWER, true), TAG, "LCD power enable");
+    /* EXIO5 low connects the native USB port instead of the optional CAN
+     * transceiver, preserving USB-Serial-JTAG logs after board init. */
+    ESP_RETURN_ON_ERROR(iox_output(IOX_USB_SELECT, false), TAG, "USB select");
+    ESP_RETURN_ON_ERROR(iox_output(IOX_SD_CS, true), TAG, "TF card select release");
+    ESP_RETURN_ON_ERROR(init_rgb_panel(), TAG, "RGB display init");
+
+    esp_err_t touch_ret = init_touch();
+    controller_diagnostics_record(CONTROLLER_TOUCH_INIT, touch_ret);
+    if (touch_ret != ESP_OK) {
+        /* The display and the rest of SomnoTrace remain useful without touch. */
+        ESP_LOGW(TAG, "GT911 unavailable: %s", esp_err_to_name(touch_ret));
+    }
+    ESP_RETURN_ON_ERROR(iox_output(IOX_BACKLIGHT, true), TAG, "backlight enable");
+
+    if (panel) *panel = s_panel;
+    if (touch) *touch = s_touch;
+    ESP_LOGI(TAG, "Waveshare 7B ready: RGB=%dx%d touch=%s",
+             WAVESHARE_7B_H_RES, WAVESHARE_7B_V_RES, s_touch ? "yes" : "no");
+    return ESP_OK;
+}
+
+esp_err_t waveshare_7b_set_backlight(bool on)
+{
+    esp_err_t result = init_i2c_and_expander();
+    /* EXIO2 is the panel's hardware enable. An off request removes the
+     * backlight electrically; it is not a black framebuffer or 0% PWM. */
+    if (result == ESP_OK) result = iox_output(IOX_BACKLIGHT, on);
+    controller_diagnostics_record(CONTROLLER_BACKLIGHT_POWER, result);
+    return result;
+}
+
+esp_err_t waveshare_7b_set_brightness(uint8_t percent)
+{
+    esp_err_t result = init_i2c_and_expander();
+    waveshare_7b_recovery_brightness(percent);
+    if (percent > 100) percent = 100;
+    /* The Waveshare I/O controller drives the backlight PWM active-low:
+     * command 0 is steady/full-on and increasing values add off-time. Keep
+     * the vendor's 97% attenuation limit so minimum brightness never becomes
+     * indistinguishable from the separate hard-off control. */
+    uint8_t attenuation = (uint8_t)(100U - percent);
+    if (attenuation > 97) attenuation = 97;
+    uint8_t pwm = (uint8_t)(attenuation * 255U / 100U);
+    if (result == ESP_OK) {
+        if (xSemaphoreTake(s_lock, pdMS_TO_TICKS(BOARD_LOCK_TIMEOUT_MS)) != pdTRUE) {
+            result = ESP_ERR_TIMEOUT;
+        } else {
+            /* This is desired PWM, retained for recovery even after failure. */
+            pwm = __atomic_load_n(&s_attenuation, __ATOMIC_RELAXED);
+            result = iox_write(IOX_REG_PWM, pwm);
+            xSemaphoreGive(s_lock);
+        }
+    }
+    controller_diagnostics_record(CONTROLLER_BACKLIGHT_BRIGHTNESS, result);
+    return result;
+}
+
+void waveshare_7b_recovery_brightness(uint8_t percent)
+{
+    if (percent > 100) percent = 100;
+    uint8_t attenuation = (uint8_t)(100U - percent);
+    if (attenuation > 97) attenuation = 97;
+    __atomic_store_n(&s_attenuation, (uint8_t)(attenuation * 255U / 100U),
+                     __ATOMIC_RELAXED);
+}
+
+/* Caller holds s_lock, including any pending-work generation check. */
+static esp_err_t reassert_visible_locked(void)
+{
+    if (__atomic_load_n(&s_touch_off_reset_active, __ATOMIC_ACQUIRE)) {
+        __atomic_store_n(&s_touch_off_reset_cancelled, true, __ATOMIC_RELEASE);
+        return ESP_ERR_TIMEOUT;
+    }
+    /* Preserve SD/USB and an ongoing touch reset. Attempt each output stage
+     * even when an earlier transaction fails. */
+    esp_err_t mode = iox_write(IOX_REG_MODE, 0xff);
+    esp_err_t pwm = iox_write(IOX_REG_PWM,
+                               __atomic_load_n(&s_attenuation, __ATOMIC_RELAXED));
+    s_output |= (uint8_t)((1U << IOX_LCD_POWER) | (1U << IOX_BACKLIGHT));
+    esp_err_t power = iox_write(IOX_REG_OUTPUT, s_output);
+    esp_err_t result = mode != ESP_OK ? mode : pwm != ESP_OK ? pwm : power;
+    s_backlight_on_acked = result == ESP_OK;
+    s_backlight_off_acked = false;
+    if (result == ESP_OK) {
+        s_touch_off_reset_generation = 0;
+        __atomic_store_n(&s_touch_off_reset_pending, false, __ATOMIC_RELEASE);
+    }
+    controller_diagnostics_record(CONTROLLER_OUTPUT_MODE, mode);
+    controller_diagnostics_record(CONTROLLER_BACKLIGHT_BRIGHTNESS, pwm);
+    controller_diagnostics_record(CONTROLLER_LCD_POWER, power);
+    controller_diagnostics_record(CONTROLLER_BACKLIGHT_POWER, power);
+    return result;
+}
+
+esp_err_t waveshare_7b_reassert_visible(void)
+{
+    if (!s_lock || !s_iox) return ESP_ERR_INVALID_STATE;
+    if (xSemaphoreTake(s_lock, pdMS_TO_TICKS(BOARD_LOCK_TIMEOUT_MS)) != pdTRUE)
+        return ESP_ERR_TIMEOUT;
+    esp_err_t result = reassert_visible_locked();
+    xSemaphoreGive(s_lock);
+    return result;
+}
+
+void waveshare_7b_touch_snapshot(touch_observation_t *out)
+{
+    if (!out) return;
+    portENTER_CRITICAL(&s_touch_lock);
+    *out = s_touch_observation;
+    portEXIT_CRITICAL(&s_touch_lock);
+}
+
+static void publish_touch(const touch_observation_t *state)
+{
+    portENTER_CRITICAL(&s_touch_lock);
+    s_touch_observation = *state;
+    portEXIT_CRITICAL(&s_touch_lock);
+}
+
+static esp_err_t touch_read_register(uint16_t reg, void *data, size_t size)
+{
+    uint8_t address[] = { (uint8_t)(reg >> 8), (uint8_t)reg };
+    return i2c_master_transmit_receive(s_touch_device, address, sizeof(address),
+                                      data, size, BOARD_I2C_TIMEOUT_MS);
+}
+
+static esp_err_t touch_read_frame(bool *frame, bool *pressed,
+                                  uint16_t *x, uint16_t *y)
+{
+    *frame = false;
+    *pressed = false;
+    uint8_t status = 0;
+    esp_err_t result = touch_read_register(GT911_STATUS_REG, &status, 1);
+    if (result != ESP_OK || !(status & 0x80)) return result;
+    uint8_t count = status & 0x0f;
+    uint8_t point[8] = {0};
+    if (count > 0 && count <= 5)
+        result = touch_read_register(GT911_STATUS_REG + 1, point, sizeof(point));
+    uint8_t clear[] = { GT911_STATUS_REG >> 8, GT911_STATUS_REG & 0xff, 0 };
+    esp_err_t cleared = i2c_master_transmit(s_touch_device, clear, sizeof(clear),
+                                           BOARD_I2C_TIMEOUT_MS);
+    if (result != ESP_OK) return result;
+    if (cleared != ESP_OK) return cleared;
+    if (count > 5) return ESP_ERR_INVALID_SIZE;
+    *frame = true;
+    *pressed = count != 0;
+    *x = (uint16_t)point[1] | (uint16_t)point[2] << 8;
+    *y = (uint16_t)point[3] | (uint16_t)point[4] << 8;
+    return ESP_OK;
+}
+
+static esp_err_t assert_touch_reset(bool cancellable, bool *cancelled)
+{
+    if (cancelled) *cancelled = false;
+    if (xSemaphoreTake(s_lock, pdMS_TO_TICKS(BOARD_LOCK_TIMEOUT_MS)) != pdTRUE)
+        return ESP_ERR_TIMEOUT;
+    if (cancellable &&
+        __atomic_load_n(&s_touch_off_reset_active, __ATOMIC_ACQUIRE) &&
+        __atomic_load_n(&s_touch_off_reset_cancelled, __ATOMIC_ACQUIRE)) {
+        if (cancelled) *cancelled = true;
+        xSemaphoreGive(s_lock);
+        return ESP_OK;
+    }
+    s_output &= (uint8_t)~(1U << IOX_TOUCH_RST);
+    esp_err_t result = iox_write(IOX_REG_OUTPUT, s_output);
+    xSemaphoreGive(s_lock);
+    return result;
+}
+
+static esp_err_t recover_touch(bool cancellable, bool *cancelled)
+{
+    /* Only the touch worker uses GPIO4 or the GT911 runtime handle. LVGL never
+     * waits for this reset sequence and observes released/invalid input until
+     * a new complete controller frame arrives. */
+    esp_err_t result = assert_touch_reset(cancellable, cancelled);
+    if (cancelled && *cancelled) return ESP_OK;
+    gpio_config_t output = {
+        .pin_bit_mask = 1ULL << GPIO_NUM_4,
+        .mode = GPIO_MODE_OUTPUT,
+        .pull_up_en = GPIO_PULLUP_DISABLE,
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,
+        .intr_type = GPIO_INTR_DISABLE,
+    };
+    if (result == ESP_OK) result = gpio_config(&output);
+    if (result == ESP_OK) result = gpio_set_level(GPIO_NUM_4, 0);
+    vTaskDelay(pdMS_TO_TICKS(100));
+    /* Always try to release reset, even after a failed preceding operation. */
+    esp_err_t release = iox_output(IOX_TOUCH_RST, true);
+    if (result == ESP_OK) result = release;
+    vTaskDelay(pdMS_TO_TICKS(200));
+    gpio_config_t input = output;
+    input.mode = GPIO_MODE_INPUT;
+    /* Goodix specifies a floating INT line after address selection. */
+    input.pull_up_en = GPIO_PULLUP_DISABLE;
+    esp_err_t restored = gpio_config(&input);
+    if (result == ESP_OK) result = restored;
+    uint8_t id[4] = {0};
+    if (result == ESP_OK) result = touch_read_register(GT911_ID_REG, id, sizeof(id));
+    if (result == ESP_OK && (id[0] != '9' || id[1] != '1' || id[2] != '1'))
+        result = ESP_ERR_INVALID_RESPONSE;
+    controller_diagnostics_record(CONTROLLER_TOUCH_RECOVERY, result);
+    return result;
+}
+
+static void service_touch_visibility(touch_observation_t *state)
+{
+    if (s_touch_visibility_work == TOUCH_VISIBILITY_IDLE ||
+        esp_timer_get_time() < s_touch_visibility_retry_at) return;
+    if (xSemaphoreTake(s_lock, pdMS_TO_TICKS(BOARD_LOCK_TIMEOUT_MS)) != pdTRUE) {
+        s_touch_visibility_retry_at = esp_timer_get_time() + BOARD_VISIBILITY_RETRY_US;
+        return;
+    }
+    /* A newer explicit OFF cancels old work before any retry can write ON.
+     * Keeping this check and the write under one mutex closes the race. */
+    if (s_touch_visibility_generation !=
+        __atomic_load_n(&s_backlight_off_generation, __ATOMIC_RELAXED)) {
+        s_touch_visibility_work = TOUCH_VISIBILITY_IDLE;
+        xSemaphoreGive(s_lock);
+        return;
+    }
+    bool notify = false;
+    if (s_touch_visibility_work == TOUCH_VISIBILITY_CHECK) {
+        if (s_backlight_on_acked) {
+            s_touch_visibility_work = TOUCH_VISIBILITY_IDLE;
+            xSemaphoreGive(s_lock);
+            return;
+        }
+        s_touch_visibility_work = TOUCH_VISIBILITY_ASSERT;
+        notify = true;
+    }
+    esp_err_t result = reassert_visible_locked();
+    if (result == ESP_OK) s_touch_visibility_work = TOUCH_VISIBILITY_IDLE;
+    else s_touch_visibility_retry_at = esp_timer_get_time() + BOARD_VISIBILITY_RETRY_US;
+    xSemaphoreGive(s_lock);
+    if (notify) {
+        state->visibility_requested_us = s_touch_visibility_requested_us;
+        ++state->visibility_requests;
+        publish_touch(state);
+    }
+}
+
+static void request_visible(touch_observation_t *state)
+{
+    s_touch_visibility_work = TOUCH_VISIBILITY_ASSERT;
+    s_touch_visibility_generation =
+        __atomic_load_n(&s_backlight_off_generation, __ATOMIC_RELAXED);
+    s_touch_visibility_retry_at = 0;
+    s_touch_visibility_requested_us = esp_timer_get_time();
+    state->visibility_requested_us = s_touch_visibility_requested_us;
+    ++state->visibility_requests;
+    publish_touch(state);
+    /* The independent operation persists until acknowledged or superseded. */
+    service_touch_visibility(state);
+}
+
+static void queue_touch_wake_check(uint32_t generation, int64_t requested_us)
+{
+    if (s_touch_visibility_work != TOUCH_VISIBILITY_IDLE &&
+        s_touch_visibility_generation == generation) return;
+    s_touch_visibility_work = TOUCH_VISIBILITY_CHECK;
+    s_touch_visibility_generation = generation;
+    s_touch_visibility_requested_us = requested_us;
+    s_touch_visibility_retry_at = 0;
+}
+
+static bool service_touch_off_reset(touch_observation_t *state)
+{
+    state->preventive_recovery_requests =
+        __atomic_load_n(&s_touch_off_reset_requests, __ATOMIC_RELAXED);
+    if (!__atomic_load_n(&s_touch_off_reset_pending, __ATOMIC_ACQUIRE))
+        return false;
+    if (xSemaphoreTake(s_lock, pdMS_TO_TICKS(BOARD_LOCK_TIMEOUT_MS)) != pdTRUE)
+        return false;
+    if (!__atomic_load_n(&s_touch_off_reset_pending, __ATOMIC_ACQUIRE) ||
+        esp_timer_get_time() < s_touch_off_reset_due_us) {
+        xSemaphoreGive(s_lock);
+        return false;
+    }
+    uint32_t generation = s_touch_off_reset_generation;
+    bool current = generation != 0 &&
+                   generation == __atomic_load_n(&s_backlight_off_generation,
+                                                  __ATOMIC_RELAXED) &&
+                   s_backlight_off_acked &&
+                   !(s_output & (1U << IOX_BACKLIGHT));
+    s_touch_off_reset_generation = 0;
+    __atomic_store_n(&s_touch_off_reset_pending, false, __ATOMIC_RELEASE);
+    __atomic_store_n(&s_touch_off_reset_active, current, __ATOMIC_RELEASE);
+    __atomic_store_n(&s_touch_off_reset_cancelled, false, __ATOMIC_RELEASE);
+    xSemaphoreGive(s_lock);
+    if (!current) return false;
+
+    touch_observation_preventive_recovering(state);
+    publish_touch(state);
+    bool cancelled = false;
+    esp_err_t result = recover_touch(true, &cancelled);
+    __atomic_store_n(&s_touch_off_reset_active, false, __ATOMIC_RELEASE);
+    __atomic_store_n(&s_touch_off_reset_cancelled, false, __ATOMIC_RELEASE);
+    ESP_LOGI(TAG, "dark touch reset %lu: %s",
+             (unsigned long)state->preventive_recovery_attempts,
+             esp_err_to_name(result));
+    if (result == ESP_OK) {
+        /* Keep the maintenance marker until the first status read, but do not
+         * route a completed reset through the failure-recovery branch below. */
+        state->recovering = false;
+        if (cancelled) state->preventive_recovery = false;
+        return true;
+    }
+
+    /* A failed maintenance reset becomes ordinary sticky recovery so the UI
+     * fails visibly and the existing bounded retry path takes ownership. */
+    state->preventive_recovery = false;
+    touch_observation_update(state, esp_timer_get_time(), result,
+                             false, false, 0, 0);
+    publish_touch(state);
+    return true;
+}
+
+static void touch_task(void *argument)
+{
+    (void)argument;
+    touch_observation_t state = {0};
+    if (!s_touch) {
+        /* A failed boot probe may leave reset/INT partway through address
+         * selection. Restore those pins before the first runtime read. */
+        state.consecutive_errors = TOUCH_OBSERVATION_FAILURE_LIMIT;
+        state.recovering = true;
+        publish_touch(&state);
+    }
+    int64_t retry_at = 0;
+    for (;;) {
+        service_touch_visibility(&state);
+        (void)service_touch_off_reset(&state);
+        int64_t now = esp_timer_get_time();
+        if (state.recovering ||
+            state.consecutive_errors >= TOUCH_OBSERVATION_FAILURE_LIMIT) {
+            /* A status read cannot prove that reset/INT restoration succeeded.
+             * Keep a failed reset pending until the complete sequence passes. */
+            if (now < retry_at) {
+                vTaskDelay(pdMS_TO_TICKS(250));
+                continue;
+            }
+            touch_observation_recovering(&state);
+            publish_touch(&state);
+            request_visible(&state);
+            esp_err_t recovered = recover_touch(false, NULL);
+            retry_at = esp_timer_get_time() + 5000000LL;
+            if (recovered != ESP_OK) {
+                touch_observation_update(&state, esp_timer_get_time(), recovered,
+                                          false, false, 0, 0);
+                publish_touch(&state);
+            }
+            ESP_LOGW(TAG, "touch recovery attempt %lu: %s",
+                     (unsigned long)state.recovery_attempts, esp_err_to_name(recovered));
+            if (recovered != ESP_OK) {
+                vTaskDelay(pdMS_TO_TICKS(250));
+                continue;
+            }
+        }
+        bool frame = false, pressed = false;
+        uint16_t x = 0, y = 0;
+        bool was_pressed = touch_observation_pressed(&state, esp_timer_get_time());
+        uint8_t prior_errors = state.consecutive_errors;
+        /* Keep the original sample order across a concurrent OFF or a delayed
+         * lock retry. A late notification must not become a new wake request. */
+        uint32_t sampled_generation =
+            __atomic_load_n(&s_backlight_off_generation, __ATOMIC_RELAXED);
+        int64_t sampled_us = esp_timer_get_time();
+        esp_err_t result = touch_read_frame(&frame, &pressed, &x, &y);
+        controller_diagnostics_record(CONTROLLER_TOUCH_READ, result);
+        if (result != ESP_OK && state.preventive_recovery)
+            state.preventive_recovery = false;
+        touch_observation_update(&state, esp_timer_get_time(), result,
+                                  frame, pressed, x, y);
+        bool failed = prior_errors < TOUCH_OBSERVATION_FAILURE_LIMIT &&
+                      state.consecutive_errors >= TOUCH_OBSERVATION_FAILURE_LIMIT;
+        if (!was_pressed && touch_observation_pressed(&state, esp_timer_get_time()))
+            queue_touch_wake_check(sampled_generation, sampled_us);
+        if (failed) request_visible(&state);
+        service_touch_visibility(&state);
+        publish_touch(&state);
+        /* Bound a failed peripheral's logging and bus traffic; never hammer
+         * it at the UI's 10 ms input cadence while it is unavailable. */
+        vTaskDelay(pdMS_TO_TICKS(result == ESP_OK ? 10 : 250));
+    }
+}
+
+esp_err_t waveshare_7b_start_touch(void)
+{
+    if (s_touch_task) return ESP_OK;
+    if (!s_i2c || !s_lock || !s_iox) return ESP_ERR_INVALID_STATE;
+    i2c_device_config_t device = {
+        .device_address = GT911_ADDR,
+        .scl_speed_hz = I2C_HZ,
+    };
+    esp_err_t result = i2c_master_bus_add_device(s_i2c, &device, &s_touch_device);
+    if (result != ESP_OK) return result;
+    s_touch_task = psram_task_create(touch_task, "touch_7b", 4096, NULL, 5,
+                                     tskNO_AFFINITY, NULL, NULL);
+    if (!s_touch_task) {
+        i2c_master_bus_rm_device(s_touch_device);
+        s_touch_device = NULL;
+        return ESP_ERR_NO_MEM;
+    }
+    return ESP_OK;
+}
+
+esp_err_t waveshare_7b_set_panel_pclk(uint32_t hz)
+{
+    /* Keep this deliberately narrow: 30.85 MHz is the accepted boot clock;
+     * 18 MHz remains available only as an A/B diagnostic fallback. */
+    if (hz != 18000000U && hz != 30850000U) return ESP_ERR_INVALID_ARG;
+    if (!s_panel) return ESP_ERR_INVALID_STATE;
+
+    esp_err_t err = esp_lcd_rgb_panel_set_pclk(s_panel, hz);
+    if (err == ESP_OK) {
+        ESP_LOGW(TAG, "diagnostic RGB pixel clock requested: %" PRIu32 " Hz", hz);
+    }
+    return err;
+}
+
+esp_err_t waveshare_7b_prepare_sd(void)
+{
+    ESP_RETURN_ON_ERROR(init_i2c_and_expander(), TAG, "board control init");
+    /* In one-bit SD mode DAT3/CS must remain high. */
+    return iox_output(IOX_SD_CS, true);
+}

--- a/main/board_waveshare_7b.h
+++ b/main/board_waveshare_7b.h
@@ -1,0 +1,30 @@
+/*
+ * SomnoTrace board support for Waveshare ESP32-S3-Touch-LCD-7B.
+ * Hardware timings and pin assignments are derived from Waveshare's
+ * Apache-2.0 ESP-IDF examples for this board.
+ */
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "esp_err.h"
+#include "esp_lcd_panel_ops.h"
+#include "esp_lcd_touch.h"
+#include "touch_observation.h"
+
+#define WAVESHARE_7B_H_RES 1024
+#define WAVESHARE_7B_V_RES 600
+
+esp_err_t waveshare_7b_init(esp_lcd_panel_handle_t *panel,
+                            esp_lcd_touch_handle_t *touch);
+esp_err_t waveshare_7b_set_backlight(bool on);
+esp_err_t waveshare_7b_set_brightness(uint8_t percent);
+esp_err_t waveshare_7b_set_panel_pclk(uint32_t hz);
+esp_err_t waveshare_7b_prepare_sd(void);
+/* Runtime reads have one retained worker; UI consumers only copy observations. */
+esp_err_t waveshare_7b_start_touch(void);
+void waveshare_7b_touch_snapshot(touch_observation_t *out);
+/* Reapply controller mode, LCD power, PWM and backlight enable even if cached
+ * application state says on. Preserve unrelated output bits. */
+esp_err_t waveshare_7b_reassert_visible(void);
+void waveshare_7b_recovery_brightness(uint8_t percent);

--- a/main/bsp_audio_7b.c
+++ b/main/bsp_audio_7b.c
@@ -1,0 +1,31 @@
+/* SomnoTrace audio shim for Waveshare ESP32-S3-Touch-LCD-7B. */
+#include "bsp_audio.h"
+
+#include "esp_log.h"
+
+static uint8_t s_volume = 100;
+
+esp_err_t bsp_audio_init(void)
+{
+    return ESP_ERR_NOT_SUPPORTED;
+}
+
+esp_err_t bsp_audio_beep(int freq_hz, int duration_ms, uint8_t volume)
+{
+    (void)freq_hz;
+    (void)duration_ms;
+    (void)volume;
+    return ESP_ERR_NOT_SUPPORTED;
+}
+
+void bsp_audio_set_volume(uint8_t percent)
+{
+    s_volume = percent > 100 ? 100 : percent;
+}
+
+esp_err_t bsp_audio_test_beep(void)
+{
+    ESP_LOGW("bsp_audio_7b", "7B has no onboard SomnoTrace alert speaker (volume=%u)",
+             (unsigned)s_volume);
+    return ESP_ERR_NOT_SUPPORTED;
+}

--- a/main/bsp_display.c
+++ b/main/bsp_display.c
@@ -597,9 +597,8 @@ static void lcd_flush(void)
 {
     if (!s_panel || !s_fb) return;
 
-    if (!s_strip[0] || !s_flush_done) {
-        /* Fallback (e.g. strip alloc failed): single direct draw. */
-        esp_lcd_panel_draw_bitmap(s_panel, 0, 0, LCD_H_RES, LCD_V_RES, s_fb);
+    if (!s_strip[0] || !s_strip[1] || !s_flush_done) {
+        ESP_LOGE(TAG, "LCD strip transport unavailable; frame skipped");
         return;
     }
 
@@ -911,8 +910,58 @@ static void display_supervisor_cb(void *arg)
     }
 }
 
+static void display_buffers_free(void)
+{
+    heap_caps_free(s_fb);
+    s_fb = NULL;
+    heap_caps_free(s_flow_buf);
+    s_flow_buf = NULL;
+    heap_caps_free(s_flow_local);
+    s_flow_local = NULL;
+    heap_caps_free(s_flow_yf);
+    s_flow_yf = NULL;
+    if (s_state_mutex) vSemaphoreDelete(s_state_mutex);
+    s_state_mutex = NULL;
+    for (int i = 0; i < LCD_STRIP_BUFS; ++i) {
+        heap_caps_free(s_strip[i]);
+        s_strip[i] = NULL;
+    }
+    if (s_flush_done) vSemaphoreDelete(s_flush_done);
+    s_flush_done = NULL;
+}
+static esp_err_t display_buffers_init(void)
+{
+    s_fb = heap_caps_malloc(LCD_H_RES * LCD_V_RES * sizeof(uint16_t), MALLOC_CAP_SPIRAM);
+    if (!s_fb)
+        s_fb = heap_caps_malloc(LCD_H_RES * LCD_V_RES * sizeof(uint16_t), MALLOC_CAP_DMA);
+    if (!s_fb) goto no_mem;
+
+    s_flow_buf = heap_caps_calloc(FLOW_BUF_SIZE, sizeof(float), MALLOC_CAP_SPIRAM);
+    s_flow_local = heap_caps_malloc(FLOW_BUF_SIZE * sizeof(float), MALLOC_CAP_SPIRAM);
+    s_flow_yf = heap_caps_malloc(LCD_H_RES * sizeof(float), MALLOC_CAP_SPIRAM);
+    if (!s_flow_buf || !s_flow_local || !s_flow_yf) goto no_mem;
+
+    for (int i = 0; i < LCD_STRIP_BUFS; ++i) {
+        s_strip[i] = heap_caps_malloc(LCD_H_RES * LCD_STRIP_ROWS * sizeof(uint16_t),
+                                      MALLOC_CAP_DMA);
+        if (!s_strip[i]) goto no_mem;
+    }
+    s_flush_done = xSemaphoreCreateCounting(LCD_STRIP_BUFS, 0);
+    if (!s_flush_done) goto no_mem;
+    s_state_mutex = xSemaphoreCreateMutex();
+    if (!s_state_mutex) goto no_mem;
+    return ESP_OK;
+
+no_mem:
+    display_buffers_free();
+    ESP_LOGE(TAG, "display buffer/semaphore allocation failed");
+    return ESP_ERR_NO_MEM;
+}
+
 esp_err_t bsp_display_init(void)
 {
+    esp_err_t err = display_buffers_init();
+    if (err != ESP_OK) return err;
     /* The project's default log level is DEBUG; spi_master emits several DEBUG
      * lines per DMA transaction. At the LCD's transfer rate that is a real CPU
      * and I/O drain, so quiet it down to WARN regardless of the global level. */
@@ -940,8 +989,6 @@ esp_err_t bsp_display_init(void)
     ESP_ERROR_CHECK(ledc_channel_config(&bl_ch));
     s_backlight_on = true;
     s_brightness = 100;
-
-    s_flush_done = xSemaphoreCreateCounting(LCD_STRIP_BUFS, 0);
 
     spi_bus_config_t bus_cfg = {
         .sclk_io_num = LCD_PIN_SCLK,
@@ -981,44 +1028,19 @@ esp_err_t bsp_display_init(void)
     ESP_ERROR_CHECK(esp_lcd_panel_set_gap(s_panel, 0, 0));
     ESP_ERROR_CHECK(esp_lcd_panel_disp_on_off(s_panel, true));
 
-    /* Allocate the framebuffer from PSRAM. The ESP32-S3 GDMA can stream SPI
-     * pixel data directly from external RAM, so the ~115 KB framebuffer does
-     * not need scarce internal DMA-capable RAM (which Wi-Fi SoftAP beacon and
-     * SDMMC buffers require). Fall back to internal DMA RAM if PSRAM is absent. */
-    s_fb = heap_caps_malloc(LCD_H_RES * LCD_V_RES * sizeof(uint16_t), MALLOC_CAP_SPIRAM);
-    if (!s_fb) {
-        s_fb = heap_caps_malloc(LCD_H_RES * LCD_V_RES * sizeof(uint16_t), MALLOC_CAP_DMA);
-    }
-    if (!s_fb) {
-        ESP_LOGE(TAG, "framebuffer alloc failed");
-        return ESP_ERR_NO_MEM;
-    }
-
-    s_flow_buf = heap_caps_calloc(FLOW_BUF_SIZE, sizeof(float), MALLOC_CAP_SPIRAM);
-    s_flow_local = heap_caps_malloc(FLOW_BUF_SIZE * sizeof(float), MALLOC_CAP_SPIRAM);
-    s_flow_yf = heap_caps_malloc(LCD_H_RES * sizeof(float), MALLOC_CAP_SPIRAM);
-    if (!s_flow_buf || !s_flow_local || !s_flow_yf) {
-        ESP_LOGE(TAG, "flow graph buffer alloc failed");
-        return ESP_ERR_NO_MEM;
-    }
-
-    /* Permanently allocate the internal DMA-capable strip buffers up front,
-     * while internal RAM is still free. */
-    for (int i = 0; i < LCD_STRIP_BUFS; i++) {
-        s_strip[i] = heap_caps_malloc(LCD_H_RES * LCD_STRIP_ROWS * sizeof(uint16_t),
-                                      MALLOC_CAP_DMA);
-        if (!s_strip[i]) {
-            ESP_LOGW(TAG, "strip buffer %d alloc failed; using direct flush", i);
-        }
-    }
-
-    /* Create the state mutex and start the single-owner render task. Only this
+    /* Start the single-owner render task after every resource exists. Only this
      * task ever touches the framebuffer or the LCD panel. */
-    s_state_mutex = xSemaphoreCreateMutex();
-    if (s_state_mutex) {
-        s_display_task = psram_task_create(display_task, "display", DISPLAY_TASK_STACK, NULL, 4, tskNO_AFFINITY, NULL, NULL);
-    } else {
-        ESP_LOGE(TAG, "state mutex alloc failed, display task not started");
+    s_display_task = psram_task_create(display_task, "display", DISPLAY_TASK_STACK, NULL, 4, tskNO_AFFINITY, NULL, NULL);
+    if (!s_display_task) {
+        esp_lcd_panel_del(s_panel);
+        s_panel = NULL;
+        esp_lcd_panel_io_del(s_io);
+        s_io = NULL;
+        spi_bus_free(LCD_SPI_HOST);
+        ledc_stop(LEDC_LOW_SPEED_MODE, BL_LEDC_CHANNEL, 0);
+        display_buffers_free();
+        ESP_LOGE(TAG, "display task allocation failed");
+        return ESP_ERR_NO_MEM;
     }
 
     /* Start non-intrusive display supervisor timer to monitor display responsiveness */

--- a/main/bsp_display.c
+++ b/main/bsp_display.c
@@ -151,6 +151,16 @@ static SemaphoreHandle_t s_state_mutex = NULL;  /* protects all shared state bel
 static disp_mode_t s_mode = DISP_MODE_STATUS;
 static bool s_status_dirty = true;              /* status content changed, force redraw */
 
+/* Two-phase restart gate, protected by s_state_mutex together with s_mode.
+ * Start waiters make the final commit fail; the restart owner releases its SD
+ * lease before cancelling the reservation and waking them. */
+static bool s_therapy_safe_restart_reserving;
+static bool s_therapy_safe_restart_committed;
+static unsigned s_therapy_start_waiters;
+static unsigned s_therapy_start_claims;
+static unsigned s_as11_notifications_pending;
+static bool s_therapy_safe_maintenance;
+
 /* Status-screen content (copied from callers) */
 static char s_status_title[STATUS_TITLE_LEN];
 static char s_status_lines[MAX_STATUS_LINES][STATUS_LINE_LEN];
@@ -184,18 +194,36 @@ static int64_t  s_therapy_start_us = 0;  /* monotonic time of TherapyStart */
 
 /* ── Public state-mutating API (never draws; render task handles drawing) ── */
 
-void bsp_display_set_therapy_active(bool active)
+bool bsp_display_set_therapy_active(bool active)
 {
     if (!s_state_mutex) {
         ESP_LOGW(TAG, "set_therapy_active(%s) called before init — ignored",
                  active ? "true" : "false");
-        return;
+        /* Display failure must not suppress therapy recording. OTA restart
+         * reservation remains unavailable while the mutex is absent. */
+        return true;
     }
 
     /* Check device settings */
     const device_settings_t *dev = device_settings_get();
 
-    xSemaphoreTake(s_state_mutex, portMAX_DELAY);
+    bool waiting_for_restart = false;
+    for (;;) {
+        xSemaphoreTake(s_state_mutex, portMAX_DELAY);
+        if (!active || !s_therapy_safe_restart_reserving) break;
+        if (!waiting_for_restart) {
+            s_therapy_start_waiters++;
+            waiting_for_restart = true;
+        }
+        xSemaphoreGive(s_state_mutex);
+        vTaskDelay(1);
+    }
+    if (waiting_for_restart) s_therapy_start_waiters--;
+    if (active && s_therapy_safe_restart_committed) {
+        xSemaphoreGive(s_state_mutex);
+        ESP_LOGW(TAG, "therapy start refused: restart already committed");
+        return false;
+    }
     disp_mode_t new_mode;
     if (active) {
         if (dev->therapy_screen == THERAPY_SCREEN_INFO)
@@ -243,7 +271,153 @@ void bsp_display_set_therapy_active(bool active)
 
     /* Wake the render task so the mode change is reflected immediately. */
     if (s_display_task) xTaskNotifyGive(s_display_task);
+    return true;
 }
+
+bool bsp_display_try_reserve_therapy_safe_restart(void)
+{
+    if (!s_state_mutex) return false;
+    xSemaphoreTake(s_state_mutex, portMAX_DELAY);
+    bool therapy_active = (s_mode == DISP_MODE_GRAPH || s_mode == DISP_MODE_INFO);
+    bool reserved = !therapy_active && s_therapy_start_claims == 0 &&
+                    s_therapy_start_waiters == 0 &&
+                    s_as11_notifications_pending == 0 &&
+                    !s_therapy_safe_maintenance &&
+                    !s_therapy_safe_restart_reserving &&
+                    !s_therapy_safe_restart_committed;
+    if (reserved) s_therapy_safe_restart_reserving = true;
+    xSemaphoreGive(s_state_mutex);
+    return reserved;
+}
+
+bool bsp_display_try_commit_therapy_safe_restart(void)
+{
+    if (!s_state_mutex) return false;
+    xSemaphoreTake(s_state_mutex, portMAX_DELAY);
+    bool therapy_active = (s_mode == DISP_MODE_GRAPH || s_mode == DISP_MODE_INFO);
+    bool committed = s_therapy_safe_restart_reserving && !therapy_active &&
+                     s_therapy_start_waiters == 0 &&
+                     s_as11_notifications_pending == 0;
+    if (committed) {
+        s_therapy_safe_restart_reserving = false;
+        s_therapy_safe_restart_committed = true;
+    }
+    xSemaphoreGive(s_state_mutex);
+    return committed;
+}
+
+void bsp_display_cancel_therapy_safe_restart(void)
+{
+    if (!s_state_mutex) return;
+    xSemaphoreTake(s_state_mutex, portMAX_DELAY);
+    if (!s_therapy_safe_restart_committed) {
+        s_therapy_safe_restart_reserving = false;
+    }
+    xSemaphoreGive(s_state_mutex);
+}
+
+bool bsp_display_reserve_therapy_start(void)
+{
+    if (!s_state_mutex) return true;
+    bool waiting_for_restart = false;
+    for (;;) {
+        xSemaphoreTake(s_state_mutex, portMAX_DELAY);
+        if (!s_therapy_safe_restart_reserving) break;
+        if (!waiting_for_restart) {
+            s_therapy_start_waiters++;
+            waiting_for_restart = true;
+        }
+        xSemaphoreGive(s_state_mutex);
+        vTaskDelay(1);
+    }
+    if (waiting_for_restart) s_therapy_start_waiters--;
+    bool reserved = !s_therapy_safe_restart_committed;
+    if (reserved) s_therapy_start_claims++;
+    xSemaphoreGive(s_state_mutex);
+    return reserved;
+}
+
+void bsp_display_release_therapy_start(void)
+{
+    if (!s_state_mutex) return;
+    xSemaphoreTake(s_state_mutex, portMAX_DELAY);
+    if (s_therapy_start_claims > 0) s_therapy_start_claims--;
+    xSemaphoreGive(s_state_mutex);
+}
+
+void bsp_display_note_as11_notification_queued(void)
+{
+    if (!s_state_mutex) return;
+    xSemaphoreTake(s_state_mutex, portMAX_DELAY);
+    s_as11_notifications_pending++;
+    xSemaphoreGive(s_state_mutex);
+}
+
+void bsp_display_note_as11_notification_processed(void)
+{
+    if (!s_state_mutex) return;
+    xSemaphoreTake(s_state_mutex, portMAX_DELAY);
+    if (s_as11_notifications_pending > 0) s_as11_notifications_pending--;
+    xSemaphoreGive(s_state_mutex);
+}
+
+bool bsp_display_try_begin_therapy_safe_maintenance(void)
+{
+    if (!s_state_mutex) return false;
+    xSemaphoreTake(s_state_mutex, portMAX_DELAY);
+    bool therapy_active = (s_mode == DISP_MODE_GRAPH || s_mode == DISP_MODE_INFO);
+    bool begun = !therapy_active && s_therapy_start_claims == 0 &&
+                 s_therapy_start_waiters == 0 &&
+                 s_as11_notifications_pending == 0 &&
+                 !s_therapy_safe_maintenance &&
+                 !s_therapy_safe_restart_reserving &&
+                 !s_therapy_safe_restart_committed;
+    if (begun) s_therapy_safe_maintenance = true;
+    xSemaphoreGive(s_state_mutex);
+    return begun;
+}
+
+/* Convert an active OTA maintenance gate into a short commit reservation.
+ * This closes the check/boot-selection race under the therapy publication lock.
+ * The updater releases this reservation immediately after SDK finish/set-boot,
+ * allowing queued starts to publish before the ordinary deferred reboot loop. */
+bool bsp_display_try_reserve_maintenance_commit(void)
+{
+    if (!s_state_mutex) return false;
+    xSemaphoreTake(s_state_mutex, portMAX_DELAY);
+    bool reserved = s_therapy_safe_maintenance &&
+        !(s_mode == DISP_MODE_GRAPH || s_mode == DISP_MODE_INFO) &&
+        s_therapy_start_claims == 0 && s_therapy_start_waiters == 0 &&
+        s_as11_notifications_pending == 0 && !s_therapy_safe_restart_reserving &&
+        !s_therapy_safe_restart_committed;
+    if (reserved) {
+        s_therapy_safe_maintenance = false;
+        s_therapy_safe_restart_reserving = true;
+    }
+    xSemaphoreGive(s_state_mutex);
+    return reserved;
+}
+
+bool bsp_display_therapy_safe_maintenance_should_abort(void)
+{
+    if (!s_state_mutex) return true;
+    xSemaphoreTake(s_state_mutex, portMAX_DELAY);
+    bool therapy_active = (s_mode == DISP_MODE_GRAPH || s_mode == DISP_MODE_INFO);
+    bool abort = !s_therapy_safe_maintenance || therapy_active ||
+                 s_therapy_start_claims > 0 || s_therapy_start_waiters > 0;
+    xSemaphoreGive(s_state_mutex);
+    return abort;
+}
+
+void bsp_display_end_therapy_safe_maintenance(void)
+{
+    if (!s_state_mutex) return;
+    xSemaphoreTake(s_state_mutex, portMAX_DELAY);
+    s_therapy_safe_maintenance = false;
+    xSemaphoreGive(s_state_mutex);
+}
+
+
 
 bool bsp_display_is_therapy_active(void)
 {
@@ -260,7 +434,7 @@ void bsp_display_push_flow(float flow_lpm)
     bool notify = false;
     xSemaphoreTake(s_state_mutex, portMAX_DELAY);
     if (s_mode == DISP_MODE_GRAPH && s_flow_buf) {
-        s_flow_buf[s_flow_head] = flow_lpm * 60.0f;
+        s_flow_buf[s_flow_head] = flow_lpm;
         s_flow_head = (s_flow_head + 1) % FLOW_BUF_SIZE;
         if (s_flow_count < FLOW_BUF_SIZE) s_flow_count++;
         notify = true;
@@ -268,6 +442,23 @@ void bsp_display_push_flow(float flow_lpm)
     xSemaphoreGive(s_state_mutex);
     /* In Graph Mode, wake display_task on incoming flow data */
     if (notify && s_display_task) xTaskNotifyGive(s_display_task);
+}
+
+
+void bsp_display_push_flow_gap(uint32_t samples)
+{
+    if (!s_state_mutex) return;
+    if (samples > FLOW_BUF_SIZE) samples = FLOW_BUF_SIZE;
+    xSemaphoreTake(s_state_mutex, portMAX_DELAY);
+    if (s_mode == DISP_MODE_GRAPH && s_flow_buf) {
+        for (uint32_t i = 0; i < samples; ++i) {
+            s_flow_buf[s_flow_head] = NAN;
+            s_flow_head = (s_flow_head + 1) % FLOW_BUF_SIZE;
+            if (s_flow_count < FLOW_BUF_SIZE) ++s_flow_count;
+        }
+    }
+    xSemaphoreGive(s_state_mutex);
+    if (s_display_task) xTaskNotifyGive(s_display_task);
 }
 
 void bsp_display_push_leak(float leak_lpm)
@@ -1252,6 +1443,7 @@ static void render_graph(void)
     /* Translucent area fill between the curve and the zero line. */
     for (int j = 0; j < m; j++) {
         int x = xbase + j;
+        if (!isfinite(yf[x])) continue;
         int y0 = (int)(yf[x] < mid_y ? yf[x] : mid_y);
         int y1 = (int)(yf[x] < mid_y ? mid_y : yf[x]);
         for (int y = y0; y <= y1; y++)
@@ -1261,10 +1453,12 @@ static void render_graph(void)
     /* Soft glow pass, then the sharp antialiased line on top. */
     for (int j = 1; j < m; j++) {
         int x = xbase + j;
+        if (!isfinite(yf[x - 1]) || !isfinite(yf[x])) continue;
         fb_draw_line_aa(x - 1, yf[x - 1], x, yf[x], 4.5f, glow_col, 45);
     }
     for (int j = 1; j < m; j++) {
         int x = xbase + j;
+        if (!isfinite(yf[x - 1]) || !isfinite(yf[x])) continue;
         fb_draw_line_aa(x - 1, yf[x - 1], x, yf[x], 2.0f, flow_col, 255);
     }
 
@@ -1617,6 +1811,12 @@ void bsp_display_set_notice(const char *text)
 
 /* The single owner of the framebuffer and LCD panel. Renders the current
  * mode at a fixed cadence and on every mode/content change. */
+
+void bsp_display_set_critical_notice(const char *text)
+{
+    bsp_display_set_notice(text);
+}
+
 static void display_task(void *arg)
 {
     (void)arg;
@@ -1707,4 +1907,10 @@ static void display_task(void *arg)
                      (unsigned)(hwm * sizeof(StackType_t)));
         }
     }
+}
+
+
+void bsp_display_set_sd_ready(bool ready)
+{
+    (void)ready;
 }

--- a/main/bsp_display.h
+++ b/main/bsp_display.h
@@ -41,9 +41,38 @@ void bsp_display_set_as11_paired(bool paired);
 void bsp_display_set_battery(int percent, bool charging, bool valid);
 
 /* Therapy graph mode */
-void bsp_display_set_therapy_active(bool active);
+bool bsp_display_set_therapy_active(bool active);
+/* Two-phase therapy-safe restart gate. Reserve before acquiring the SD lease;
+ * then commit only after the lease is held. A concurrent therapy start waits
+ * for cancellation and forces commit to fail, so it cannot lose its recording
+ * claim to a restart that subsequently defers. No state lock spans SD calls. */
+bool bsp_display_try_reserve_therapy_safe_restart(void);
+bool bsp_display_try_commit_therapy_safe_restart(void);
+void bsp_display_cancel_therapy_safe_restart(void);
+/* Hold this short-lived claim around a local command that can start therapy.
+ * It participates in the same restart reservation and must always be released. */
+bool bsp_display_reserve_therapy_start(void);
+void bsp_display_release_therapy_start(void);
+/* Account for raw AirSense notifications from enqueue through dispatch.  A
+ * queued TherapyStart must be visible to the restart gate before its JSON is
+ * decrypted and classified by the worker. */
+void bsp_display_note_as11_notification_queued(void);
+void bsp_display_note_as11_notification_processed(void);
+/* Cancellable maintenance gate used by OTA. Unlike the final restart gate,
+ * it never blocks therapy publication: an independent start makes
+ * should_abort true so recording wins immediately. */
+bool bsp_display_try_begin_therapy_safe_maintenance(void);
+bool bsp_display_therapy_safe_maintenance_should_abort(void);
+/* Short atomic OTA boot-selection reservation; cancel after SDK commit returns. */
+bool bsp_display_try_reserve_maintenance_commit(void);
+void bsp_display_end_therapy_safe_maintenance(void);
 void bsp_display_push_flow(float flow_lpm);
+/* Preserve absent 25 Hz positions without synthesizing physiological values. */
+void bsp_display_push_flow_gap(uint32_t samples);
 void bsp_display_push_leak(float leak_lpm);
+/* Live two-second metrics. Pass NAN for an unavailable value. */
+void bsp_display_push_metrics(float pressure_cmh2o, float respiratory_rate,
+                              float flow_limitation);
 void bsp_display_set_therapy_start_time(int64_t start_us);
 bool bsp_display_is_therapy_active(void);
 
@@ -78,3 +107,9 @@ void bsp_display_cancel_temporary_wake(void);
  * using the ST7789's reliable 0°/90° paths plus a software half-turn for
  * 180°/270°, and re-applied after panel reset. */
 void bsp_display_set_rotation(uint16_t degrees);
+
+void bsp_display_push_flow_gap(uint32_t samples);
+void bsp_display_set_critical_notice(const char *text);
+
+/* Storage publishes readiness; the compact screen has no separate SD badge. */
+void bsp_display_set_sd_ready(bool ready);

--- a/main/bsp_display_7b.c
+++ b/main/bsp_display_7b.c
@@ -1,0 +1,1129 @@
+/*
+ * SomnoTrace native 1024x600 touch UI for Waveshare ESP32-S3-Touch-LCD-7B.
+ * Copyright (C) 2026 Ilya Kruchinin <https://github.com/ilyakruchinin>
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "bsp_display.h"
+#include "board_waveshare_7b.h"
+#include "device_settings.h"
+#include "esp_check.h"
+#include "esp_heap_caps.h"
+#include "sdkconfig.h"
+#include "esp_lcd_touch.h"
+#include "controller_diagnostics.h"
+#include "esp_log.h"
+#include "esp_timer.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+#include "freertos/task.h"
+#include "lvgl.h"
+#include "live_flow_plot.h"
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+#include "esp_lcd_panel_rgb.h"
+#define FLOW_POINTS 300
+#define UI_UPDATE_MS 50
+#define TOUCH_FAILURE_THRESHOLD 3
+#define BACKLIGHT_RETRY_US 250000
+typedef struct {
+    bool wifi;
+    bool paired;
+    bool sd_ready;
+    bool storage_near_full;
+    bool therapy;
+    bool charging;
+    int battery;
+    float leak;
+    float pressure;
+    float respiratory_rate;
+    float flow_limitation;
+    int64_t leak_sample_us;
+    int64_t pressure_sample_us;
+    int64_t respiratory_rate_sample_us;
+    int64_t flow_limitation_sample_us;
+    int64_t therapy_start_us;
+    int16_t flow[FLOW_POINTS];
+    unsigned flow_head;
+    unsigned flow_count;
+    unsigned flow_version;
+    int64_t flow_sample_us;
+    char title[48];
+    char status[192];
+    char attention[256];
+    char notice[64];
+    int64_t notice_expires_us;
+    bool notice_critical;
+} ui_state_t;
+
+static const char *TAG = "display_7b";
+
+#define UI_BOARD_NAME "Waveshare ESP32-S3 Touch LCD 7B"
+#define UI_TOUCH_STATUS (s_touch ? "GT911 ready" : "not detected")
+static portMUX_TYPE s_state_lock = portMUX_INITIALIZER_UNLOCKED;
+static ui_state_t s_state;
+/* Protected by s_state_lock together with s_state.therapy. Start waiters force
+ * a pending restart reservation to release its SD lease before they publish. */
+static bool s_therapy_safe_restart_reserving;
+static bool s_therapy_safe_restart_committed;
+static unsigned s_therapy_start_waiters;
+static unsigned s_therapy_start_claims;
+static unsigned s_as11_notifications_pending;
+static bool s_therapy_safe_maintenance;
+static esp_lcd_panel_handle_t s_panel;
+static esp_lcd_touch_handle_t s_touch;
+static SemaphoreHandle_t s_lvgl_lock;
+static TaskHandle_t s_lvgl_task;
+static uint8_t s_brightness = 100;
+static bool s_backlight = true;
+static bool s_backlight_requested = true;
+static bool s_backlight_known = true;
+static bool s_wake_gesture_pending;
+static uint32_t s_touch_seen_visibility;
+static uint32_t s_touch_seen_continuity;
+static uint32_t s_backlight_revision;
+static bool s_backlight_force_on;
+static bool s_temporarily_awake;
+static esp_timer_handle_t s_wake_timer;
+static bool s_touch_was_pressed;
+static int64_t s_last_touch_activity_us;
+static uint32_t s_flush_count;
+static uint32_t s_flush_timeouts;
+static uint32_t s_touch_read_errors;
+static uint8_t s_touch_consecutive_errors;
+static uint32_t s_backlight_write_errors;
+static int64_t s_backlight_retry_after_us;
+static lv_coord_t s_last_touch_x;
+static lv_coord_t s_last_touch_y;
+static lv_obj_t *s_title_label, *s_status_label, *s_metrics_label, *s_notice_label;
+static lv_obj_t *s_wake_overlay;
+static void apply_pending_backlight_locked(void);
+void bsp_display_restart_idle_timeout(void);
+static void wake_timer_cb(void *arg);
+static bool screen_wake_input_available(void)
+{
+    touch_observation_t touch;
+    waveshare_7b_touch_snapshot(&touch);
+    return touch.preventive_recovery ||
+           touch_observation_healthy(&touch, esp_timer_get_time());
+}
+static bool lock_lvgl(TickType_t timeout)
+{
+    return s_lvgl_lock && xSemaphoreTakeRecursive(s_lvgl_lock, timeout) == pdTRUE;
+}
+static void unlock_lvgl(void)
+{
+    xSemaphoreGiveRecursive(s_lvgl_lock);
+}
+static bool IRAM_ATTR on_frame_complete(esp_lcd_panel_handle_t panel,
+                              const esp_lcd_rgb_panel_event_data_t *event,
+                              void *ctx)
+{
+    (void)panel;
+    (void)event;
+    (void)ctx;
+    BaseType_t wake = pdFALSE;
+    if (s_lvgl_task) vTaskNotifyGiveFromISR(s_lvgl_task, &wake);
+    return wake == pdTRUE;
+}
+static void submit_rgb_frame(lv_disp_drv_t *drv, lv_color_t *pixels)
+{
+    esp_lcd_panel_handle_t panel = (esp_lcd_panel_handle_t)drv->user_data;
+    for (;;) {
+        esp_err_t result = esp_lcd_panel_draw_bitmap(
+            panel, 0, 0, WAVESHARE_7B_H_RES, WAVESHARE_7B_V_RES, pixels);
+        controller_diagnostics_record(CONTROLLER_PANEL_SUBMIT, result);
+        if (result == ESP_OK) break;
+        s_flush_timeouts++;
+        ESP_LOGE(TAG, "RGB frame submission failed: %s", esp_err_to_name(result));
+        /* LVGL must not swap back to the buffer still owned by scanout. Other
+         * tasks, including the web recovery interface, remain runnable. */
+        vTaskDelay(pdMS_TO_TICKS(100));
+    }
+
+    /* IDF 5.5.1 selects cur_fb_index in draw_bitmap, then latches it into
+     * bb_fb_index before on_frame_buf_complete. Drain AFTER selection: an EOF
+     * between a pre-submit drain and draw_bitmap still belongs to the old
+     * frame and cannot release it for LVGL's next render/sync copy. A boundary
+     * just before this drain costs one extra scan, but never tears a frame. */
+    ulTaskNotifyTake(pdTRUE, 0);
+    while (ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(100)) == 0) {
+        controller_diagnostics_record(CONTROLLER_PANEL_HANDOFF, ESP_ERR_TIMEOUT);
+        s_flush_timeouts++;
+        if (s_flush_timeouts == 1 || (s_flush_timeouts % 100) == 0)
+            ESP_LOGW(TAG, "RGB handoff delayed (%lu); retaining framebuffer",
+                     (unsigned long)s_flush_timeouts);
+        /* Restart is deferred to VSYNC by IDF. A timeout itself is never
+         * evidence that the old buffer is free; await the actual callback. */
+        (void)esp_lcd_rgb_panel_restart(panel);
+    }
+    controller_diagnostics_record(CONTROLLER_PANEL_HANDOFF, ESP_OK);
+}
+static void flush_cb(lv_disp_drv_t *drv, const lv_area_t *area,
+                     lv_color_t *pixels)
+{
+    (void)area;
+    /* In double-buffered direct mode LVGL renders only dirty areas, but the
+     * RGB peripheral still needs the address of the complete finished frame.
+     * Submit that framebuffer once, after LVGL has drawn every dirty region. */
+    if (!lv_disp_flush_is_last(drv)) {
+        lv_disp_flush_ready(drv);
+        return;
+    }
+    submit_rgb_frame(drv, pixels);
+    /* Hardware has positively retired the previous framebuffer at this point. */
+    if (lv_disp_flush_is_last(drv)) s_flush_count++;
+    lv_disp_flush_ready(drv);
+}
+static void touch_read_cb(lv_indev_drv_t *drv, lv_indev_data_t *data)
+{
+    (void)drv;
+    touch_observation_t touch;
+    waveshare_7b_touch_snapshot(&touch);
+    int64_t now = esp_timer_get_time();
+    bool healthy = touch_observation_healthy(&touch, now);
+    bool continuity_changed = touch.continuity != s_touch_seen_continuity;
+    bool touch_became_unavailable = false;
+    portENTER_CRITICAL(&s_state_lock);
+    touch_became_unavailable = s_touch_consecutive_errors < TOUCH_FAILURE_THRESHOLD &&
+                               touch.consecutive_errors >= TOUCH_FAILURE_THRESHOLD;
+    s_touch_read_errors = touch.errors;
+    s_touch_consecutive_errors = touch.consecutive_errors;
+    if (continuity_changed) {
+        s_touch_seen_continuity = touch.continuity;
+        /* A fresh down frame cannot bridge a missed release. Disarm the
+         * whole gesture even when the next frame arrived before LVGL ran. */
+        s_wake_gesture_pending = true;
+    }
+    if (touch.visibility_requests != s_touch_seen_visibility) {
+        s_touch_seen_visibility = touch.visibility_requests;
+        s_backlight_requested = true;
+        s_backlight_known = false;
+        s_wake_gesture_pending = true;
+        s_last_touch_activity_us = now;
+        ++s_backlight_revision;
+    }
+    bool input_lost = continuity_changed || !healthy || touch.last_error ||
+                      !touch.valid ||
+                      (touch.pressed && !touch_observation_pressed(&touch, now));
+    bool cancel_gesture = input_lost || s_wake_gesture_pending ||
+                          !s_backlight_requested;
+    if (cancel_gesture) s_wake_gesture_pending = true;
+    if (healthy && touch.valid && !touch.pressed)
+        s_wake_gesture_pending = false;
+    /* Physical wake is admitted by the board's ordered visibility demand. */
+    bool allow_press = s_backlight_requested && !s_wake_gesture_pending;
+    portEXIT_CRITICAL(&s_state_lock);
+    /* An ordinary RELEASED sample generates CLICKED in LVGL. Cancel the
+     * active gesture first; never call LVGL inside the state critical section. */
+    if (cancel_gesture && s_touch_was_pressed)
+        lv_indev_wait_release(lv_indev_get_act());
+    if (touch_observation_pressed(&touch, now) && allow_press) {
+        s_last_touch_x = touch.x < WAVESHARE_7B_H_RES ? touch.x
+                                                       : WAVESHARE_7B_H_RES - 1;
+        s_last_touch_y = touch.y < WAVESHARE_7B_V_RES ? touch.y
+                                                       : WAVESHARE_7B_V_RES - 1;
+        data->point.x = s_last_touch_x;
+        data->point.y = s_last_touch_y;
+        data->state = LV_INDEV_STATE_PRESSED;
+    } else {
+        data->point.x = s_last_touch_x;
+        data->point.y = s_last_touch_y;
+        data->state = LV_INDEV_STATE_RELEASED;
+    }
+    if (touch_became_unavailable)
+        bsp_display_set_notice("Touch unavailable - recovering controls");
+    bool pressed_now = data->state == LV_INDEV_STATE_PRESSED;
+    if (pressed_now) {
+        int64_t now_us = esp_timer_get_time();
+        portENTER_CRITICAL(&s_state_lock);
+        s_last_touch_activity_us = now_us;
+        portEXIT_CRITICAL(&s_state_lock);
+    }
+    s_touch_was_pressed = pressed_now;
+}
+static void tick_cb(void *arg)
+{
+    (void)arg;
+    lv_tick_inc(5);
+}
+static void wake_overlay_cb(lv_event_t *event)
+{
+    if (lv_event_get_code(event) == LV_EVENT_PRESSED) {
+        /* This object is above every control while dark, so the wake gesture
+         * cannot also activate the button that happens to be underneath it. */
+        lv_indev_t *indev = lv_indev_get_act();
+        if (indev) lv_indev_wait_release(indev);
+        /* Hardware wake comes from the board worker. A delayed overlay event
+         * must not create another ON demand after a newer OFF request. */
+    }
+}
+static void screen_off_cb(lv_event_t *event)
+{
+    if (lv_event_get_code(event) == LV_EVENT_CLICKED && screen_wake_input_available())
+        bsp_display_set_backlight(false);
+}
+
+static void build_ui(void)
+{
+    lv_obj_t *screen = lv_scr_act();
+    lv_obj_set_style_bg_color(screen, lv_color_hex(0x101820), 0);
+    lv_obj_set_style_text_color(screen, lv_color_white(), 0);
+    s_title_label = lv_label_create(screen);
+    lv_obj_set_pos(s_title_label, 40, 40);
+    lv_obj_set_style_text_font(s_title_label, &lv_font_montserrat_28, 0);
+    s_status_label = lv_label_create(screen);
+    lv_obj_set_pos(s_status_label, 40, 110);
+    lv_obj_set_width(s_status_label, 930);
+    s_metrics_label = lv_label_create(screen);
+    lv_obj_set_pos(s_metrics_label, 40, 260);
+    lv_obj_set_width(s_metrics_label, 930);
+    s_notice_label = lv_label_create(screen);
+    lv_obj_set_pos(s_notice_label, 40, 440);
+    lv_obj_set_width(s_notice_label, 930);
+    lv_obj_t *off = lv_btn_create(screen);
+    lv_obj_set_pos(off, 800, 520);
+    lv_obj_set_size(off, 180, 50);
+    lv_obj_t *label = lv_label_create(off);
+    lv_label_set_text(label, "Screen off");
+    lv_obj_center(label);
+    lv_obj_add_event_cb(off, screen_off_cb, LV_EVENT_CLICKED, NULL);
+    s_wake_overlay = lv_obj_create(lv_layer_top());
+    lv_obj_set_pos(s_wake_overlay, 0, 0);
+    lv_obj_set_size(s_wake_overlay, WAVESHARE_7B_H_RES, WAVESHARE_7B_V_RES);
+    lv_obj_set_style_bg_color(s_wake_overlay, lv_color_black(), 0);
+    /* Hardware sleep electrically disables the backlight, so painting black
+     * there would only force two needless full-screen redraws. QEMU has no
+     * physical lamp to disable; make the same state visibly black so emulator
+     * acceptance can observe the command as well as its wake-only shield. */
+    lv_obj_set_style_bg_opa(s_wake_overlay, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(s_wake_overlay, 0, 0);
+    lv_obj_set_style_radius(s_wake_overlay, 0, 0);
+    lv_obj_clear_flag(s_wake_overlay, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_add_flag(s_wake_overlay, LV_OBJ_FLAG_CLICKABLE);
+    lv_obj_add_flag(s_wake_overlay, LV_OBJ_FLAG_PRESS_LOCK);
+    lv_obj_add_event_cb(s_wake_overlay, wake_overlay_cb, LV_EVENT_PRESSED, NULL);
+    lv_obj_add_flag(s_wake_overlay, LV_OBJ_FLAG_HIDDEN);
+
+}
+
+static void update_ui(void)
+{
+    ui_state_t state;
+    portENTER_CRITICAL(&s_state_lock);
+    state = s_state;
+    portEXIT_CRITICAL(&s_state_lock);
+    int64_t now = esp_timer_get_time();
+    if (state.notice_critical || !screen_wake_input_available()) {
+        portENTER_CRITICAL(&s_state_lock);
+        bool wake_needed = !s_backlight_requested;
+        portEXIT_CRITICAL(&s_state_lock);
+        if (wake_needed) bsp_display_set_backlight(true);
+    }
+    char battery[24] = "unavailable";
+    if (state.battery >= 0) snprintf(battery, sizeof(battery), "%d%%", state.battery);
+    lv_label_set_text(s_title_label, state.title);
+    lv_label_set_text_fmt(s_status_label, "%s\n\nWi-Fi: %s    AirSense: %s    SD: %s    Battery: %s\n%s",
+        state.attention, state.wifi ? "connected" : "disconnected",
+        state.paired ? "paired" : "unpaired", state.sd_ready ? "ready" : "unavailable",
+        battery, state.therapy ? "Therapy active" : "Waiting for therapy");
+    char flow[24] = "--", pressure[24] = "--", leak[24] = "--";
+    if (state.flow_count && now - state.flow_sample_us < 8000000) {
+        int16_t value = state.flow[(state.flow_head + FLOW_POINTS - 1) % FLOW_POINTS];
+        if (value != LIVE_FLOW_MISSING) snprintf(flow, sizeof(flow), "%.1f", value / 10.0f);
+    }
+    if (isfinite(state.pressure) && now - state.pressure_sample_us < 8000000)
+        snprintf(pressure, sizeof(pressure), "%.1f", state.pressure);
+    if (isfinite(state.leak) && now - state.leak_sample_us < 8000000)
+        snprintf(leak, sizeof(leak), "%.1f", state.leak);
+    lv_label_set_text_fmt(s_metrics_label, "Flow: %s L/min    Pressure: %s cmH2O    Leak: %s L/min\n\n%s",
+                          flow, pressure, leak, UI_TOUCH_STATUS);
+    lv_label_set_text(s_notice_label, state.notice_critical || now < state.notice_expires_us ? state.notice : "");
+    lv_obj_set_style_text_color(s_notice_label, lv_color_hex(state.notice_critical ? 0xff7070 : 0xffd080), 0);
+}
+static void lvgl_task(void *arg)
+{
+    (void)arg;
+    s_lvgl_task = xTaskGetCurrentTaskHandle();
+    TickType_t last_update = 0;
+    while (true) {
+        if (lock_lvgl(portMAX_DELAY)) {
+            apply_pending_backlight_locked();
+            TickType_t now = xTaskGetTickCount();
+            if (now - last_update >= pdMS_TO_TICKS(UI_UPDATE_MS)) {
+                update_ui();
+                last_update = now;
+            }
+            uint32_t delay = lv_timer_handler();
+            unlock_lvgl();
+            if (delay < 5) delay = 5;
+            if (delay > 50) delay = 50;
+            vTaskDelay(pdMS_TO_TICKS(delay));
+        }
+    }
+}
+typedef struct {
+    SemaphoreHandle_t done;
+    esp_err_t result;
+    esp_lcd_panel_handle_t panel;
+    esp_lcd_touch_handle_t touch;
+} panel_init_context_t;
+
+static void panel_init_task(void *arg)
+{
+    panel_init_context_t *ctx = arg;
+    ESP_LOGI(TAG, "allocating RGB panel on core %d beside LVGL",
+             xPortGetCoreID());
+    ctx->result = waveshare_7b_init(&ctx->panel, &ctx->touch);
+
+    /* The caller owns ctx and this task. Do not access ctx after signalling;
+     * suspending lets the caller delete us and reclaim the temporary internal
+     * stack synchronously before the rest of boot consumes that heap. */
+    xSemaphoreGive(ctx->done);
+    vTaskSuspend(NULL);
+}
+
+static esp_err_t init_panel_on_render_core(esp_lcd_panel_handle_t *panel,
+                                           esp_lcd_touch_handle_t *touch)
+{
+    StaticSemaphore_t done_storage;
+    SemaphoreHandle_t done = xSemaphoreCreateBinaryStatic(&done_storage);
+    ESP_RETURN_ON_FALSE(done, ESP_ERR_NO_MEM, TAG,
+                        "create panel-init completion signal");
+
+    panel_init_context_t ctx = {
+        .done = done,
+        .result = ESP_FAIL,
+    };
+    TaskHandle_t task = NULL;
+    BaseType_t created = xTaskCreatePinnedToCore(
+        panel_init_task, "panel_init", 8192, &ctx, 5, &task, 1);
+    if (created != pdPASS || !task) {
+        /* IRQ/render colocation is part of framebuffer ownership, not an
+         * optional optimization. Never fall back to a different IRQ core. */
+        ESP_LOGE(TAG, "panel-init task unavailable on render core");
+        return ESP_ERR_NO_MEM;
+    }
+
+    if (xSemaphoreTake(done, pdMS_TO_TICKS(15000)) != pdTRUE) {
+        ESP_LOGE(TAG, "panel initialization timed out");
+        vTaskDelete(task);
+        return ESP_ERR_TIMEOUT;
+    }
+
+    /* panel_init_task no longer touches ctx after giving the semaphore. */
+    vTaskDelete(task);
+    if (ctx.result == ESP_OK) {
+        *panel = ctx.panel;
+        *touch = ctx.touch;
+    }
+    return ctx.result;
+}
+
+esp_err_t bsp_display_init(void)
+{
+    controller_diagnostics_init(false);
+    memset(&s_state, 0, sizeof(s_state));
+    strcpy(s_state.title, "SomnoTrace");
+    strcpy(s_state.status, "Initializing display...");
+    s_state.battery = -1;
+    s_state.leak = NAN;
+    s_state.pressure = NAN;
+    s_state.respiratory_rate = NAN;
+    s_state.flow_limitation = NAN;
+    portENTER_CRITICAL(&s_state_lock);
+    s_touch_was_pressed = false;
+    s_backlight_force_on = false;
+    s_temporarily_awake = false;
+    s_backlight_known = true;
+    s_wake_gesture_pending = false;
+    s_touch_seen_visibility = 0;
+    s_touch_seen_continuity = 0;
+    s_backlight_revision = 0;
+    s_last_touch_activity_us = esp_timer_get_time();
+    s_touch_consecutive_errors = 0;
+    s_backlight_write_errors = 0;
+    s_backlight_retry_after_us = 0;
+    portEXIT_CRITICAL(&s_state_lock);
+
+    /* ESP-IDF installs the RGB DMA EOF interrupt on the core which allocates
+     * the panel. Keep that PSRAM-to-bounce-buffer copy on core 1 beside LVGL,
+     * so it preempts framebuffer rendering instead of racing it from core 0. */
+    esp_err_t display_init_result = init_panel_on_render_core(&s_panel, &s_touch);
+    controller_diagnostics_record(CONTROLLER_PANEL_INIT, display_init_result);
+    ESP_RETURN_ON_ERROR(display_init_result, TAG, "initialize display on render core");
+    esp_err_t touch_start = waveshare_7b_start_touch();
+    if (touch_start != ESP_OK)
+        ESP_LOGE(TAG, "touch observation worker unavailable: %s", esp_err_to_name(touch_start));
+
+    /* With an RGB bounce buffer, frame-buffer handoff completion is reported
+     * by on_frame_buf_complete. Waiting for it prevents LVGL from drawing into
+     * a buffer that the panel is still scanning out. */
+    esp_lcd_rgb_panel_event_callbacks_t callbacks = {
+        .on_frame_buf_complete = on_frame_complete,
+    };
+    ESP_RETURN_ON_ERROR(esp_lcd_rgb_panel_register_event_callbacks(s_panel,
+                                                                  &callbacks, NULL),
+                        TAG, "register display VSYNC");
+
+    lv_init();
+    void *fb1 = NULL, *fb2 = NULL;
+    ESP_RETURN_ON_ERROR(esp_lcd_rgb_panel_get_frame_buffer(s_panel, 2, &fb1, &fb2),
+                        TAG, "get RGB framebuffers");
+    /* IDF starts scanout from its first buffer. LVGL's first render must use
+     * the second one, before the normal submit/retire alternation begins. */
+    void *boot_scanout = fb1;
+    fb1 = fb2;
+    fb2 = boot_scanout;
+    static lv_disp_draw_buf_t draw_buffer;
+    lv_disp_draw_buf_init(&draw_buffer, fb1, fb2,
+                          WAVESHARE_7B_H_RES * WAVESHARE_7B_V_RES);
+    static lv_disp_drv_t display_driver;
+    lv_disp_drv_init(&display_driver);
+    display_driver.hor_res = WAVESHARE_7B_H_RES;
+    display_driver.ver_res = WAVESHARE_7B_V_RES;
+    display_driver.flush_cb = flush_cb;
+    display_driver.draw_buf = &draw_buffer;
+    display_driver.user_data = s_panel;
+    /* Both targets retain a complete composition buffer while LVGL redraws
+     * only invalidated regions. Hardware swaps two RGB buffers at its
+     * frame-complete boundary; QEMU publishes its single buffer on the final
+     * dirty-area callback. */
+    display_driver.direct_mode = 1;
+    lv_disp_drv_register(&display_driver);
+
+    /* Register even after a failed boot probe: the retained worker can repair
+     * the controller later, while invalid snapshots keep input released. */
+    const bool input_available = true;
+    if (input_available) {
+        static lv_indev_drv_t touch_driver;
+        lv_indev_drv_init(&touch_driver);
+        touch_driver.type = LV_INDEV_TYPE_POINTER;
+        touch_driver.read_cb = touch_read_cb;
+        touch_driver.user_data = s_touch;
+        lv_indev_drv_register(&touch_driver);
+    }
+
+    s_lvgl_lock = xSemaphoreCreateRecursiveMutex();
+    ESP_RETURN_ON_FALSE(s_lvgl_lock, ESP_ERR_NO_MEM, TAG, "create LVGL mutex");
+    size_t internal_before = heap_caps_get_free_size(MALLOC_CAP_INTERNAL);
+    size_t psram_before = heap_caps_get_free_size(MALLOC_CAP_SPIRAM);
+    UBaseType_t build_stack_before = uxTaskGetStackHighWaterMark(NULL);
+    if (lock_lvgl(portMAX_DELAY)) {
+        build_ui();
+        unlock_lvgl();
+    }
+    size_t internal_after = heap_caps_get_free_size(MALLOC_CAP_INTERNAL);
+    size_t psram_after = heap_caps_get_free_size(MALLOC_CAP_SPIRAM);
+    UBaseType_t build_stack_after = uxTaskGetStackHighWaterMark(NULL);
+    ESP_LOGI(TAG,
+             "UI tree: internal %d bytes, PSRAM %d bytes; init stack %u -> %u free",
+             (int)(internal_before - internal_after),
+             (int)(psram_before - psram_after),
+             (unsigned)build_stack_before, (unsigned)build_stack_after);
+
+    esp_timer_handle_t tick_timer;
+    const esp_timer_create_args_t tick_args = {
+        .callback = tick_cb,
+        .name = "lvgl_tick",
+    };
+    ESP_RETURN_ON_ERROR(esp_timer_create(&tick_args, &tick_timer), TAG,
+                        "create LVGL tick timer");
+    ESP_RETURN_ON_ERROR(esp_timer_start_periodic(tick_timer, 5000), TAG,
+                        "start LVGL tick timer");
+    const esp_timer_create_args_t wake_timer_args = {
+        .callback = wake_timer_cb,
+        .name = "lcd_wake_tmr",
+    };
+    ESP_RETURN_ON_ERROR(esp_timer_create(&wake_timer_args, &s_wake_timer), TAG,
+                        "create temporary-wake timer");
+    /* Service snapshots live in PSRAM and are refreshed before LVGL reads them,
+     * keeping the display-task stack independent of History depth. */
+    ESP_RETURN_ON_FALSE(xTaskCreatePinnedToCore(lvgl_task, "display_7b", 12288,
+                                               NULL, 5, &s_lvgl_task, 1) == pdPASS,
+                        ESP_ERR_NO_MEM, TAG, "create display task");
+
+
+    /* Start at the exact steady/full-on endpoint. Persisted hardware PWM
+     * dimming is applied by main once NVS is available. */
+    waveshare_7b_set_brightness(100);
+    ESP_LOGI(TAG, "native 1024x600 touch dashboard initialized");
+    return ESP_OK;
+}
+void bsp_display_show_number(uint32_t value)
+{
+    char line[16];
+    snprintf(line, sizeof(line), "%lu", (unsigned long)value);
+    const char *lines[] = { line };
+    bsp_display_show_lines(NULL, lines, 1);
+}
+
+void bsp_display_show_lines(const char *title, const char *const *lines, int n_lines)
+{
+    portENTER_CRITICAL(&s_state_lock);
+    if (title && title[0]) snprintf(s_state.title, sizeof(s_state.title), "%s", title);
+    s_state.status[0] = '\0';
+    s_state.attention[0] = '\0';
+    for (int i = 0; lines && i < n_lines; ++i) {
+        size_t used = strlen(s_state.status);
+        if (used && used + 3 < sizeof(s_state.status)) strcat(s_state.status, "  |  ");
+        used = strlen(s_state.status);
+        if (used < sizeof(s_state.status) - 1) {
+            snprintf(s_state.status + used, sizeof(s_state.status) - used, "%s", lines[i]);
+        }
+        used = strlen(s_state.attention);
+        if (used && used + 1 < sizeof(s_state.attention)) strcat(s_state.attention, "\n");
+        used = strlen(s_state.attention);
+        if (used < sizeof(s_state.attention) - 1) {
+            snprintf(s_state.attention + used,
+                     sizeof(s_state.attention) - used, "%s", lines[i]);
+        }
+    }
+    portEXIT_CRITICAL(&s_state_lock);
+}
+
+void bsp_display_set_notice(const char *text)
+{
+    portENTER_CRITICAL(&s_state_lock);
+    if (text && strstr(text, "microSD nearly full"))
+        s_state.storage_near_full = true;
+    if (!text || !text[0]) {
+        s_state.notice[0] = '\0';
+        s_state.notice_expires_us = 0;
+        s_state.notice_critical = false;
+    } else if (!s_state.notice_critical) {
+        snprintf(s_state.notice, sizeof(s_state.notice), "%s", text);
+        s_state.notice_expires_us = esp_timer_get_time() + 3000000;
+    }
+    portEXIT_CRITICAL(&s_state_lock);
+}
+
+void bsp_display_set_critical_notice(const char *text)
+{
+    portENTER_CRITICAL(&s_state_lock);
+    snprintf(s_state.notice, sizeof(s_state.notice), "%s", text ? text : "");
+    s_state.notice_expires_us = 0;
+    s_state.notice_critical = text && text[0];
+    portEXIT_CRITICAL(&s_state_lock);
+}
+
+void bsp_display_set_wifi_connected(bool connected)
+{
+    portENTER_CRITICAL(&s_state_lock);
+    s_state.wifi = connected;
+    portEXIT_CRITICAL(&s_state_lock);
+}
+
+void bsp_display_set_as11_paired(bool paired)
+{
+    portENTER_CRITICAL(&s_state_lock);
+    s_state.paired = paired;
+    portEXIT_CRITICAL(&s_state_lock);
+}
+
+void bsp_display_set_sd_ready(bool ready)
+{
+    portENTER_CRITICAL(&s_state_lock);
+    s_state.sd_ready = ready;
+    portEXIT_CRITICAL(&s_state_lock);
+}
+
+void bsp_display_set_battery(int percent, bool charging, bool valid)
+{
+    portENTER_CRITICAL(&s_state_lock);
+    s_state.battery = valid ? percent : -1;
+    s_state.charging = charging;
+    portEXIT_CRITICAL(&s_state_lock);
+}
+
+bool bsp_display_set_therapy_active(bool active)
+{
+    bool waiting_for_restart = false;
+    for (;;) {
+        portENTER_CRITICAL(&s_state_lock);
+        if (!active || !s_therapy_safe_restart_reserving) break;
+        if (!waiting_for_restart) {
+            s_therapy_start_waiters++;
+            waiting_for_restart = true;
+        }
+        portEXIT_CRITICAL(&s_state_lock);
+        vTaskDelay(1);
+    }
+    if (waiting_for_restart) s_therapy_start_waiters--;
+    if (active && s_therapy_safe_restart_committed) {
+        portEXIT_CRITICAL(&s_state_lock);
+        ESP_LOGW(TAG, "therapy start refused: restart already committed");
+        return false;
+    }
+    bool changed = s_state.therapy != active;
+    s_state.therapy = active;
+    if (changed) {
+        s_state.leak = NAN;
+        s_state.pressure = NAN;
+        s_state.respiratory_rate = NAN;
+        s_state.flow_limitation = NAN;
+        s_state.leak_sample_us = 0;
+        s_state.pressure_sample_us = 0;
+        s_state.respiratory_rate_sample_us = 0;
+        s_state.flow_limitation_sample_us = 0;
+        s_state.flow_head = 0;
+        s_state.flow_count = 0;
+        s_state.flow_version++;
+        s_state.flow_sample_us = 0;
+    }
+    portEXIT_CRITICAL(&s_state_lock);
+    if (changed) bsp_display_restart_idle_timeout();
+    bsp_display_apply_backlight_policy(false);
+    return true;
+}
+
+bool bsp_display_try_reserve_therapy_safe_restart(void)
+{
+    portENTER_CRITICAL(&s_state_lock);
+    bool reserved = !s_state.therapy && s_therapy_start_claims == 0 &&
+                    s_therapy_start_waiters == 0 &&
+                    s_as11_notifications_pending == 0 &&
+                    !s_therapy_safe_maintenance &&
+                    !s_therapy_safe_restart_reserving &&
+                    !s_therapy_safe_restart_committed;
+    if (reserved) s_therapy_safe_restart_reserving = true;
+    portEXIT_CRITICAL(&s_state_lock);
+    return reserved;
+}
+
+bool bsp_display_try_commit_therapy_safe_restart(void)
+{
+    portENTER_CRITICAL(&s_state_lock);
+    bool committed = s_therapy_safe_restart_reserving && !s_state.therapy &&
+                     s_therapy_start_waiters == 0 &&
+                     s_as11_notifications_pending == 0;
+    if (committed) {
+        s_therapy_safe_restart_reserving = false;
+        s_therapy_safe_restart_committed = true;
+    }
+    portEXIT_CRITICAL(&s_state_lock);
+    return committed;
+}
+
+void bsp_display_cancel_therapy_safe_restart(void)
+{
+    portENTER_CRITICAL(&s_state_lock);
+    if (!s_therapy_safe_restart_committed) {
+        s_therapy_safe_restart_reserving = false;
+    }
+    portEXIT_CRITICAL(&s_state_lock);
+}
+
+bool bsp_display_reserve_therapy_start(void)
+{
+    bool waiting_for_restart = false;
+    for (;;) {
+        portENTER_CRITICAL(&s_state_lock);
+        if (!s_therapy_safe_restart_reserving) break;
+        if (!waiting_for_restart) {
+            s_therapy_start_waiters++;
+            waiting_for_restart = true;
+        }
+        portEXIT_CRITICAL(&s_state_lock);
+        vTaskDelay(1);
+    }
+    if (waiting_for_restart) s_therapy_start_waiters--;
+    bool reserved = !s_therapy_safe_restart_committed;
+    if (reserved) s_therapy_start_claims++;
+    portEXIT_CRITICAL(&s_state_lock);
+    return reserved;
+}
+
+void bsp_display_release_therapy_start(void)
+{
+    portENTER_CRITICAL(&s_state_lock);
+    if (s_therapy_start_claims > 0) s_therapy_start_claims--;
+    portEXIT_CRITICAL(&s_state_lock);
+}
+
+void bsp_display_note_as11_notification_queued(void)
+{
+    portENTER_CRITICAL(&s_state_lock);
+    s_as11_notifications_pending++;
+    portEXIT_CRITICAL(&s_state_lock);
+}
+
+void bsp_display_note_as11_notification_processed(void)
+{
+    portENTER_CRITICAL(&s_state_lock);
+    if (s_as11_notifications_pending > 0) s_as11_notifications_pending--;
+    portEXIT_CRITICAL(&s_state_lock);
+}
+
+bool bsp_display_try_begin_therapy_safe_maintenance(void)
+{
+    portENTER_CRITICAL(&s_state_lock);
+    bool begun = !s_state.therapy && s_therapy_start_claims == 0 &&
+                 s_therapy_start_waiters == 0 &&
+                 s_as11_notifications_pending == 0 &&
+                 !s_therapy_safe_maintenance &&
+                 !s_therapy_safe_restart_reserving &&
+                 !s_therapy_safe_restart_committed;
+    if (begun) s_therapy_safe_maintenance = true;
+    portEXIT_CRITICAL(&s_state_lock);
+    return begun;
+}
+
+/* Convert an active OTA maintenance gate into a short commit reservation.
+ * This closes the check/boot-selection race under the therapy publication lock.
+ * The updater releases this reservation immediately after SDK finish/set-boot,
+ * allowing queued starts to publish before the ordinary deferred reboot loop. */
+bool bsp_display_try_reserve_maintenance_commit(void)
+{
+    portENTER_CRITICAL(&s_state_lock);
+    bool reserved = s_therapy_safe_maintenance && !(s_state.therapy) &&
+        s_therapy_start_claims == 0 && s_therapy_start_waiters == 0 &&
+        s_as11_notifications_pending == 0 && !s_therapy_safe_restart_reserving &&
+        !s_therapy_safe_restart_committed;
+    if (reserved) {
+        s_therapy_safe_maintenance = false;
+        s_therapy_safe_restart_reserving = true;
+    }
+    portEXIT_CRITICAL(&s_state_lock);
+    return reserved;
+}
+
+bool bsp_display_therapy_safe_maintenance_should_abort(void)
+{
+    portENTER_CRITICAL(&s_state_lock);
+    bool abort = !s_therapy_safe_maintenance || s_state.therapy ||
+                 s_therapy_start_claims > 0 || s_therapy_start_waiters > 0;
+    portEXIT_CRITICAL(&s_state_lock);
+    return abort;
+}
+
+void bsp_display_end_therapy_safe_maintenance(void)
+{
+    portENTER_CRITICAL(&s_state_lock);
+    s_therapy_safe_maintenance = false;
+    portEXIT_CRITICAL(&s_state_lock);
+}
+
+void bsp_display_push_flow(float flow_lpm)
+{
+    if (!isfinite(flow_lpm)) {
+        bsp_display_push_flow_gap(1);
+        return;
+    }
+    int value = (int)lrintf(flow_lpm * 10.0f);
+    if (value > 1000) value = 1000;
+    if (value < -1000) value = -1000;
+    portENTER_CRITICAL(&s_state_lock);
+    s_state.flow[s_state.flow_head] = (int16_t)value;
+    s_state.flow_head = (s_state.flow_head + 1) % FLOW_POINTS;
+    if (s_state.flow_count < FLOW_POINTS) s_state.flow_count++;
+    s_state.flow_version++;
+    s_state.flow_sample_us = esp_timer_get_time();
+    portEXIT_CRITICAL(&s_state_lock);
+}
+
+void bsp_display_push_flow_gap(uint32_t samples)
+{
+    if (samples > FLOW_POINTS) samples = FLOW_POINTS;
+    portENTER_CRITICAL(&s_state_lock);
+    for (uint32_t i = 0; i < samples; ++i) {
+        s_state.flow[s_state.flow_head] = LIVE_FLOW_MISSING;
+        s_state.flow_head = (s_state.flow_head + 1) % FLOW_POINTS;
+        if (s_state.flow_count < FLOW_POINTS) ++s_state.flow_count;
+        ++s_state.flow_version;
+    }
+    /* A gap is not a new valid Flow measurement; keep the freshness clock. */
+    portEXIT_CRITICAL(&s_state_lock);
+}
+
+void bsp_display_push_leak(float leak_lpm)
+{
+    portENTER_CRITICAL(&s_state_lock);
+    s_state.leak = leak_lpm;
+    s_state.leak_sample_us = esp_timer_get_time();
+    portEXIT_CRITICAL(&s_state_lock);
+}
+
+void bsp_display_push_metrics(float pressure_cmh2o, float respiratory_rate,
+                              float flow_limitation)
+{
+    int64_t sample_us = esp_timer_get_time();
+    portENTER_CRITICAL(&s_state_lock);
+    s_state.pressure = pressure_cmh2o;
+    s_state.respiratory_rate = respiratory_rate;
+    s_state.flow_limitation = flow_limitation;
+    s_state.pressure_sample_us = sample_us;
+    s_state.respiratory_rate_sample_us = sample_us;
+    s_state.flow_limitation_sample_us = sample_us;
+    portEXIT_CRITICAL(&s_state_lock);
+}
+
+void bsp_display_set_therapy_start_time(int64_t start_us)
+{
+    portENTER_CRITICAL(&s_state_lock);
+    s_state.therapy_start_us = start_us;
+    portEXIT_CRITICAL(&s_state_lock);
+}
+
+bool bsp_display_is_therapy_active(void)
+{
+    portENTER_CRITICAL(&s_state_lock);
+    bool active = s_state.therapy;
+    portEXIT_CRITICAL(&s_state_lock);
+    return active;
+}
+
+static uint8_t physical_brightness(uint8_t tenth_percent)
+{
+    uint8_t physical_percent = (uint8_t)(((uint16_t)tenth_percent + 1U) / 2U);
+    return physical_percent < 1 ? 1 : physical_percent;
+}
+
+void bsp_display_set_brightness(uint8_t tenth_percent)
+{
+    if (tenth_percent < 1) tenth_percent = 1;
+    if (tenth_percent > 200) tenth_percent = 200;
+    portENTER_CRITICAL(&s_state_lock);
+    s_brightness = tenth_percent;
+    bool backlight = s_backlight;
+    portEXIT_CRITICAL(&s_state_lock);
+    waveshare_7b_recovery_brightness(physical_brightness(tenth_percent));
+    if (backlight) {
+        /* The original 1.54-inch target stores 1..200 as tenths of a percent.
+         * On the 7B that same byte spans 1..100% hardware brightness. The
+         * board driver inverts this logical value for the active-low PWM;
+         * exactly 100% is a steady level with no PWM interruption. */
+        esp_err_t result = waveshare_7b_set_brightness(physical_brightness(tenth_percent));
+        if (result != ESP_OK) {
+            portENTER_CRITICAL(&s_state_lock);
+            s_backlight_known = false;
+            ++s_backlight_revision;
+            portEXIT_CRITICAL(&s_state_lock);
+        }
+    }
+}
+
+void bsp_display_set_backlight(bool on)
+{
+    portENTER_CRITICAL(&s_state_lock);
+    s_backlight_requested = on;
+    ++s_backlight_revision;
+    /* An explicit ON request is a physical reassertion, even after peripheral
+     * state loss left the application's last successful value unchanged. */
+    if (on) s_backlight_known = false;
+    portEXIT_CRITICAL(&s_state_lock);
+}
+
+bool bsp_display_toggle_backlight(void)
+{
+    portENTER_CRITICAL(&s_state_lock);
+    bool on = s_backlight_force_on || !s_backlight_requested;
+    portEXIT_CRITICAL(&s_state_lock);
+    bsp_display_set_backlight(on);
+    return on;
+}
+
+/* Called only while the LVGL mutex is held. Keeping this as a sticky desired
+ * state means a one-shot safety policy change cannot be lost to lock pressure. */
+static void apply_pending_backlight_locked(void)
+{
+    int64_t now_us = esp_timer_get_time();
+    touch_observation_t touch;
+    waveshare_7b_touch_snapshot(&touch);
+    portENTER_CRITICAL(&s_state_lock);
+    if (touch.visibility_requests != s_touch_seen_visibility) {
+        s_touch_seen_visibility = touch.visibility_requests;
+        s_backlight_requested = true;
+        s_backlight_known = false;
+        s_wake_gesture_pending = true;
+        s_last_touch_activity_us = now_us;
+        ++s_backlight_revision;
+    }
+    bool requested = s_backlight_requested;
+    bool current = s_backlight;
+    bool known = s_backlight_known;
+    uint32_t revision = s_backlight_revision;
+    uint8_t brightness = s_brightness;
+    int64_t retry_after_us = s_backlight_retry_after_us;
+    portEXIT_CRITICAL(&s_state_lock);
+
+    /* Keep the wake surface synchronized even after a failed or superseded
+     * hardware request. */
+    if (requested == current && known) {
+        if (s_wake_overlay) {
+            if (current) lv_obj_add_flag(s_wake_overlay, LV_OBJ_FLAG_HIDDEN);
+            else {
+                lv_obj_clear_flag(s_wake_overlay, LV_OBJ_FLAG_HIDDEN);
+                lv_obj_move_foreground(s_wake_overlay);
+            }
+        }
+        return;
+    }
+    if (now_us < retry_after_us) return;
+
+    /* Install the input shield before switching off. On wake, retain it until
+     * the I/O controller confirms that the backlight is physically enabled. */
+    if (!requested && s_wake_overlay) {
+        lv_obj_clear_flag(s_wake_overlay, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_move_foreground(s_wake_overlay);
+    }
+
+    esp_err_t brightness_result = ESP_OK;
+    if (requested) {
+        brightness_result =
+            waveshare_7b_set_brightness(physical_brightness(brightness));
+    }
+    esp_err_t backlight_result;
+    backlight_result = requested ? waveshare_7b_reassert_visible()
+                                 : waveshare_7b_set_backlight(false);
+    if (backlight_result == ESP_OK && brightness_result != ESP_OK)
+        backlight_result = brightness_result;
+    if (backlight_result != ESP_OK) {
+        uint32_t failure_count;
+        portENTER_CRITICAL(&s_state_lock);
+        s_backlight_write_errors++;
+        s_backlight_known = false;
+        failure_count = s_backlight_write_errors;
+        if (requested) {
+            s_backlight_retry_after_us = now_us + BACKLIGHT_RETRY_US;
+        } else {
+            /* Sleep is optional; abandon a failed off request and restart its
+             * idle window. A failed wake is safety-critical and keeps retrying. */
+            if (!s_backlight_requested) s_backlight_requested = true;
+            s_last_touch_activity_us = now_us;
+            s_backlight_retry_after_us = 0;
+        }
+        portEXIT_CRITICAL(&s_state_lock);
+        if (!requested && s_wake_overlay)
+            lv_obj_add_flag(s_wake_overlay, LV_OBJ_FLAG_HIDDEN);
+        if (failure_count == 1 || (failure_count % 10U) == 0) {
+            ESP_LOGE(TAG, "backlight %s failed (%lu): %s",
+                     requested ? "wake" : "sleep",
+                     (unsigned long)failure_count,
+                     esp_err_to_name(backlight_result));
+        }
+        if (!requested)
+            bsp_display_set_notice("Could not turn screen off - kept on");
+        return;
+    }
+
+    if (s_wake_overlay) {
+        if (requested) {
+            lv_obj_add_flag(s_wake_overlay, LV_OBJ_FLAG_HIDDEN);
+        } else {
+            lv_obj_clear_flag(s_wake_overlay, LV_OBJ_FLAG_HIDDEN);
+            lv_obj_move_foreground(s_wake_overlay);
+        }
+    }
+    ESP_LOGI(TAG, "backlight %s", requested ? "on" : "off");
+
+    portENTER_CRITICAL(&s_state_lock);
+    s_backlight = requested;
+    s_backlight_known = s_backlight_revision == revision;
+    s_backlight_retry_after_us = 0;
+    portEXIT_CRITICAL(&s_state_lock);
+}
+
+uint8_t bsp_display_get_brightness(void)
+{
+    portENTER_CRITICAL(&s_state_lock);
+    uint8_t brightness = s_brightness;
+    portEXIT_CRITICAL(&s_state_lock);
+    return brightness;
+}
+
+void bsp_display_restart_idle_timeout(void)
+{
+    int64_t now_us = esp_timer_get_time();
+    portENTER_CRITICAL(&s_state_lock);
+    s_last_touch_activity_us = now_us;
+    portEXIT_CRITICAL(&s_state_lock);
+}
+
+void bsp_display_apply_backlight_policy(bool force_on)
+{
+    if (force_on) {
+        bsp_display_restart_idle_timeout();
+        portENTER_CRITICAL(&s_state_lock);
+        s_backlight_force_on = true;
+        portEXIT_CRITICAL(&s_state_lock);
+        bsp_display_set_backlight(true);
+        return;
+    }
+    portENTER_CRITICAL(&s_state_lock);
+    bool forced = s_backlight_force_on;
+    bool temporarily_awake = s_temporarily_awake;
+    portEXIT_CRITICAL(&s_state_lock);
+    if (forced || temporarily_awake) {
+        bsp_display_set_backlight(true);
+        return;
+    }
+    if (!screen_wake_input_available()) {
+        /* The 7B has no alternate input control. Fail visibly if GT911 is not
+         * available instead of honoring a policy the user cannot wake from. */
+        bsp_display_set_backlight(true);
+        return;
+    }
+    device_settings_t settings;
+    device_settings_snapshot(&settings);
+    bool therapy = bsp_display_is_therapy_active();
+    bool off = settings.backlight_mode == BACKLIGHT_MODE_ALWAYS_OFF ||
+               (therapy && settings.backlight_mode == BACKLIGHT_MODE_OFF_THRP);
+    bsp_display_set_backlight(!off);
+}
+
+static void wake_timer_cb(void *arg)
+{
+    (void)arg;
+    portENTER_CRITICAL(&s_state_lock);
+    s_temporarily_awake = false;
+    portEXIT_CRITICAL(&s_state_lock);
+    bsp_display_apply_backlight_policy(false);
+}
+
+void bsp_display_wake_temporary(uint32_t duration_sec)
+{
+    if (duration_sec == 0 || !s_wake_timer) return;
+
+    (void)esp_timer_stop(s_wake_timer);
+    portENTER_CRITICAL(&s_state_lock);
+    s_temporarily_awake = true;
+    portEXIT_CRITICAL(&s_state_lock);
+    bsp_display_restart_idle_timeout();
+    bsp_display_set_backlight(true);
+    esp_err_t result = esp_timer_start_once(
+        s_wake_timer, (uint64_t)duration_sec * 1000000ULL);
+    if (result != ESP_OK) {
+        ESP_LOGE(TAG, "temporary-wake timer failed: %s", esp_err_to_name(result));
+        portENTER_CRITICAL(&s_state_lock);
+        s_temporarily_awake = false;
+        portEXIT_CRITICAL(&s_state_lock);
+        bsp_display_apply_backlight_policy(false);
+    }
+}
+
+bool bsp_display_is_temporarily_awake(void)
+{
+    portENTER_CRITICAL(&s_state_lock);
+    bool awake = s_temporarily_awake;
+    portEXIT_CRITICAL(&s_state_lock);
+    return awake;
+}
+
+void bsp_display_cancel_temporary_wake(void)
+{
+    if (s_wake_timer) (void)esp_timer_stop(s_wake_timer);
+    portENTER_CRITICAL(&s_state_lock);
+    s_temporarily_awake = false;
+    portEXIT_CRITICAL(&s_state_lock);
+    bsp_display_apply_backlight_policy(false);
+}
+
+void bsp_display_set_rotation(uint16_t degrees)
+{
+    if (degrees != 0) {
+        ESP_LOGW(TAG, "rotation %u ignored: the 7B dashboard is landscape-native",
+                 (unsigned)degrees);
+    }
+}

--- a/main/bsp_power.c
+++ b/main/bsp_power.c
@@ -109,6 +109,22 @@ static struct {
     int  plus_last_press_ms;
 } s_btn;
 
+static esp_err_t start_therapy_with_lifecycle_gate(void)
+{
+    if (!bsp_display_reserve_therapy_start()) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    bool may_have_started = false;
+    esp_err_t result = as11_ble_start_therapy_tracked(&may_have_started);
+    if ((result == ESP_OK || may_have_started) &&
+        !bsp_display_set_therapy_active(true)) {
+        /* The start claim excludes a restart commit, so this is defensive. */
+        result = ESP_ERR_INVALID_STATE;
+    }
+    bsp_display_release_therapy_start();
+    return result;
+}
+
 static void button_monitor_task(void *arg)
 {
     (void)arg;
@@ -204,7 +220,7 @@ static void button_monitor_task(void *arg)
                     }
                 } else {
                     ESP_LOGI(TAG, "starting therapy via EnterTherapy RPC");
-                    esp_err_t ret = as11_ble_start_therapy();
+                    esp_err_t ret = start_therapy_with_lifecycle_gate();
                     if (ret != ESP_OK) {
                         ESP_LOGW(TAG, "start_therapy failed: %s",
                                  esp_err_to_name(ret));
@@ -243,7 +259,7 @@ static void button_monitor_task(void *arg)
                             }
                         } else {
                             ESP_LOGI(TAG, "starting therapy via EnterTherapy RPC");
-                            esp_err_t ret = as11_ble_start_therapy();
+                            esp_err_t ret = start_therapy_with_lifecycle_gate();
                             if (ret != ESP_OK) {
                                 ESP_LOGW(TAG, "start_therapy failed: %s",
                                          esp_err_to_name(ret));

--- a/main/bsp_power.c
+++ b/main/bsp_power.c
@@ -609,7 +609,7 @@ static void battery_monitor_task(void *arg)
 
     if (bat_adc_init() != ESP_OK) {
         ESP_LOGE(TAG, "battery: monitor exiting, ADC unavailable");
-        vTaskDelete(NULL);
+        psram_task_delete(NULL);
         return;
     }
 

--- a/main/bsp_power_7b.c
+++ b/main/bsp_power_7b.c
@@ -1,0 +1,58 @@
+/* SomnoTrace power shim for Waveshare ESP32-S3-Touch-LCD-7B. */
+#include "bsp_power.h"
+
+#include <string.h>
+#include "esp_log.h"
+
+static const char *TAG = "bsp_power_7b";
+
+void bsp_power_hold(void)
+{
+    /* The 7B is powered directly; GPIO2 is an LCD red-data signal. */
+}
+
+void bsp_power_off(void)
+{
+    ESP_LOGW(TAG, "power-off is not available on the 7B; use its supply switch");
+}
+
+void bsp_power_start_button_monitor(int hold_ms)
+{
+    (void)hold_ms;
+}
+
+void bsp_power_start_boot_monitor(volatile bool *softap_flag, int hold_ms)
+{
+    (void)softap_flag;
+    (void)hold_ms;
+    /* GPIO0 carries LCD G3 after boot and must not be polled as a button. */
+}
+
+void bsp_power_start_plus_monitor(void)
+{
+    /* The native touch UI replaces the 1.54-inch board's PLUS button. */
+}
+
+esp_err_t bsp_power_battery_monitor_start(void)
+{
+    return ESP_OK;
+}
+
+void bsp_power_battery_get(bsp_battery_t *out)
+{
+    if (!out) return;
+    memset(out, 0, sizeof(*out));
+    out->percent = -1;
+    out->millivolts = -1;
+    out->valid = false;
+}
+
+int bsp_power_battery_percent(void)
+{
+    return -1;
+}
+
+bool bsp_power_is_charging(void)
+{
+    return false;
+}

--- a/main/controller_diagnostics.c
+++ b/main/controller_diagnostics.c
@@ -1,0 +1,103 @@
+#include "controller_diagnostics.h"
+#include <string.h>
+
+#ifdef CONTROLLER_DIAGNOSTICS_HOST_TEST
+/* The host test supplies a deterministic clock. Firmware always uses the
+ * real clock and a cross-core critical section. */
+extern int64_t esp_timer_get_time(void);
+#define DIAG_LOCK() ((void)0)
+#define DIAG_UNLOCK() ((void)0)
+#else
+#include "esp_timer.h"
+#include "freertos/FreeRTOS.h"
+static portMUX_TYPE s_lock = portMUX_INITIALIZER_UNLOCKED;
+#define DIAG_LOCK() portENTER_CRITICAL(&s_lock)
+#define DIAG_UNLOCK() portEXIT_CRITICAL(&s_lock)
+#endif
+
+static controller_diagnostics_snapshot_t s_snapshot;
+
+static uint32_t increment(uint32_t value)
+{
+    return value < UINT32_MAX ? value + 1U : value;
+}
+
+void controller_diagnostics_init(bool simulated)
+{
+    DIAG_LOCK();
+    memset(&s_snapshot, 0, sizeof(s_snapshot));
+    s_snapshot.initialized = true;
+    s_snapshot.simulated = simulated;
+    DIAG_UNLOCK();
+}
+
+void controller_diagnostics_record(controller_operation_t operation,
+                                   esp_err_t result)
+{
+    if ((unsigned)operation >= CONTROLLER_OPERATION_COUNT) return;
+    DIAG_LOCK();
+    if (!s_snapshot.initialized) {
+        DIAG_UNLOCK();
+        return;
+    }
+    int64_t now = esp_timer_get_time();
+    controller_operation_status_t *status = &s_snapshot.operations[operation];
+    bool continued = status->observed && status->last_result == result;
+    status->observed = true;
+    status->last_result = result;
+    status->last_observed_us = now;
+    if (result != ESP_OK) {
+        status->error_count = increment(status->error_count);
+        status->last_error_us = now;
+        size_t found = s_snapshot.history_count;
+        if (continued) {
+            for (size_t i = 0; i < s_snapshot.history_count; ++i) {
+                if (s_snapshot.history[i].operation == operation) {
+                    /* The newest episode for this operation is the only one
+                     * that can still be active. Never join a pre-recovery one. */
+                    if (s_snapshot.history[i].result == result) found = i;
+                    break;
+                }
+            }
+        }
+        controller_error_episode_t episode = {
+            .operation = operation, .result = result, .occurrences = 1,
+            .first_us = now, .last_us = now,
+        };
+        size_t move;
+        if (found < s_snapshot.history_count) {
+            episode = s_snapshot.history[found];
+            episode.occurrences = increment(episode.occurrences);
+            episode.last_us = now;
+            move = found;
+        } else {
+            if (s_snapshot.history_count < CONTROLLER_DIAGNOSTICS_HISTORY_MAX)
+                ++s_snapshot.history_count;
+            move = s_snapshot.history_count - 1U;
+        }
+        memmove(&s_snapshot.history[1], &s_snapshot.history[0],
+                move * sizeof(s_snapshot.history[0]));
+        s_snapshot.history[0] = episode;
+    }
+    DIAG_UNLOCK();
+}
+
+void controller_diagnostics_get_snapshot(controller_diagnostics_snapshot_t *out)
+{
+    if (!out) return;
+    DIAG_LOCK();
+    *out = s_snapshot;
+    DIAG_UNLOCK();
+}
+
+const char *controller_diagnostics_operation_name(controller_operation_t operation)
+{
+    static const char *const names[] = {
+        "Display initialization", "RGB frame submission", "RGB frame handoff",
+        "Touch initialization", "Touch read", "Backlight power",
+        "Backlight brightness",
+        "Touch recovery", "Controller output mode", "LCD power",
+    };
+    return (unsigned)operation < CONTROLLER_OPERATION_COUNT
+               ? names[operation] : "Unknown controller operation";
+}

--- a/main/controller_diagnostics.h
+++ b/main/controller_diagnostics.h
@@ -1,0 +1,59 @@
+/* Bounded, allocation-free 7B controller observations since boot. */
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include "esp_err.h"
+
+#define CONTROLLER_DIAGNOSTICS_HISTORY_MAX 8U
+
+typedef enum {
+    CONTROLLER_PANEL_INIT = 0,
+    CONTROLLER_PANEL_SUBMIT,
+    CONTROLLER_PANEL_HANDOFF,
+    CONTROLLER_TOUCH_INIT,
+    CONTROLLER_TOUCH_READ,
+    CONTROLLER_BACKLIGHT_POWER,
+    CONTROLLER_BACKLIGHT_BRIGHTNESS,
+    CONTROLLER_TOUCH_RECOVERY,
+    CONTROLLER_OUTPUT_MODE,
+    CONTROLLER_LCD_POWER,
+    CONTROLLER_OPERATION_COUNT,
+} controller_operation_t;
+
+typedef struct {
+    bool observed;
+    esp_err_t last_result;
+    uint32_t error_count;
+    int64_t last_observed_us;
+    int64_t last_error_us;
+} controller_operation_status_t;
+
+typedef struct {
+    controller_operation_t operation;
+    esp_err_t result;
+    uint32_t occurrences;
+    int64_t first_us;
+    int64_t last_us;
+} controller_error_episode_t;
+
+typedef struct {
+    bool initialized;
+    bool simulated;
+    controller_operation_status_t operations[CONTROLLER_OPERATION_COUNT];
+    /* Most recently observed failures first. Repeated errors before recovery
+     * coalesce into one episode, even when another operation also fails. */
+    controller_error_episode_t history[CONTROLLER_DIAGNOSTICS_HISTORY_MAX];
+    size_t history_count;
+} controller_diagnostics_snapshot_t;
+
+/* Initialize once before controller startup. No heap, card, or log writes.
+ * Task-context calls only; do not call from an ISR or another critical section.
+ * Timestamps are monotonic microseconds since boot, never wall-clock dates.
+ * Counters saturate at UINT32_MAX. Unobserved operations remain unknown. */
+void controller_diagnostics_init(bool simulated);
+void controller_diagnostics_record(controller_operation_t operation,
+                                   esp_err_t result);
+void controller_diagnostics_get_snapshot(controller_diagnostics_snapshot_t *out);
+const char *controller_diagnostics_operation_name(controller_operation_t operation);

--- a/main/device_settings.c
+++ b/main/device_settings.c
@@ -31,6 +31,8 @@
 #include "nvs.h"
 #include "cJSON.h"
 #include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
 
 static const char *TAG = "dev_settings";
 
@@ -59,6 +61,51 @@ static const char *TAG = "dev_settings";
 #define DEFAULT_WAKE_TIMEOUT_SEC 10
 
 static device_settings_t s_settings;
+static device_settings_t s_save_work;
+static uint32_t s_settings_revision;
+static StaticSemaphore_t s_settings_mutex_storage;
+static StaticSemaphore_t s_save_mutex_storage;
+static SemaphoreHandle_t s_settings_mutex;
+static SemaphoreHandle_t s_save_mutex;
+static portMUX_TYPE s_mutex_init_lock = portMUX_INITIALIZER_UNLOCKED;
+
+/* The display is initialized before NVS is available, so touchscreen code can
+ * read or change defaults before device_settings_load(). Static, lazily-created
+ * mutexes keep that early path allocation-free and make web/touch updates safe
+ * once both tasks are running. */
+static void ensure_settings_mutexes(void)
+{
+    if (s_settings_mutex && s_save_mutex) return;
+
+    portENTER_CRITICAL(&s_mutex_init_lock);
+    if (!s_settings_mutex) {
+        s_settings_mutex = xSemaphoreCreateRecursiveMutexStatic(
+            &s_settings_mutex_storage);
+    }
+    if (!s_save_mutex) {
+        s_save_mutex = xSemaphoreCreateMutexStatic(&s_save_mutex_storage);
+    }
+    portEXIT_CRITICAL(&s_mutex_init_lock);
+}
+
+static void settings_lock(void)
+{
+    ensure_settings_mutexes();
+    xSemaphoreTakeRecursive(s_settings_mutex, portMAX_DELAY);
+}
+
+static void settings_unlock(void)
+{
+    xSemaphoreGiveRecursive(s_settings_mutex);
+}
+
+static void copy_current_settings(device_settings_t *out, uint32_t *revision)
+{
+    settings_lock();
+    *out = s_settings;
+    if (revision) *revision = s_settings_revision;
+    settings_unlock();
+}
 
 static bool lcd_rotation_is_valid(int degrees)
 {
@@ -73,8 +120,12 @@ static bool lcd_rotation_is_valid(int degrees)
     }
 }
 
+
 esp_err_t device_settings_load(device_settings_t *cfg)
 {
+    if (!cfg) return ESP_ERR_INVALID_ARG;
+    ensure_settings_mutexes();
+
     memset(cfg, 0, sizeof(*cfg));
     cfg->brightness = DEFAULT_BRIGHTNESS;
     cfg->therapy_screen = DEFAULT_THE_SCREEN;
@@ -91,7 +142,10 @@ esp_err_t device_settings_load(device_settings_t *cfg)
     if (nvs_open(NVS_NAMESPACE, NVS_READONLY, &h) != ESP_OK) {
         nvs_writer_unlock();
         ESP_LOGI(TAG, "no device settings in NVS — using defaults");
-        memcpy(&s_settings, cfg, sizeof(s_settings));
+        settings_lock();
+        s_settings = *cfg;
+        s_settings_revision++;
+        settings_unlock();
         return ESP_ERR_NVS_NOT_FOUND;
     }
 
@@ -138,32 +192,87 @@ esp_err_t device_settings_load(device_settings_t *cfg)
 
     nvs_close(h);
     nvs_writer_unlock();
-    memcpy(&s_settings, cfg, sizeof(s_settings));
+    settings_lock();
+    s_settings = *cfg;
+    s_settings_revision++;
+    settings_unlock();
     ESP_LOGI(TAG, "loaded: brightness=%u (%.1f%%), thr_screen=%u, bkl_mode=%u, alert_vol=%u, lcd_rot=%u, bat_en=%d, wake_tch=%d, wake_sec=%u",
-             s_settings.brightness, s_settings.brightness / 10.0,
-             s_settings.therapy_screen, s_settings.backlight_mode, s_settings.alert_volume,
-             (unsigned)s_settings.lcd_rotation, s_settings.battery_enabled,
-             s_settings.wake_on_touch, s_settings.wake_timeout_sec);
+             cfg->brightness, cfg->brightness / 10.0,
+             cfg->therapy_screen, cfg->backlight_mode, cfg->alert_volume,
+             (unsigned)cfg->lcd_rotation, cfg->battery_enabled,
+             cfg->wake_on_touch, cfg->wake_timeout_sec);
     return ESP_OK;
 }
 
 static esp_err_t do_device_settings_save(void *arg)
 {
-    const device_settings_t *cfg = (const device_settings_t *)arg;
+    /* arg points at s_save_work in internal DRAM. Copy it to this writer
+     * task's internal stack before any flash operation disables caches. */
+    const device_settings_t cfg = *(const device_settings_t *)arg;
     nvs_handle_t h;
     esp_err_t ret = nvs_open(NVS_NAMESPACE, NVS_READWRITE, &h);
     if (ret != ESP_OK) return ret;
 
-    nvs_set_u8(h, NVS_KEY_BRIGHTNESS, cfg->brightness);
-    nvs_set_u8(h, NVS_KEY_THE_SCREEN, (uint8_t)cfg->therapy_screen);
-    nvs_set_u8(h, NVS_KEY_BACKLIGHT, (uint8_t)cfg->backlight_mode);
-    nvs_set_u8(h, NVS_KEY_ALERT_VOL, cfg->alert_volume);
-    nvs_set_u16(h, NVS_KEY_LCD_ROTATION, cfg->lcd_rotation);
-    nvs_set_u8(h, NVS_KEY_BAT_ENABLED, cfg->battery_enabled ? 1 : 0);
-    nvs_set_u8(h, NVS_KEY_WAKE_TOUCH, cfg->wake_on_touch ? 1 : 0);
-    nvs_set_u8(h, NVS_KEY_WAKE_SEC, cfg->wake_timeout_sec);
-    ret = nvs_commit(h);
+    ret = nvs_set_u8(h, NVS_KEY_BRIGHTNESS, cfg.brightness);
+    if (ret == ESP_OK)
+        ret = nvs_set_u8(h, NVS_KEY_THE_SCREEN,
+                         (uint8_t)cfg.therapy_screen);
+    if (ret == ESP_OK)
+        ret = nvs_set_u8(h, NVS_KEY_BACKLIGHT,
+                         (uint8_t)cfg.backlight_mode);
+    if (ret == ESP_OK)
+        ret = nvs_set_u8(h, NVS_KEY_ALERT_VOL, cfg.alert_volume);
+    if (ret == ESP_OK)
+        ret = nvs_set_u16(h, NVS_KEY_LCD_ROTATION, cfg.lcd_rotation);
+    if (ret == ESP_OK)
+        ret = nvs_set_u8(h, NVS_KEY_BAT_ENABLED,
+                         cfg.battery_enabled ? 1 : 0);
+    if (ret == ESP_OK)
+        ret = nvs_set_u8(h, NVS_KEY_WAKE_TOUCH,
+                         cfg.wake_on_touch ? 1 : 0);
+    if (ret == ESP_OK)
+        ret = nvs_set_u8(h, NVS_KEY_WAKE_SEC, cfg.wake_timeout_sec);
+    if (ret == ESP_OK) ret = nvs_commit(h);
     nvs_close(h);
+    return ret;
+}
+
+/* s_save_mutex must be held. If a setter runs during the flash commit, repeat
+ * with its newer revision so an older snapshot can never be the last durable
+ * value. Setters only take s_settings_mutex and therefore never block the UI
+ * for the duration of an NVS write. */
+static esp_err_t persist_current_locked(device_settings_t *persisted)
+{
+    for (;;) {
+        uint32_t revision;
+        copy_current_settings(&s_save_work, &revision);
+        esp_err_t ret = nvs_writer_run(do_device_settings_save, &s_save_work);
+        if (ret != ESP_OK) return ret;
+
+        settings_lock();
+        bool stable = revision == s_settings_revision;
+        if (stable && persisted) *persisted = s_settings;
+        settings_unlock();
+        if (stable) return ESP_OK;
+    }
+}
+
+esp_err_t device_settings_save_current(void)
+{
+    ensure_settings_mutexes();
+    xSemaphoreTake(s_save_mutex, portMAX_DELAY);
+    device_settings_t persisted;
+    esp_err_t ret = persist_current_locked(&persisted);
+    xSemaphoreGive(s_save_mutex);
+
+    if (ret == ESP_OK) {
+        ESP_LOGI(TAG, "saved: brightness=%u (%.1f%%), thr_screen=%u, bkl_mode=%u, alert_vol=%u, lcd_rot=%u, bat_en=%d, wake_tch=%d, wake_sec=%u",
+                 persisted.brightness, persisted.brightness / 10.0,
+                 persisted.therapy_screen, persisted.backlight_mode,
+                 persisted.alert_volume, (unsigned)persisted.lcd_rotation,
+                 persisted.battery_enabled, persisted.wake_on_touch,
+                 persisted.wake_timeout_sec);
+    }
     return ret;
 }
 
@@ -171,17 +280,19 @@ esp_err_t device_settings_save(const device_settings_t *cfg)
 {
     if (!cfg) return ESP_ERR_INVALID_ARG;
 
-    /* Delegate the flash write so callers on a PSRAM stack (httpd) are safe. */
-    esp_err_t ret = nvs_writer_run(do_device_settings_save, (void *)cfg);
-    if (ret == ESP_OK) {
-        memcpy(&s_settings, cfg, sizeof(s_settings));
-        ESP_LOGI(TAG, "saved: brightness=%u (%.1f%%), thr_screen=%u, bkl_mode=%u, alert_vol=%u, lcd_rot=%u, bat_en=%d, wake_tch=%d, wake_sec=%u",
-                 s_settings.brightness, s_settings.brightness / 10.0,
-                 s_settings.therapy_screen, s_settings.backlight_mode, s_settings.alert_volume,
-                 (unsigned)s_settings.lcd_rotation, s_settings.battery_enabled,
-                 s_settings.wake_on_touch, s_settings.wake_timeout_sec);
-    }
-    return ret;
+    /* This is an explicit full-structure replacement. Interactive callers
+     * that already used a field setter should call save_current() instead. */
+    settings_lock();
+    s_settings = *cfg;
+    s_settings_revision++;
+    settings_unlock();
+    return device_settings_save_current();
+}
+
+void device_settings_snapshot(device_settings_t *out)
+{
+    if (!out) return;
+    copy_current_settings(out, NULL);
 }
 
 const device_settings_t *device_settings_get(void)
@@ -194,22 +305,35 @@ esp_err_t device_settings_set_brightness(uint8_t percent)
     if (percent < MIN_BRIGHTNESS) percent = MIN_BRIGHTNESS;
     if (percent > MAX_BRIGHTNESS) percent = MAX_BRIGHTNESS;
 
+    settings_lock();
     s_settings.brightness = percent;
+    s_settings_revision++;
     bsp_display_set_brightness(percent);
+    settings_unlock();
     return ESP_OK;
 }
 
 esp_err_t device_settings_set_therapy_screen(therapy_screen_t screen)
 {
+    if (screen > THERAPY_SCREEN_STATUS) return ESP_ERR_INVALID_ARG;
+    settings_lock();
     s_settings.therapy_screen = screen;
+    s_settings_revision++;
+    /* Re-evaluate display mode and backlight immediately */
     bsp_display_set_therapy_active(bsp_display_is_therapy_active());
+    bsp_display_apply_backlight_policy(false);
+    settings_unlock();
     return ESP_OK;
 }
 
 esp_err_t device_settings_set_backlight_mode(backlight_mode_t mode)
 {
+    if (mode > BACKLIGHT_MODE_ALWAYS_OFF) return ESP_ERR_INVALID_ARG;
+    settings_lock();
     s_settings.backlight_mode = mode;
+    s_settings_revision++;
     bsp_display_apply_backlight_policy(false);
+    settings_unlock();
     return ESP_OK;
 }
 
@@ -217,30 +341,41 @@ esp_err_t device_settings_set_alert_volume(uint8_t percent)
 {
     if (percent < MIN_ALERT_VOLUME) percent = MIN_ALERT_VOLUME;
     if (percent > 100) percent = 100;
+    settings_lock();
     s_settings.alert_volume = percent;
+    s_settings_revision++;
     bsp_audio_set_volume(percent);
+    settings_unlock();
     return ESP_OK;
 }
 
 esp_err_t device_settings_set_lcd_rotation(uint16_t degrees)
 {
     if (!lcd_rotation_is_valid(degrees)) return ESP_ERR_INVALID_ARG;
+    settings_lock();
     s_settings.lcd_rotation = degrees;
+    s_settings_revision++;
     bsp_display_set_rotation(degrees);
+    settings_unlock();
     return ESP_OK;
 }
 
 bool device_settings_battery_enabled(void)
 {
-    return s_settings.battery_enabled;
+    device_settings_t settings;
+    device_settings_snapshot(&settings);
+    return settings.battery_enabled;
 }
 
 esp_err_t device_settings_set_battery_enabled(bool enabled)
 {
+    settings_lock();
     s_settings.battery_enabled = enabled;
+    s_settings_revision++;
     if (!enabled) {
         bsp_display_set_battery(-1, false, false);
     }
+    settings_unlock();
     return ESP_OK;
 }
 
@@ -248,15 +383,18 @@ esp_err_t device_settings_get_json(char **out_json)
 {
     if (!out_json) return ESP_ERR_INVALID_ARG;
 
+    device_settings_t settings;
+    device_settings_snapshot(&settings);
     cJSON *root = cJSON_CreateObject();
-    cJSON_AddNumberToObject(root, "brightness", s_settings.brightness);
-    cJSON_AddNumberToObject(root, "therapy_screen", (int)s_settings.therapy_screen);
-    cJSON_AddNumberToObject(root, "backlight_mode", (int)s_settings.backlight_mode);
-    cJSON_AddNumberToObject(root, "alert_volume", s_settings.alert_volume);
-    cJSON_AddNumberToObject(root, "lcd_rotation", s_settings.lcd_rotation);
-    cJSON_AddBoolToObject(root, "battery_enabled", s_settings.battery_enabled);
-    cJSON_AddBoolToObject(root, "wake_on_touch", s_settings.wake_on_touch);
-    cJSON_AddNumberToObject(root, "wake_timeout_sec", s_settings.wake_timeout_sec);
+    if (!root) return ESP_ERR_NO_MEM;
+    cJSON_AddNumberToObject(root, "brightness", settings.brightness);
+    cJSON_AddNumberToObject(root, "therapy_screen", (int)settings.therapy_screen);
+    cJSON_AddNumberToObject(root, "backlight_mode", (int)settings.backlight_mode);
+    cJSON_AddNumberToObject(root, "alert_volume", settings.alert_volume);
+    cJSON_AddNumberToObject(root, "lcd_rotation", settings.lcd_rotation);
+    cJSON_AddBoolToObject(root, "battery_enabled", settings.battery_enabled);
+    cJSON_AddBoolToObject(root, "wake_on_touch", settings.wake_on_touch);
+    cJSON_AddNumberToObject(root, "wake_timeout_sec", settings.wake_timeout_sec);
 
     *out_json = cJSON_PrintUnformatted(root);
     cJSON_Delete(root);
@@ -273,8 +411,8 @@ esp_err_t device_settings_save_json(const char *json_str)
         return ESP_ERR_INVALID_STATE;
     }
 
-    device_settings_t cfg;
-    memcpy(&cfg, &s_settings, sizeof(cfg));
+    settings_lock();
+    device_settings_t cfg = s_settings;
 
     cJSON *v;
     if ((v = cJSON_GetObjectItem(root, "brightness")) && cJSON_IsNumber(v)) {
@@ -319,24 +457,22 @@ esp_err_t device_settings_save_json(const char *json_str)
         cfg.wake_timeout_sec = (uint8_t)val;
     }
 
-    cJSON_Delete(root);
-
-    /* Apply brightness immediately */
+    s_settings = cfg;
+    s_settings_revision++;
+    /* Keep state and hardware application in one ordered section. A newer
+     * touchscreen update blocks here briefly and then applies after this one. */
     bsp_display_set_brightness(cfg.brightness);
-    /* Apply alert volume immediately */
     bsp_audio_set_volume(cfg.alert_volume);
-    /* Apply LCD rotation immediately */
     bsp_display_set_rotation(cfg.lcd_rotation);
-    /* Apply battery display immediately if disabled */
     if (!cfg.battery_enabled) {
         bsp_display_set_battery(-1, false, false);
     }
-
-    /* Persist first so device_settings_get() returns the new settings,
-     * then re-evaluate therapy display mode and backlight based on the new settings. */
-    esp_err_t ret = device_settings_save(&cfg);
     bsp_display_set_therapy_active(bsp_display_is_therapy_active());
     bsp_display_apply_backlight_policy(false);
+    settings_unlock();
+    cJSON_Delete(root);
 
-    return ret;
+    /* If a touchscreen setter races this flash commit, save_current() repeats
+     * with the newer revision instead of leaving the stale web snapshot in NVS. */
+    return device_settings_save_current();
 }

--- a/main/device_settings.c
+++ b/main/device_settings.c
@@ -48,7 +48,11 @@ static const char *TAG = "dev_settings";
 
 /* Brightness stored in tenth-percent units: 1=0.1%, 200=20.0%
  * Discrete steps: 0.1, 0.2, 0.5, 1, 2, 5, 10, 20 (roughly 2x each) */
+#if CONFIG_SOMNOTRACE_BOARD_WAVESHARE_7B
+#define DEFAULT_BRIGHTNESS       200 /* Full steady brightness on 7B. */
+#else
 #define DEFAULT_BRIGHTNESS       100 /* 10.0% */
+#endif
 #define MIN_BRIGHTNESS           1   /* 0.1% */
 #define MAX_BRIGHTNESS           200 /* 20.0% */
 #define DEFAULT_THE_SCREEN       THERAPY_SCREEN_INFO

--- a/main/device_settings.h
+++ b/main/device_settings.h
@@ -65,8 +65,15 @@ typedef struct {
  * if no settings stored (defaults are filled in). */
 esp_err_t device_settings_load(device_settings_t *cfg);
 
-/* Save settings to NVS. */
+/* Replace the complete in-memory settings structure and save it to NVS. */
 esp_err_t device_settings_save(const device_settings_t *cfg);
+
+/* Persist the latest in-memory settings without replacing changes made by a
+ * concurrent web or touchscreen task. */
+esp_err_t device_settings_save_current(void);
+
+/* Copy a coherent snapshot of the current in-memory settings. */
+void device_settings_snapshot(device_settings_t *out);
 
 /* Get current in-memory settings (loaded at boot). */
 const device_settings_t *device_settings_get(void);
@@ -78,23 +85,24 @@ bool device_settings_battery_enabled(void);
 esp_err_t device_settings_set_battery_enabled(bool enabled);
 
 /* Set brightness immediately (applies to hardware + updates in-memory copy).
- * Does NOT persist to NVS — call device_settings_save() for that. */
+ * Does NOT persist to NVS — call device_settings_save_current() for that. */
 esp_err_t device_settings_set_brightness(uint8_t percent);
 
 /* Set therapy screen (updates in-memory copy only).
- * Call device_settings_save() to persist. */
+ * Call device_settings_save_current() to persist. */
 esp_err_t device_settings_set_therapy_screen(therapy_screen_t screen);
 
 /* Set backlight policy (updates in-memory copy only).
- * Call device_settings_save() to persist. */
+ * Call device_settings_save_current() to persist. */
 esp_err_t device_settings_set_backlight_mode(backlight_mode_t mode);
 
 /* Set alert speaker volume (0-100). Updates in-memory copy and applies to
- * bsp_audio. Call device_settings_save() to persist. */
+ * bsp_audio. Call device_settings_save_current() to persist. */
 esp_err_t device_settings_set_alert_volume(uint8_t percent);
 
 /* Set LCD rotation (0, 90, 180, or 270 degrees). Updates in-memory copy and
- * applies to hardware immediately. Call device_settings_save() to persist. */
+ * applies to hardware immediately. Call device_settings_save_current() to
+ * persist. */
 esp_err_t device_settings_set_lcd_rotation(uint16_t degrees);
 
 /* Get settings as JSON string for web UI. Caller must free(). */

--- a/main/edf_gen.c
+++ b/main/edf_gen.c
@@ -103,6 +103,31 @@ static bool day_metadata_fallback(const char *session_dir, const char *session_i
     return true;
 }
 
+/* A continuous ResMed EDF cannot represent gaps in an explicitly positioned
+ * source stream. Refuse before touching prior output; the raw SNT remains the
+ * source of truth until discontinuous export is supported. */
+static esp_err_t validate_positioned_sources(const char *dir, const char *id)
+{
+    static const char *const names[] = {"flow", "press", "sa2", "pld", "brp"};
+    for (size_t i = 0; i < sizeof(names) / sizeof(names[0]); ++i) {
+        char path[400];
+        int n = snprintf(path, sizeof(path), "%s/%s_%s.snt", dir, id, names[i]);
+        if (n < 0 || n >= (int)sizeof(path)) return ESP_ERR_INVALID_SIZE;
+        FILE *f = fopen(path, "rb");
+        if (!f) {
+            if (errno == ENOENT) continue;
+            return ESP_FAIL;
+        }
+        snt_header_t hdr;
+        esp_err_t ret = snt_read_header(f, &hdr) == 0 ? ESP_OK : ESP_FAIL;
+        if (fclose(f) != 0 && ret == ESP_OK) ret = ESP_FAIL;
+        if (ret != ESP_OK) return ret;
+        if (hdr.version >= 2 && (hdr.reserved & SNT_POSITION_GAP_FLAG))
+            return EDF_GEN_ERR_POSITION_GAPS;
+    }
+    return ESP_OK;
+}
+
 esp_err_t edf_gen_generate_ex(const char *out_root,
                               const char *session_dir, const char *session_id,
                               int64_t start_epoch_ms, int64_t end_epoch_ms,
@@ -128,6 +153,17 @@ esp_err_t edf_gen_generate_ex(const char *out_root,
                  (long long)start_epoch_ms, session_id);
         sd_storage_lease_release(SD_LEASE_EXPORT);
         return ESP_ERR_INVALID_ARG;
+    }
+    if (flags & EDF_GEN_PER_SESSION) {
+        esp_err_t valid = validate_positioned_sources(session_dir, session_id);
+        if (valid != ESP_OK) {
+            ESP_LOGE(TAG, "source preflight failed for %s (%s); retaining raw and prior export",
+                     session_id, valid == EDF_GEN_ERR_POSITION_GAPS
+                         ? "positioned_gaps_require_discontinuous_export"
+                         : esp_err_to_name(valid));
+            sd_storage_lease_release(SD_LEASE_EXPORT);
+            return valid;
+        }
     }
 
     ESP_LOGI(TAG, "=== EDF GENERATION START ===");

--- a/main/edf_gen.c
+++ b/main/edf_gen.c
@@ -27,6 +27,7 @@
 #include "edf_waveform.h"
 #include "edf_annotations.h"
 #include "edf_summary.h"
+#include "session_writer.h"
 
 static const char *TAG = "edf_gen";
 
@@ -154,6 +155,7 @@ esp_err_t edf_gen_generate_ex(const char *out_root,
         sd_storage_lease_release(SD_LEASE_EXPORT);
         return ESP_ERR_INVALID_ARG;
     }
+    edf_source_error_begin();
     if (flags & EDF_GEN_PER_SESSION) {
         esp_err_t valid = validate_positioned_sources(session_dir, session_id);
         if (valid != ESP_OK) {
@@ -161,6 +163,7 @@ esp_err_t edf_gen_generate_ex(const char *out_root,
                      session_id, valid == EDF_GEN_ERR_POSITION_GAPS
                          ? "positioned_gaps_require_discontinuous_export"
                          : esp_err_to_name(valid));
+            (void)edf_source_error_end();
             sd_storage_lease_release(SD_LEASE_EXPORT);
             return valid;
         }
@@ -642,9 +645,15 @@ esp_err_t edf_gen_generate_ex(const char *out_root,
      * below (cJSON_AddItemReferenceToObject does not transfer ownership). */
     if ((flags & EDF_GEN_SHARED) && settings) {
         cJSON *cs_root = cJSON_CreateObject();
-        cJSON_AddItemReferenceToObject(cs_root, "FlowGenerator", settings);
-        char *settings_str = cJSON_PrintUnformatted(cs_root);
-        cJSON_Delete(cs_root);
+        char *settings_str = NULL;
+        if (!cs_root) {
+            errors++;
+        } else {
+            cJSON_AddItemReferenceToObject(cs_root, "FlowGenerator", settings);
+            settings_str = cJSON_PrintUnformatted(cs_root);
+            cJSON_Delete(cs_root);
+            if (!settings_str) errors++;
+        }
         if (settings_str) {
             /* cJSON drops ".0" for integer-valued doubles (e.g. 7.0 → 7),
              * but AS11 preserves it for pressure/temperature fields.
@@ -654,7 +663,8 @@ esp_err_t edf_gen_generate_ex(const char *out_root,
                 "StartPressure", "MaxPressure", "MinPressure",
                 "SetPressure", "HeatedTubeTemperature", NULL
             };
-            for (int fi = 0; float_fields[fi]; fi++) {
+            bool settings_encode_ok = true;
+            for (int fi = 0; float_fields[fi] && settings_encode_ok; fi++) {
                 char pattern[64];
                 snprintf(pattern, sizeof(pattern), "\"%s\":", float_fields[fi]);
                 size_t plen = strlen(pattern);
@@ -680,6 +690,10 @@ esp_err_t edf_gen_generate_ex(const char *out_root,
                                     settings_str + insert_pos, tail_len);
                             settings_str[insert_pos] = '.';
                             settings_str[insert_pos + 1] = '0';
+                        } else {
+                            errors++;
+                            settings_encode_ok = false;
+                            break;
                         }
                         p = settings_str + insert_pos + 2;
                     } else {
@@ -687,6 +701,12 @@ esp_err_t edf_gen_generate_ex(const char *out_root,
                     }
                 }
             }
+            if (!settings_encode_ok) {
+                free(settings_str);
+                settings_str = NULL;
+            }
+        }
+        if (settings_str) {
             size_t slen = strlen(settings_str);
             char cs_path[300];
             char cs_crc_path[300];
@@ -754,8 +774,10 @@ esp_err_t edf_gen_generate_ex(const char *out_root,
 
     ESP_LOGI(TAG, "=== EDF GENERATION DONE (%d errors) ===", errors);
 
+    esp_err_t source_result = edf_source_error_end();
     sd_storage_lease_release(SD_LEASE_EXPORT);
-    return errors > 0 ? ESP_FAIL : ESP_OK;
+    return source_result != ESP_OK ? source_result :
+           (errors > 0 ? ESP_FAIL : ESP_OK);
 }
 
 /* ════════════════════════════════════════════════════════════════════
@@ -777,18 +799,10 @@ esp_err_t edf_gen_generate_ex(const char *out_root,
 #define REBUILD_MAX_SESSIONS  64
 #define REBUILD_STAGING_DIR   SD_MOUNT_POINT "/SDCARD/.rebuild"
 
-/* Publish sentinel.
- *
- * Staging is failure-safe, but publication is not atomic: the live day is
- * deleted and the staged files are moved in one by one, and the shared
- * STR/Identification pass runs after that swap.  A reset in that window
- * leaves a day that looks published but is incomplete.
- *
- * The sentinel names the day currently being published and is removed only
- * after the whole rebuild succeeds.  A sentinel found at boot therefore means
- * "this day's export was interrupted", and the day is re-queued for an
- * automatic rebuild.  It is written outside the day folder because the day
- * folder itself is deleted during publication. */
+/* Publish sentinel. All conversion completes in staging before this is
+ * persisted. Same-volume directory publication plus several shared files is
+ * not one atomic filesystem operation; retain this durable intent until all
+ * installation steps succeed so a reset never reports an incomplete day done. */
 #define REBUILD_SENTINEL      SD_SDCARD_DIR "/.rebuilding"
 
 typedef struct {
@@ -832,8 +846,7 @@ static esp_err_t rebuild_move_dir(const char *src, const char *dst)
         char from[656], to[656];
         snprintf(from, sizeof(from), "%s/%s", src, ent->d_name);
         snprintf(to, sizeof(to), "%s/%s", dst, ent->d_name);
-        unlink(to);
-        if (rename(from, to) != 0) {
+        if (edf_publish_atomic_path(from, to) != ESP_OK) {
             ESP_LOGE(TAG, "rebuild: publish failed for %s: %s",
                      ent->d_name, strerror(errno));
             ret = ESP_FAIL;
@@ -845,35 +858,36 @@ static esp_err_t rebuild_move_dir(const char *src, const char *dst)
 }
 
 /* Read one session manifest into a rebuild descriptor. */
-static bool rebuild_read_manifest(const char *day_path, const char *fname,
+static esp_err_t rebuild_read_manifest(const char *day_path, const char *fname,
                                   rebuild_session_t *out)
 {
     const char *suffix = "_session.json";
     size_t slen = strlen(suffix), flen = strlen(fname);
-    if (flen <= slen || strcmp(fname + flen - slen, suffix) != 0) return false;
+    if (flen <= slen || strcmp(fname + flen - slen, suffix) != 0) return ESP_FAIL;
 
     size_t prefix_len = flen - slen;
-    if (prefix_len == 0 || prefix_len >= sizeof(out->session_id)) return false;
+    if (prefix_len == 0 || prefix_len >= sizeof(out->session_id)) return ESP_FAIL;
 
     char json_path[656];
     snprintf(json_path, sizeof(json_path), "%s/%s", day_path, fname);
     FILE *f = fopen(json_path, "r");
-    if (!f) return false;
-    fseek(f, 0, SEEK_END);
-    long size = ftell(f);
-    fseek(f, 0, SEEK_SET);
-    if (size <= 0 || size > 16384) { fclose(f); return false; }
+    if (!f) return ESP_FAIL;
+    long size = -1;
+    if (fseek(f, 0, SEEK_END) == 0) size = ftell(f);
+    if (fseek(f, 0, SEEK_SET) != 0) { fclose(f); return ESP_FAIL; }
+    if (size <= 0 || size > 16384) { fclose(f); return ESP_FAIL; }
     char *buf = malloc(size + 1);
-    if (!buf) { fclose(f); return false; }
+    if (!buf) { fclose(f); return ESP_ERR_NO_MEM; }
     size_t rd = fread(buf, 1, size, f);
-    fclose(f);
+    int close_ret = fclose(f);
+    if (rd != (size_t)size || close_ret != 0) { free(buf); return ESP_FAIL; }
     buf[rd] = '\0';
 
     cJSON *j = cJSON_Parse(buf);
     free(buf);
     if (!j) {
-        ESP_LOGW(TAG, "rebuild: %s is not valid JSON, skipping", fname);
-        return false;
+        ESP_LOGW(TAG, "rebuild: %s is not valid JSON; refusing partial day", fname);
+        return ESP_FAIL;
     }
 
     bool ok = false;
@@ -891,8 +905,7 @@ static bool rebuild_read_manifest(const char *day_path, const char *fname,
 
             /* An unusable drift estimate is still better than 0 (which would
              * put every spool-sourced timestamp ~7-8 min out), but say so. */
-            /* Sessions rebuilt from a crash have partially damaged raw data by
-             * definition; the day rebuild treats their failures differently. */
+            /* State does not classify I/O/OOM failures as damaged source. */
             cJSON *jst = cJSON_GetObjectItem(j, "state");
             out->interrupted = (jst && cJSON_IsString(jst) &&
                                 strcmp(jst->valuestring, "interrupted") == 0);
@@ -912,7 +925,7 @@ static bool rebuild_read_manifest(const char *day_path, const char *fname,
         }
     }
     cJSON_Delete(j);
-    return ok;
+    return ok ? ESP_OK : ESP_FAIL;
 }
 
 esp_err_t edf_gen_rebuild_day(const char *day_folder)
@@ -941,15 +954,27 @@ esp_err_t edf_gen_rebuild_day(const char *day_folder)
 
     int n = 0;
     bool truncated = false;
+    esp_err_t scan_error = ESP_OK;
     DIR *d = opendir(day_path);
-    if (d) {
-        struct dirent *ent;
-        while ((ent = readdir(d)) != NULL) {
-            if (ent->d_type != DT_REG) continue;
+    if (!d) scan_error = errno == ENOENT ? ESP_ERR_NOT_FOUND : ESP_FAIL;
+    else {
+        while (1) {
+            errno = 0;
+            struct dirent *ent = readdir(d);
+            if (!ent) { if (errno) scan_error = ESP_FAIL; break; }
+            size_t len = strlen(ent->d_name);
+            if (len <= 13 || strcmp(ent->d_name + len - 13, "_session.json")) continue;
             if (n >= REBUILD_MAX_SESSIONS) { truncated = true; break; }
-            if (rebuild_read_manifest(day_path, ent->d_name, &sessions[n])) n++;
+            scan_error = rebuild_read_manifest(day_path, ent->d_name, &sessions[n]);
+            if (scan_error != ESP_OK) break;
+            n++;
         }
-        closedir(d);
+        if (closedir(d) != 0 && scan_error == ESP_OK) scan_error = ESP_FAIL;
+    }
+    if (scan_error != ESP_OK) {
+        free(sessions);
+        sd_storage_lease_release(SD_LEASE_EXPORT);
+        return scan_error;
     }
 
     if (truncated) {
@@ -986,7 +1011,6 @@ esp_err_t edf_gen_rebuild_day(const char *day_folder)
     mkdir(REBUILD_STAGING_DIR, 0775);
 
     esp_err_t ret = ESP_OK;
-    int degraded = 0;
     for (int i = 0; i < n; i++) {
         ESP_LOGI(TAG, "rebuild %s: session %d/%d: %s",
                  day_folder, i + 1, n, sessions[i].session_id);
@@ -997,26 +1021,25 @@ esp_err_t edf_gen_rebuild_day(const char *day_folder)
                                          sessions[i].clock_drift_ms,
                                          EDF_GEN_PER_SESSION);
         if (r != ESP_OK) {
-            if (sessions[i].interrupted) {
-                /* A crash-recovered fragment can be damaged in ways no amount
-                 * of retrying will fix.  Letting it veto the rebuild would
-                 * lose the whole night — every healthy session included — which
-                 * is a far worse outcome than exporting the night without this
-                 * one fragment.  Loud, not silent: the skipped session is named
-                 * here and counted in the completion line. */
-                ESP_LOGE(TAG, "rebuild %s: interrupted session %s could not be "
-                         "exported (%s) — SKIPPING it and continuing with the "
-                         "rest of the day", day_folder,
-                         sessions[i].session_id, esp_err_to_name(r));
-                degraded++;
-                continue;
-            }
+            /* A terminal-state label is not evidence of source damage. Until
+             * a validator identifies a specific irreparable source defect,
+             * all conversion failures abort and discard the entire staging
+             * tree, including any earlier outputs from this session. */
             ESP_LOGE(TAG, "rebuild %s: session %s failed (%s) — aborting, "
                      "existing export left untouched", day_folder,
                      sessions[i].session_id, esp_err_to_name(r));
             ret = r;
             break;
         }
+    }
+
+    /* Shared conversion is also fallible (OOM, read/write/fsync). Complete
+     * it in staging before changing any live day or shared artifact. */
+    if (ret == ESP_OK) {
+        const rebuild_session_t *newest = &sessions[n - 1];
+        ret = edf_gen_generate_ex(REBUILD_STAGING_DIR, day_path, newest->session_id,
+                                  newest->start_epoch_ms, newest->end_epoch_ms,
+                                  newest->clock_drift_ms, EDF_GEN_SHARED);
     }
 
     if (ret != ESP_OK) {
@@ -1046,68 +1069,71 @@ esp_err_t edf_gen_rebuild_day(const char *day_folder)
     mkdir(SD_SDCARD_DIR, 0775);
     mkdir(SD_SDCARD_DATALOG, 0775);
 
-    /* Mark the day as mid-publication before anything is destroyed, so an
-     * interruption from here on is detectable on the next boot. */
-    {
-        FILE *sf = fopen(REBUILD_SENTINEL, "w");
-        if (sf) {
-            fprintf(sf, "%s\n", day_folder);
-            fflush(sf);
-            fsync(fileno(sf));
-            fclose(sf);
-        } else {
-            ESP_LOGW(TAG, "rebuild %s: could not write publish sentinel — an "
-                     "interrupted publish will not self-heal", day_folder);
-        }
-    }
-
-    rebuild_rmtree(live_day);
-    ret = rebuild_move_dir(staged_day, live_day);
+    /* Durable publication intent is mandatory before changing live output. */
+    char sentinel_tmp[400];
+    FILE *sf = edf_open_atomic_file(REBUILD_SENTINEL, sentinel_tmp, sizeof(sentinel_tmp));
+    if (!sf) ret = ESP_FAIL;
+    else if (fprintf(sf, "%s\n", day_folder) < 0) {
+        edf_discard_atomic_file(sf, sentinel_tmp); ret = ESP_FAIL;
+    } else ret = edf_finalize_atomic_file(sf, sentinel_tmp, REBUILD_SENTINEL);
     if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "rebuild %s: publish failed — day may be incomplete, "
-                 "re-run the rebuild", day_folder);
         rebuild_rmtree(REBUILD_STAGING_DIR);
         free(sessions);
         sd_storage_lease_release(SD_LEASE_EXPORT);
         return ret;
     }
-    rebuild_rmtree(REBUILD_STAGING_DIR);
 
-    /* ── Pass 2: shared artifacts, exactly once ──
-     * STR.edf is multi-day and cumulative, and its current-day record is
-     * synthesised from the session given here — so it must be the newest
-     * session of the day, not an arbitrary one.  Identification and
-     * CurrentSettings likewise come from the newest session's captured data. */
-    const rebuild_session_t *newest = &sessions[n - 1];
-    esp_err_t shared = edf_gen_generate_ex(SD_SDCARD_DIR, day_path,
-                                          newest->session_id,
-                                          newest->start_epoch_ms,
-                                          newest->end_epoch_ms,
-                                          newest->clock_drift_ms,
-                                          EDF_GEN_SHARED);
-    if (shared != ESP_OK) {
-        /* The day's per-session files are published and correct; only the
-         * cumulative/shared files are stale.  Report it without claiming the
-         * rebuild succeeded. */
-        ESP_LOGE(TAG, "rebuild %s: shared pass (STR/Identification) failed",
-                 day_folder);
+    /* Keep a recoverable prior day until the replacement directory is in
+     * place. Same-volume FAT rename needs physical power-cut validation. */
+    char prior_day[420];
+    snprintf(prior_day, sizeof(prior_day), "%s/.previous-%s", SD_SDCARD_DATALOG, day_folder);
+    bool had_live = stat(live_day, &st) == 0;
+    if (!had_live && errno != ENOENT) ret = ESP_FAIL;
+    if (ret == ESP_OK && !had_live) {
+        if (rename(prior_day, live_day) == 0) had_live = true;
+        else if (errno != ENOENT) ret = ESP_FAIL;
+    }
+    if (ret == ESP_OK && had_live) {
+        rebuild_rmtree(prior_day);
+        if (rename(live_day, prior_day) != 0) ret = ESP_FAIL;
+    }
+    bool installed = false;
+    if (ret == ESP_OK) {
+        if (rename(staged_day, live_day) != 0) ret = ESP_FAIL;
+        else installed = true;
+    }
+    if (ret == ESP_OK) {
+        char staged_settings[400], live_settings[400];
+        snprintf(staged_settings, sizeof(staged_settings), "%s/SETTINGS", REBUILD_STAGING_DIR);
+        snprintf(live_settings, sizeof(live_settings), "%s/SETTINGS", SD_SDCARD_DIR);
+        ret = rebuild_move_dir(staged_settings, live_settings);
+        if (ret == ESP_OK) ret = rebuild_move_dir(REBUILD_STAGING_DIR, SD_SDCARD_DIR);
+    }
+    if (ret != ESP_OK) {
+        if (installed) rebuild_rmtree(live_day);
+        if (had_live) (void)rename(prior_day, live_day);
+        /* Any earlier shared-file replacements remain individually complete;
+         * the durable sentinel prevents declaring the mixed day complete. */
+        rebuild_rmtree(REBUILD_STAGING_DIR);
         free(sessions);
         sd_storage_lease_release(SD_LEASE_EXPORT);
-        return shared;
+        return ret;
     }
+    rebuild_rmtree(prior_day);
+    rebuild_rmtree(REBUILD_STAGING_DIR);
 
-    /* Fully published, including the shared pass: the day is consistent, so
-     * retire the sentinel.  Every failure path above deliberately leaves it in
-     * place so the day is rebuilt again. */
+    /* Every caller, including manual rebuilds, transfers to durable uploader
+     * invalidation before retiring the rebuild sentinel. A queue wakeup is
+     * insufficient: it can be rejected or lost at reboot. */
+    ret = session_writer_mark_upload_invalidation(day_folder);
+    if (ret != ESP_OK) {
+        free(sessions);
+        sd_storage_lease_release(SD_LEASE_EXPORT);
+        return ret; /* keep sentinel so failed handoff is repaired at boot */
+    }
     unlink(REBUILD_SENTINEL);
 
-    if (degraded > 0) {
-        ESP_LOGW(TAG, "=== REBUILD DAY %s COMPLETE (%d sessions, %d skipped as "
-                 "unexportable) ===", day_folder, n - degraded, degraded);
-    } else {
-        ESP_LOGI(TAG, "=== REBUILD DAY %s COMPLETE (%d sessions) ===",
-                 day_folder, n);
-    }
+    ESP_LOGI(TAG, "=== REBUILD DAY %s COMPLETE (%d sessions) ===", day_folder, n);
     free(sessions);
     sd_storage_lease_release(SD_LEASE_EXPORT);
     return ESP_OK;
@@ -1135,11 +1161,9 @@ bool edf_gen_take_interrupted_rebuild(char *out_day, size_t out_len)
         if (buf[i] < '0' || buf[i] > '9') valid = false;
     }
 
-    /* Consume it either way: a malformed sentinel would otherwise be reported
-     * on every boot for ever. */
-    unlink(REBUILD_SENTINEL);
+    /* Keep this durable intent until a complete rebuild succeeds. */
     if (!valid) {
-        ESP_LOGW(TAG, "discarding malformed publish sentinel");
+        ESP_LOGW(TAG, "retaining malformed publish sentinel for inspection");
         return false;
     }
 

--- a/main/edf_gen.h
+++ b/main/edf_gen.h
@@ -137,3 +137,6 @@ esp_err_t edf_gen_rebuild_day(const char *day_folder);
  * the caller owns the retry.  Call once at boot, before anything reads the
  * export tree. */
 bool edf_gen_take_interrupted_rebuild(char *out_day, size_t out_len);
+
+/* Continuous EDF cannot represent positioned missing data; retain raw sources. */
+#define EDF_GEN_ERR_POSITION_GAPS (0x7e01)

--- a/main/edf_gen.h
+++ b/main/edf_gen.h
@@ -79,7 +79,7 @@
  *                    already NTP-timestamped and needs no adjustment.
  */
 /* Build a per-noon-day JSON summary (AHI/indices, usage, leak/pressure/EPAP/
- * resp-rate percentiles, session count) from that day's Summary spool, in
+ * resp-rate percentiles, session and mask-off counts) from that day's Summary spool, in
  * physical units matching STR.edf/OSCAR. On success returns ESP_OK and sets
  * *out_json to a malloc'd string (caller frees). Returns ESP_ERR_NOT_FOUND if
  * the day has no spool. noon_day is "YYYYMMDD". */
@@ -119,24 +119,25 @@ esp_err_t edf_gen_generate_ex(const char *out_root,
  *
  * Generates every session of that day into a staging directory, and only
  * swaps it into place once all of them succeeded — so a partial failure
- * leaves the previous good export untouched.  Then runs the shared pass
- * once.  Takes the storage export lease for the whole operation, so it
+ * leaves the previous good export untouched. The shared pass also finishes
+ * in staging before publication.  Takes the storage export lease for the whole operation, so it
  * cannot run concurrently with another export, an upload of the same day,
  * or a destructive action.
  *
  * day_folder is "YYYYMMDD" (noon-based).  Returns ESP_OK only if the day
  * was fully rebuilt and published — the caller may then queue it for
  * upload. */
+/* Raw data is intact but this EDF profile cannot faithfully encode its gaps.
+ * Caller must retain durable export intent and avoid publishing/uploading it. */
+#define EDF_GEN_ERR_POSITION_GAPS (0x7e01)
+
 esp_err_t edf_gen_rebuild_day(const char *day_folder);
 
 /* Boot check: was a day rebuild interrupted while publishing?
  *
- * Publication deletes the live day and moves the staged files into place, so
- * a reset in that window leaves the day incomplete.  Returns true and fills
- * out_day (8 chars + NUL) when such a day is found, consuming the marker so
- * the caller owns the retry.  Call once at boot, before anything reads the
+ * Publication retains the prior day until the new day is installed; shared
+ * artifacts still require several file replacements, so reset can interrupt it.  Returns true and fills
+ * out_day (8 chars + NUL) when such a day is found. The marker is retained until
+ * a successful rebuild. Call once at boot, before anything reads the
  * export tree. */
 bool edf_gen_take_interrupted_rebuild(char *out_day, size_t out_len);
-
-/* Continuous EDF cannot represent positioned missing data; retain raw sources. */
-#define EDF_GEN_ERR_POSITION_GAPS (0x7e01)

--- a/main/edf_header.c
+++ b/main/edf_header.c
@@ -22,8 +22,39 @@
  */
 
 #include "edf_header.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 
 static const char *TAG = "edf_hdr";
+static esp_err_t s_source_error;
+static TaskHandle_t s_source_owner;
+
+static void source_error(esp_err_t err)
+{
+    if (__atomic_load_n(&s_source_owner, __ATOMIC_ACQUIRE) ==
+            xTaskGetCurrentTaskHandle() && s_source_error == ESP_OK) {
+        s_source_error = err;
+    }
+}
+
+void edf_source_error_begin(void)
+{
+    s_source_error = ESP_OK;
+    __atomic_store_n(&s_source_owner, xTaskGetCurrentTaskHandle(),
+                     __ATOMIC_RELEASE);
+}
+
+esp_err_t edf_source_error_end(void)
+{
+    TaskHandle_t current = xTaskGetCurrentTaskHandle();
+    esp_err_t result =
+        __atomic_load_n(&s_source_owner, __ATOMIC_ACQUIRE) == current
+            ? s_source_error : ESP_OK;
+    if (__atomic_load_n(&s_source_owner, __ATOMIC_ACQUIRE) == current) {
+        __atomic_store_n(&s_source_owner, NULL, __ATOMIC_RELEASE);
+    }
+    return result;
+}
 
 /* ════════════════════════════════════════════════════════════════════
  *  CRC functions
@@ -89,19 +120,45 @@ FILE *edf_open_atomic_file(const char *path, char *tmp_path, size_t tmp_path_len
     return fopen(tmp_path, "wb");
 }
 
+esp_err_t edf_publish_atomic_path(const char *tmp_path, const char *path)
+{
+    char backup[700];
+    int n = snprintf(backup, sizeof(backup), "%s.bak", path);
+    if (n < 0 || n >= (int)sizeof(backup)) {
+        errno = ENAMETOOLONG;
+        return ESP_FAIL;
+    }
+    struct stat st;
+    bool exists = stat(path, &st) == 0;
+    if (!exists && errno != ENOENT) return ESP_FAIL;
+    if (!exists) {
+        if (rename(backup, path) == 0) exists = true;
+        else if (errno != ENOENT) return ESP_FAIL;
+    }
+    if (exists) {
+        if (unlink(backup) != 0 && errno != ENOENT) return ESP_FAIL;
+        if (rename(path, backup) != 0) return ESP_FAIL;
+    }
+    if (rename(tmp_path, path) != 0) {
+        int first_error = errno;
+        if (exists) (void)rename(backup, path);
+        errno = first_error;
+        return ESP_FAIL;
+    }
+    if (exists) (void)unlink(backup);
+    return ESP_OK;
+}
+
 esp_err_t edf_finalize_atomic_file(FILE *f, const char *tmp_path, const char *path)
 {
     int saved_errno = 0;
-    if (fflush(f) != 0 || fsync(fileno(f)) != 0 || fclose(f) != 0) {
-        saved_errno = errno;
-        unlink(tmp_path);
-        errno = saved_errno;
-        return ESP_FAIL;
-    }
-    /* FATFS does not support rename-over-existing — remove target first. */
-    unlink(path);
-    if (rename(tmp_path, path) != 0) {
-        saved_errno = errno;
+    if (fflush(f) != 0) saved_errno = errno ? errno : EIO;
+    if (!saved_errno && fsync(fileno(f)) != 0)
+        saved_errno = errno ? errno : EIO;
+    if (fclose(f) != 0 && !saved_errno) saved_errno = errno ? errno : EIO;
+    if (!saved_errno && edf_publish_atomic_path(tmp_path, path) != ESP_OK)
+        saved_errno = errno ? errno : EIO;
+    if (saved_errno) {
         unlink(tmp_path);
         errno = saved_errno;
         return ESP_FAIL;
@@ -111,23 +168,42 @@ esp_err_t edf_finalize_atomic_file(FILE *f, const char *tmp_path, const char *pa
 
 void edf_discard_atomic_file(FILE *f, const char *tmp_path)
 {
+    int first_error = errno;
     if (f) fclose(f);
     if (tmp_path) unlink(tmp_path);
+    errno = first_error;
 }
 
 cJSON *edf_read_json_file(const char *path)
 {
-    FILE *f = fopen(path, "r");
-    if (!f) return NULL;
-    fseek(f, 0, SEEK_END);
-    long fsize = ftell(f);
-    fseek(f, 0, SEEK_SET);
-    char *buf = malloc(fsize + 1);
-    if (!buf) { fclose(f); return NULL; }
-    size_t rd = fread(buf, 1, fsize, f);
-    buf[rd] = '\0';
-    fclose(f);
-    cJSON *json = cJSON_Parse(buf);
+    FILE *f = fopen(path, "rb");
+    if (!f) {
+        if (errno != ENOENT) source_error(ESP_FAIL);
+        return NULL;
+    }
+    long size = -1;
+    if (fseek(f, 0, SEEK_END) == 0) size = ftell(f);
+    char *buf = NULL;
+    if (size <= 0 || size > 1024 * 1024 || fseek(f, 0, SEEK_SET) != 0) {
+        source_error(ESP_FAIL);
+    } else {
+        buf = malloc((size_t)size + 1);
+        if (!buf) source_error(ESP_ERR_NO_MEM);
+        else if (fread(buf, 1, (size_t)size, f) != (size_t)size) {
+            source_error(ESP_FAIL);
+            free(buf);
+            buf = NULL;
+        } else {
+            buf[size] = '\0';
+        }
+    }
+    if (fclose(f) != 0) {
+        source_error(ESP_FAIL);
+        free(buf);
+        buf = NULL;
+    }
+    cJSON *json = buf ? cJSON_Parse(buf) : NULL;
+    if (buf && !json) source_error(ESP_FAIL);
     free(buf);
     return json;
 }
@@ -135,33 +211,50 @@ cJSON *edf_read_json_file(const char *path)
 esp_err_t edf_write_json_file(const char *path, const cJSON *json)
 {
     char *str = cJSON_Print(json);
-    if (!str) return ESP_FAIL;
-    FILE *f = fopen(path, "w");
-    if (!f) {
-        free(str);
-        return ESP_FAIL;
+    if (!str) {
+        source_error(ESP_ERR_NO_MEM);
+        return ESP_ERR_NO_MEM;
     }
-    fputs(str, f);
-    fputc('\n', f);
-    fclose(f);
+    char tmp[700];
+    FILE *f = edf_open_atomic_file(path, tmp, sizeof(tmp));
+    esp_err_t ret = ESP_FAIL;
+    if (f) {
+        if (!edf_write_all(f, str, strlen(str))) edf_discard_atomic_file(f, tmp);
+        else ret = edf_finalize_atomic_file(f, tmp, path);
+    }
     free(str);
-    return ESP_OK;
+    if (ret != ESP_OK) source_error(ret);
+    return ret;
 }
 
 uint8_t *edf_read_bin_file(const char *path, size_t *out_len)
 {
+    if (out_len) *out_len = 0;
     FILE *f = fopen(path, "rb");
-    if (!f) return NULL;
-    fseek(f, 0, SEEK_END);
-    long fsize = ftell(f);
-    fseek(f, 0, SEEK_SET);
-    if (fsize <= 0) { fclose(f); return NULL; }
-    uint8_t *buf = malloc(fsize);
-    if (!buf) { fclose(f); return NULL; }
-    size_t rd = fread(buf, 1, fsize, f);
-    fclose(f);
-    if (rd != (size_t)fsize) { free(buf); return NULL; }
-    *out_len = (size_t)fsize;
+    if (!f) {
+        if (errno != ENOENT) source_error(ESP_FAIL);
+        return NULL;
+    }
+    long size = -1;
+    if (fseek(f, 0, SEEK_END) == 0) size = ftell(f);
+    uint8_t *buf = NULL;
+    if (size < 0 || size > 1024 * 1024 || fseek(f, 0, SEEK_SET) != 0) {
+        source_error(ESP_FAIL);
+    } else if (size > 0) {
+        buf = malloc((size_t)size);
+        if (!buf) source_error(ESP_ERR_NO_MEM);
+        else if (fread(buf, 1, (size_t)size, f) != (size_t)size) {
+            source_error(ESP_FAIL);
+            free(buf);
+            buf = NULL;
+        }
+    }
+    if (fclose(f) != 0) {
+        source_error(ESP_FAIL);
+        free(buf);
+        buf = NULL;
+    }
+    if (buf && out_len) *out_len = (size_t)size;
     return buf;
 }
 

--- a/main/edf_internal.h
+++ b/main/edf_internal.h
@@ -59,8 +59,15 @@ void edf_write_field(char *buf, int width, const char *text);
 bool edf_write_all(FILE *f, const void *data, size_t len);
 
 FILE *edf_open_atomic_file(const char *path, char *tmp_path, size_t tmp_path_len);
+esp_err_t edf_publish_atomic_path(const char *tmp_path, const char *path);
 esp_err_t edf_finalize_atomic_file(FILE *f, const char *tmp_path, const char *path);
 void edf_discard_atomic_file(FILE *f, const char *tmp_path);
+
+/* Per-export source fault latch. Helpers record I/O/OOM/parse failures only
+ * for the task that began the export, so concurrent summary reads cannot
+ * poison its result. */
+void edf_source_error_begin(void);
+esp_err_t edf_source_error_end(void);
 
 cJSON *edf_read_json_file(const char *path);
 esp_err_t edf_write_json_file(const char *path, const cJSON *json);

--- a/main/edf_summary.c
+++ b/main/edf_summary.c
@@ -1389,6 +1389,7 @@ esp_err_t edf_gen_summary_json(const char *noon_day, char **out_json)
 
     cJSON_AddStringToObject(root, "day", noon_day);
     cJSON_AddNumberToObject(root, "sessions", ctx->n_session_entries);
+    cJSON_AddNumberToObject(root, "mask_off_count", ctx->n_session_entries);
     cJSON_AddNumberToObject(root, "usage_min", (double)usage_min);
 
     /* Indices (events/hr): raw × 0.01. -1 sentinel → null. */
@@ -1833,4 +1834,3 @@ esp_err_t edf_generate_str_edf(const char *sdcard_dir,
     free(str_sigs);
     return ESP_OK;
 }
-

--- a/main/edf_waveform.c
+++ b/main/edf_waveform.c
@@ -22,6 +22,7 @@
  */
 
 #include "edf_waveform.h"
+#include "edf_gen.h"
 
 static const char *TAG = "edf_wav";
 
@@ -228,7 +229,19 @@ esp_err_t edf_convert_snt_to_edf(const char *snt_path, const char *edf_path,
             fclose(snt); fclose(snt2);
             return ESP_FAIL;
         }
+        if (hdr2.version >= 2 &&
+            (hdr2.reserved & SNT_POSITION_GAP_FLAG)) {
+            fclose(snt);
+            fclose(snt2);
+            return EDF_GEN_ERR_POSITION_GAPS;
+        }
         hdr.n_channels = 2;
+    }
+
+    if (hdr.version >= 2 && (hdr.reserved & SNT_POSITION_GAP_FLAG)) {
+        fclose(snt);
+        if (snt2) fclose(snt2);
+        return EDF_GEN_ERR_POSITION_GAPS;
     }
 
     int snt_channels = hdr.n_channels;

--- a/main/edf_waveform.c
+++ b/main/edf_waveform.c
@@ -312,10 +312,16 @@ esp_err_t edf_convert_snt_to_edf(const char *snt_path, const char *edf_path,
             if (snt2) fclose(snt2);
             return ESP_FAIL;
         }
+        esp_err_t written = ESP_OK;
         if (edf_write_header(edf, patient_id, recording_id,
                              start_date, start_time,
-                             0, record_dur, "EDF", sig, n_signals) < 0 ||
-            edf_finalize_atomic_file(edf, tmp_path, edf_path) != ESP_OK) {
+                             0, record_dur, "EDF", sig, n_signals) < 0) {
+            edf_discard_atomic_file(edf, tmp_path);
+            written = ESP_FAIL;
+        } else {
+            written = edf_finalize_atomic_file(edf, tmp_path, edf_path);
+        }
+        if (written != ESP_OK) {
             ESP_LOGE(TAG, "cannot write %s: %s", edf_path, strerror(errno));
             free(spr); free(sig);
             fclose(snt);

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -1,3 +1,7 @@
 dependencies:
   espressif/mdns:
     version: "^1.2.0"
+  espressif/esp_lcd_touch_gt911:
+    version: "==1.1.3"
+  lvgl/lvgl:
+    version: "==8.4.0"

--- a/main/live_flow_plot.h
+++ b/main/live_flow_plot.h
@@ -1,0 +1,5 @@
+#pragma once
+#include <stdint.h>
+#include <limits.h>
+
+#define LIVE_FLOW_MISSING INT16_MIN

--- a/main/log_stream.c
+++ b/main/log_stream.c
@@ -555,7 +555,7 @@ static void ws_forwarder_task(void *arg)
     char *frame_buf = heap_caps_malloc(LOG_LINE_MAX * 16, MALLOC_CAP_SPIRAM);
     if (!frame_buf) {
         ESP_LOGE(TAG, "ws_fwd: failed to allocate frame buffer");
-        vTaskDelete(NULL);
+        psram_task_delete(NULL);
         return;
     }
     size_t frame_cap = LOG_LINE_MAX * 16;

--- a/main/main.c
+++ b/main/main.c
@@ -67,6 +67,41 @@ static void show_status(const char *title, const char *lines[], int n)
     }
 }
 
+
+static void controlled_restart(void)
+{
+    if (!netprov_lifecycle_try_claim("main-reboot")) {
+        ESP_LOGW(TAG, "restart deferred because another lifecycle operation is active");
+        bsp_display_set_notice("Restart deferred: update or restart in progress");
+        return;
+    }
+    if (bsp_display_is_therapy_active() || sd_storage_recording_active() ||
+        !bsp_display_try_reserve_therapy_safe_restart()) {
+        ESP_LOGE(TAG, "restart deferred because storage is recording or busy");
+        bsp_display_set_notice("Restart deferred: therapy or microSD is busy");
+        netprov_lifecycle_release();
+        return;
+    }
+    if (!sd_storage_lease_acquire(SD_LEASE_DESTRUCTIVE, 0)) {
+        bsp_display_cancel_therapy_safe_restart();
+        ESP_LOGE(TAG, "restart deferred because storage is busy");
+        bsp_display_set_notice("Restart deferred: microSD is busy");
+        netprov_lifecycle_release();
+        return;
+    }
+    if (bsp_display_is_therapy_active() || sd_storage_recording_active() ||
+        !bsp_display_try_commit_therapy_safe_restart()) {
+        sd_storage_lease_release(SD_LEASE_DESTRUCTIVE);
+        bsp_display_cancel_therapy_safe_restart();
+        ESP_LOGW(TAG, "restart deferred because therapy start won lifecycle gate");
+        bsp_display_set_notice("Restart deferred: therapy recording started");
+        netprov_lifecycle_release();
+        return;
+    }
+    sd_storage_deinit();
+    esp_restart();
+}
+
 static void enter_softap(const struct netprov_config *cfg)
 {
     as11_ble_disconnect();
@@ -376,7 +411,7 @@ void app_main(void)
                 }
 
                 vTaskDelay(pdMS_TO_TICKS(500));
-                esp_restart();
+                controlled_restart();
             }
         }
     } else {
@@ -475,7 +510,7 @@ void app_main(void)
             if ((xTaskGetTickCount() - softap_start_ticks) * portTICK_PERIOD_MS
                  > 10 * 60 * 1000) {
                 ESP_LOGW(TAG, "SoftAP 10-minute idle timeout: rebooting to retry connection");
-                esp_restart();
+                controlled_restart();
             }
             /* Update battery indicator in SoftAP mode */
             bsp_battery_t batt;

--- a/main/main.c
+++ b/main/main.c
@@ -161,6 +161,8 @@ void app_main(void)
     bsp_power_battery_monitor_start();
 
     /* 4. Initialise networking stack (includes NVS init). */
+    uploader_set_invalidation_hooks(session_writer_next_upload_invalidation,
+                                    session_writer_ack_upload_invalidation);
     ESP_ERROR_CHECK(netprov_init());
 
     /* 4a. Load device settings (brightness, LCD therapy mode) and apply.

--- a/main/main.c
+++ b/main/main.c
@@ -224,16 +224,21 @@ void app_main(void)
         session_writer_recover();
     }
 
-    /* 4b-2. Initialise audio codec and touch sensor BEFORE BLE —
-     * BLE RF activity during connection causes I2C bus noise that makes
-     * register writes NACK. The devices share the I2C bus on GPIO 41/42. */
+    /* 4b-2. Initialise board audio before BLE. On the compact board, also
+     * initialize its shared I2C bus and CST816 touch controller first because
+     * BLE RF activity can make setup-time register writes NACK. The 7B display
+     * owns its separate controller and GT911 initialization. */
+#if !CONFIG_SOMNOTRACE_BOARD_WAVESHARE_7B
     bsp_i2c_init();
+#endif
     if (bsp_audio_init() != ESP_OK) {
         ESP_LOGW(TAG, "audio codec init failed — buzzer will be unavailable");
     }
+#if !CONFIG_SOMNOTRACE_BOARD_WAVESHARE_7B
     if (bsp_touch_init() != ESP_OK) {
         ESP_LOGW(TAG, "touch init failed — tap to wake unavailable");
     }
+#endif
 
     /* 4c. Initialise BLE (AirSense 11 pairing). Non-fatal on failure.
      * Runs after storage init + crash recovery (see 4b). */

--- a/main/main.c
+++ b/main/main.c
@@ -37,6 +37,8 @@
 #include "sd_storage.h"
 #include "session_writer.h"
 #include "nvs_writer.h"
+#include "psram_task.h"
+#include "therapy_alert_runtime.h"
 #include "esp_system.h"
 #include "esp_app_desc.h"
 #include "esp_heap_caps.h"
@@ -105,6 +107,7 @@ void app_main(void)
     /* 1c. Log reset reason and check for crash core dump from previous boot.
      * Must be after log_stream_init() so output is captured. */
     crash_diag_check();
+    ESP_ERROR_CHECK(psram_task_init());
 
     /* 2. Start button monitors. */
     bsp_power_start_button_monitor(5000);   /* PWR 5 s = power off */
@@ -216,6 +219,7 @@ void app_main(void)
     session_writer_enable_deferred_export();
 
     /* 4d. Init therapy alert subsystem (loads config from NVS). */
+    therapy_alert_set_task_fns(psram_task_create, psram_task_delete);
     therapy_alert_set_beep_fn(bsp_audio_beep);
     therapy_alert_set_therapy_active_fn(bsp_display_is_therapy_active);
     therapy_alert_init();

--- a/main/net_provision.c
+++ b/main/net_provision.c
@@ -2305,6 +2305,12 @@ static void uploader_lease_release(void)
     sd_storage_lease_release(SD_LEASE_UPLOAD);
 }
 
+
+static bool uploader_recording_requested(void)
+{
+    return sd_storage_recording_pending() || sd_storage_recording_active();
+}
+
 /* Recursively delete a directory and all its contents. */
 static void recursive_delete(const char *path)
 {
@@ -3271,6 +3277,7 @@ static esp_err_t start_webserver(void)
     /* Let the uploader participate in storage arbitration so it never reads a
      * day folder while a rebuild is replacing it. */
     uploader_set_lease_fns(uploader_lease_acquire, uploader_lease_release);
+    uploader_set_cancel_fn(uploader_recording_requested);
     /* Periodic upload scans yield to a live therapy recording; event-driven
      * uploads still run, since they matter more than a housekeeping scan. */
     upload_sched_set_busy_fn(sd_storage_recording_active);

--- a/main/net_provision.c
+++ b/main/net_provision.c
@@ -860,22 +860,15 @@ static struct {
     char     ntp_srv[64];
     TickType_t tz_tick;
 } s_status_cache;
-
 static volatile bool s_sd_refreshing = false;
 
 static void sd_refresh_task(void *arg)
 {
     (void)arg;
-    if (sd_storage_is_ready()) {
-        FATFS *fs = NULL;
-        DWORD free_clst = 0;
-        if (f_getfree("0:", &free_clst, &fs) == FR_OK && fs) {
-            s_status_cache.sd_total = (uint64_t)fs->n_fatent * fs->csize * fs->ssize;
-            s_status_cache.sd_free  = (uint64_t)free_clst * fs->csize * fs->ssize;
-            s_status_cache.sd_valid = true;
-        }
+    if (sd_storage_is_ready() &&
+        sd_storage_get_free(NULL, NULL) == ESP_OK) {
+        s_status_cache.sd_tick = xTaskGetTickCount();
     }
-    s_status_cache.sd_tick = xTaskGetTickCount();
     s_sd_refreshing = false;
     vTaskDelete(NULL);
 }
@@ -887,6 +880,12 @@ static void trigger_sd_refresh(void)
     if (xTaskCreate(sd_refresh_task, "sd_refresh", 3072, NULL, 1, NULL) != pdPASS) {
         s_sd_refreshing = false;
     }
+}
+
+static void status_cache_refresh_sd(void)
+{
+    s_status_cache.sd_valid = sd_storage_get_cached_free(
+        &s_status_cache.sd_free, &s_status_cache.sd_total);
 }
 
 static void status_cache_refresh_nvs(void)
@@ -902,11 +901,13 @@ cJSON *netprov_build_status_json(void)
     TickType_t now = xTaskGetTickCount();
     uint32_t ms = portTICK_PERIOD_MS;
 
-    /* Refresh SD free space asynchronously at most once per STATUS_CACHE_SD_MS */
+    /* Refresh free space asynchronously, then copy its coherent cached
+     * snapshot into this request's status cache. */
     if (!s_status_cache.sd_valid ||
         (uint32_t)((now - s_status_cache.sd_tick) * ms) >= STATUS_CACHE_SD_MS) {
         trigger_sd_refresh();
     }
+    status_cache_refresh_sd();
 
     /* Refresh NVS-backed settings at most once per STATUS_CACHE_NVS_MS */
     if (!s_status_cache.cfg_valid ||
@@ -1151,7 +1152,7 @@ static void wifi_scan_task(void *arg)
     s_scan_running = false;
     if (s_scan_mutex) xSemaphoreGive(s_scan_mutex);
 
-    vTaskDelete(NULL);
+    psram_task_delete(NULL);
 }
 
 static esp_err_t scan_get_handler(httpd_req_t *req)
@@ -1334,7 +1335,11 @@ static esp_err_t ox_pair_handler(httpd_req_t *req)
 
 static esp_err_t ox_forget_handler(httpd_req_t *req)
 {
-    oximeter_forget();
+    esp_err_t e = oximeter_forget();
+    if (e != ESP_OK) {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "forget failed");
+        return ESP_FAIL;
+    }
     httpd_resp_set_type(req, "application/json");
     httpd_resp_sendstr(req, "{\"ok\":true}");
     return ESP_OK;
@@ -2196,7 +2201,7 @@ static void recreate_edfs_task(void *arg)
 
     if (total_sessions == 0) {
         ESP_LOGI(TAG, "recreate_edfs_task: no sessions found");
-        vTaskDelete(NULL);
+        psram_task_delete(NULL);
         return;
     }
 
@@ -2206,7 +2211,7 @@ static void recreate_edfs_task(void *arg)
             sizeof(recreate_session_t), MALLOC_CAP_SPIRAM);
     if (!sessions) {
         ESP_LOGE(TAG, "recreate_edfs_task: failed to allocate %d sessions", total_sessions);
-        vTaskDelete(NULL);
+        psram_task_delete(NULL);
         return;
     }
     int n_sessions = 0;
@@ -2300,7 +2305,7 @@ static void recreate_edfs_task(void *arg)
     if (!queued_days) {
         ESP_LOGE(TAG, "recreate_edfs_task: failed to allocate queued_days");
         free(sessions);
-        vTaskDelete(NULL);
+        psram_task_delete(NULL);
         return;
     }
     int n_queued_days = 0;
@@ -2347,7 +2352,7 @@ static void recreate_edfs_task(void *arg)
              n_processed, n_sessions, n_queued_days);
     free(queued_days);
     free(sessions);
-    vTaskDelete(NULL);
+    psram_task_delete(NULL);
 }
 
 /* Scoped single-day rebuild.  Unlike recreate_edfs_task() this deletes
@@ -2356,7 +2361,7 @@ static void recreate_edfs_task(void *arg)
 static void rebuild_day_task(void *arg)
 {
     char *day = (char *)arg;
-    if (!day) { vTaskDelete(NULL); return; }
+    if (!day) { psram_task_delete(NULL); return; }
 
     esp_err_t ret = edf_gen_rebuild_day(day);
     if (ret == ESP_OK) {
@@ -2369,7 +2374,7 @@ static void rebuild_day_task(void *arg)
                  day, esp_err_to_name(ret));
     }
     free(day);
-    vTaskDelete(NULL);
+    psram_task_delete(NULL);
 }
 
 /* SD format progress, polled by the browser via /api/format-progress.  The
@@ -2430,7 +2435,7 @@ static void format_sd_task(void *arg)
     s_format_progress.done = true;
     s_format_progress.active = false;
     xSemaphoreGive(s_format_mtx);
-    vTaskDelete(NULL);
+    psram_task_delete(NULL);
 }
 
 static esp_err_t format_progress_handler(httpd_req_t *req)
@@ -3239,7 +3244,7 @@ void netprov_dns_task(void *arg)
     int sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
     if (sock < 0) {
         ESP_LOGE(TAG, "dns socket create failed");
-        vTaskDelete(NULL);
+        psram_task_delete(NULL);
         return;
     }
 
@@ -3251,7 +3256,7 @@ void netprov_dns_task(void *arg)
     if (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
         ESP_LOGE(TAG, "dns bind failed");
         close(sock);
-        vTaskDelete(NULL);
+        psram_task_delete(NULL);
         return;
     }
 

--- a/main/net_provision.c
+++ b/main/net_provision.c
@@ -52,6 +52,7 @@
 #include "bsp_power.h"
 #include "bsp_audio.h"
 #include "esp_log.h"
+#include "esp_timer.h"
 #include "esp_wifi.h"
 #include "esp_event.h"
 #include "esp_netif.h"
@@ -74,6 +75,48 @@
 #include "mdns.h"
 
 static const char *TAG = "netprov";
+
+/* One global claim covers every firmware update and controlled restart.  Some
+ * owners continue in background tasks and can originate outside httpd, so the
+ * claim is public and atomically acquired before any worker is scheduled. */
+static portMUX_TYPE s_lifecycle_claim_lock = portMUX_INITIALIZER_UNLOCKED;
+static bool s_lifecycle_claimed;
+static const char *s_lifecycle_claim_owner;
+
+
+
+
+bool netprov_lifecycle_try_claim(const char *owner)
+{
+    bool claimed = false;
+    portENTER_CRITICAL(&s_lifecycle_claim_lock);
+    if (!s_lifecycle_claimed) {
+        s_lifecycle_claimed = true;
+        s_lifecycle_claim_owner = owner;
+        claimed = true;
+    }
+    portEXIT_CRITICAL(&s_lifecycle_claim_lock);
+    return claimed;
+}
+
+
+void netprov_lifecycle_release(void)
+{
+    portENTER_CRITICAL(&s_lifecycle_claim_lock);
+    s_lifecycle_claimed = false;
+    s_lifecycle_claim_owner = NULL;
+    portEXIT_CRITICAL(&s_lifecycle_claim_lock);
+}
+
+
+static const char *lifecycle_claim_owner(void)
+{
+    const char *owner;
+    portENTER_CRITICAL(&s_lifecycle_claim_lock);
+    owner = s_lifecycle_claim_owner;
+    portEXIT_CRITICAL(&s_lifecycle_claim_lock);
+    return owner ? owner : "none";
+}
 
 #define NVS_NAMESPACE       "cfg"
 #define NVS_KEY_HOSTNAME    "hostname"
@@ -1395,19 +1438,94 @@ static esp_err_t ble_passthrough_handler(httpd_req_t *req)
         return ESP_FAIL;
     }
 
-    int received = httpd_req_recv(req, body, total);
-    if (received < 0) {
-        free(body);
-        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "recv failed");
-        return ESP_FAIL;
+    int received = 0;
+    while (received < total) {
+        int chunk = httpd_req_recv(req, body + received, total - received);
+        if (chunk <= 0) {
+            free(body);
+            httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "recv failed");
+            return ESP_FAIL;
+        }
+        received += chunk;
     }
     body[received] = '\0';
 
+    /* The passthrough endpoint can issue the same lifecycle-changing RPC as
+     * the local controls. Detect it from parsed JSON (including JSON-RPC batch
+     * form), then hold a therapy-start claim across the command response and
+     * local state publication so a restart cannot commit in between. */
+    bool starts_therapy = false;
+    bool batched_therapy_start = false;
+    cJSON *request_json = cJSON_Parse(body);
+    if (!request_json) {
+        free(body);
+        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "invalid JSON");
+        return ESP_FAIL;
+    }
+    if (cJSON_IsObject(request_json)) {
+        /* Scan every direct field so duplicate JSON keys cannot hide a later
+         * lifecycle-changing method from the gate. */
+        cJSON *field = NULL;
+        cJSON_ArrayForEach(field, request_json) {
+            if (field->string && strcmp(field->string, "method") == 0 &&
+                cJSON_IsString(field) &&
+                strcmp(field->valuestring, "EnterTherapy") == 0) {
+                starts_therapy = true;
+                break;
+            }
+        }
+    } else if (cJSON_IsArray(request_json)) {
+        cJSON *item = NULL;
+        cJSON_ArrayForEach(item, request_json) {
+            if (cJSON_IsObject(item)) {
+                cJSON *field = NULL;
+                cJSON_ArrayForEach(field, item) {
+                    if (field->string && strcmp(field->string, "method") == 0 &&
+                        cJSON_IsString(field) &&
+                        strcmp(field->valuestring, "EnterTherapy") == 0) {
+                        starts_therapy = true;
+                        batched_therapy_start = true;
+                        break;
+                    }
+                }
+            }
+            if (batched_therapy_start) break;
+        }
+    }
+    cJSON_Delete(request_json);
+
+    if (batched_therapy_start) {
+        free(body);
+        httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST,
+                            "batched EnterTherapy is not supported");
+        return ESP_FAIL;
+    }
+
+    if (starts_therapy && !bsp_display_reserve_therapy_start()) {
+        free(body);
+        httpd_resp_set_status(req, "409 Conflict");
+        httpd_resp_set_type(req, "application/json");
+        httpd_resp_set_hdr(req, "Connection", "close");
+        return httpd_resp_sendstr(
+            req, "{\"ok\":false,\"error\":\"restart already committed\"}");
+    }
+
     char *out_json = NULL;
-    esp_err_t err = as11_ble_passthrough_rpc(body, &out_json, 10000);
+    bool may_have_run = false;
+    esp_err_t err = as11_ble_passthrough_rpc_tracked(
+        body, &out_json, 10000, &may_have_run);
     free(body);
 
     if (err != ESP_OK || !out_json) {
+        if (starts_therapy) {
+            /* A post-send timeout/failure is indeterminate. Conservatively
+             * publish active before releasing the start claim so a real AS11
+             * start cannot lose to a restart while its event is in flight. */
+            if (may_have_run && bsp_display_set_therapy_active(true)) {
+                bsp_display_set_therapy_start_time(esp_timer_get_time());
+            }
+            bsp_display_release_therapy_start();
+        }
         httpd_resp_set_status(req, "503 Service Unavailable");
         httpd_resp_set_type(req, "application/json");
         httpd_resp_set_hdr(req, "Connection", "close");
@@ -1417,6 +1535,21 @@ static esp_err_t ble_passthrough_handler(httpd_req_t *req)
         snprintf(errbuf, sizeof(errbuf), "{\"ok\":false,\"error\":\"%s\"}", errmsg);
         httpd_resp_sendstr(req, errbuf);
         return ESP_FAIL;
+    }
+
+    if (starts_therapy) {
+        /* as11_ble_passthrough_rpc returns a syntactically valid serialized
+         * response. Only an explicit JSON-RPC error means EnterTherapy was
+         * rejected; on a local parse-allocation failure, conservatively mark
+         * therapy active so a real start can never lose to a restart. */
+        cJSON *response_json = cJSON_Parse(out_json);
+        bool accepted = !response_json ||
+                        !cJSON_GetObjectItemCaseSensitive(response_json, "error");
+        if (accepted && bsp_display_set_therapy_active(true)) {
+            bsp_display_set_therapy_start_time(esp_timer_get_time());
+        }
+        cJSON_Delete(response_json);
+        bsp_display_release_therapy_start();
     }
 
     httpd_resp_set_type(req, "application/json");
@@ -1430,9 +1563,56 @@ static void reboot_task(void *arg)
 {
     (void)arg;
     vTaskDelay(pdMS_TO_TICKS(1500));
+
+    if (bsp_display_is_therapy_active() || sd_storage_recording_active() ||
+        !bsp_display_try_reserve_therapy_safe_restart()) {
+        ESP_LOGW(TAG, "credential reboot deferred: therapy is active");
+        bsp_display_set_notice("Wi-Fi saved; restart deferred while recording");
+        netprov_lifecycle_release();
+        psram_task_delete(NULL);
+        return;
+    }
+
+    if (!sd_storage_lease_acquire(SD_LEASE_DESTRUCTIVE, 0)) {
+        bsp_display_cancel_therapy_safe_restart();
+        ESP_LOGW(TAG, "credential reboot deferred: SD operation active");
+        bsp_display_set_notice("Wi-Fi saved; restart deferred for microSD");
+        netprov_lifecycle_release();
+        psram_task_delete(NULL);
+        return;
+    }
+
+    if (bsp_display_is_therapy_active() || sd_storage_recording_active() ||
+        !bsp_display_try_commit_therapy_safe_restart()) {
+        sd_storage_lease_release(SD_LEASE_DESTRUCTIVE);
+        bsp_display_cancel_therapy_safe_restart();
+        ESP_LOGW(TAG, "credential reboot deferred: therapy start won lifecycle gate");
+        bsp_display_set_notice("Wi-Fi saved; restart deferred while recording");
+        netprov_lifecycle_release();
+        psram_task_delete(NULL);
+        return;
+    }
+
     ESP_LOGI(TAG, "rebooting to apply credentials");
+    sd_storage_deinit();
     esp_restart();
 }
+
+static bool schedule_reboot(const char *name)
+{
+    if (!netprov_lifecycle_try_claim(name)) {
+        ESP_LOGW(TAG, "reboot deferred: lifecycle owned by %s", lifecycle_claim_owner());
+        return false;
+    }
+    if (!psram_task_create(reboot_task, name, 4096, NULL, 5,
+                           tskNO_AFFINITY, NULL, NULL)) {
+        netprov_lifecycle_release();
+        ESP_LOGE(TAG, "reboot worker allocation failed");
+        return false;
+    }
+    return true;
+}
+
 
 static esp_err_t heap_stats_handler(httpd_req_t *req)
 {
@@ -1486,7 +1666,7 @@ static esp_err_t reboot_post_handler(httpd_req_t *req)
 {
     httpd_resp_set_type(req, "application/json");
     httpd_resp_send(req, "{\"ok\":true}", HTTPD_RESP_USE_STRLEN);
-    psram_task_create(reboot_task, "reboot", 4096, NULL, 5, tskNO_AFFINITY, NULL, NULL);
+    schedule_reboot("reboot");
     return ESP_OK;
 }
 
@@ -1591,7 +1771,7 @@ static esp_err_t save_post_handler(httpd_req_t *req)
     httpd_resp_sendstr(req,
         "<html><body style=\"font-family:sans-serif\">Saved. Rebooting to connect...</body></html>");
 
-    psram_task_create(reboot_task, "reboot", 4096, NULL, 5, tskNO_AFFINITY, NULL, NULL);
+    schedule_reboot("reboot");
     return ESP_OK;
 }
 
@@ -2396,32 +2576,92 @@ static SemaphoreHandle_t s_format_mtx;  /* guards s_format_progress reads/writes
  * card in between.  The success path never returns (it reboots). */
 static void format_sd_task(void *arg)
 {
+    (void)arg;
     ESP_LOGW(TAG, "format_sd_task: starting destructive format");
 
-    if (!sd_storage_lease_acquire(SD_LEASE_DESTRUCTIVE, 5000)) {
+    /* The lifecycle claim serializes this destructive operation with OTA and
+     * other restarts. Do not hold the therapy restart reservation across the
+     * long, blocking format: therapy publication must remain responsive. */
+    if (!sd_storage_lease_acquire(SD_LEASE_DESTRUCTIVE, 0)) {
         xSemaphoreTake(s_format_mtx, portMAX_DELAY);
         strlcpy(s_format_progress.error,
                 "SD busy — a recording, export or upload is using the card",
                 sizeof(s_format_progress.error));
         xSemaphoreGive(s_format_mtx);
+    } else if (bsp_display_is_therapy_active() ||
+               sd_storage_recording_active()) {
+        sd_storage_lease_release(SD_LEASE_DESTRUCTIVE);
+        xSemaphoreTake(s_format_mtx, portMAX_DELAY);
+        strlcpy(s_format_progress.error,
+                "therapy started before format could begin",
+                sizeof(s_format_progress.error));
+        xSemaphoreGive(s_format_mtx);
     } else {
-        /* No uploader_reset_state() here: on success the reboot re-inits the
-         * uploader against the now-empty state dir, and on failure the old
-         * state is still valid.  Calling it would also wake the upload
-         * scheduler to rescan the card mid-format. */
+        /* Do not reset uploader state before the result is known: that would
+         * wake its scheduler to rescan the card mid-format, and on failure the
+         * old state remains valid. */
         esp_err_t ret = sd_storage_format();
         if (ret == ESP_OK) {
-            ESP_LOGI(TAG, "format_sd_task: formatted OK, rebooting for clean remount");
+            ESP_LOGI(TAG, "format_sd_task: formatted OK, preparing clean reboot");
             xSemaphoreTake(s_format_mtx, portMAX_DELAY);
             s_format_progress.ok = true;
             s_format_progress.done = true;
             s_format_progress.active = false;
             xSemaphoreGive(s_format_mtx);
+            /* Formatting is complete and the fresh volume is mounted. Let a
+             * therapy start record immediately during the browser grace
+             * period instead of retaining the destructive lease. */
+            sd_storage_lease_release(SD_LEASE_DESTRUCTIVE);
+            /* Keep the live process coherent if therapy defers reboot for a
+             * long time: clear stale upload tracking only after the fresh
+             * filesystem is mounted and the format lease is released. */
+            uploader_reset_state();
             /* Give the browser poll (2 s interval) time to read the result,
-             * then flush the fresh filesystem and reboot. */
+             * then atomically arbitrate the clean reboot with current/new
+             * therapy. The short reservation begins only after formatting. */
             vTaskDelay(pdMS_TO_TICKS(2500));
-            sd_storage_deinit();
-            esp_restart();
+            bool announced_defer = false;
+            for (;;) {
+                if (bsp_display_is_therapy_active() ||
+                    sd_storage_recording_active()) {
+                    if (!announced_defer) {
+                        ESP_LOGW(TAG, "format reboot deferred during therapy");
+                        bsp_display_set_notice(
+                            "Card formatted; restart deferred during therapy");
+                        announced_defer = true;
+                    }
+                    vTaskDelay(pdMS_TO_TICKS(2000));
+                    continue;
+                }
+
+                if (!bsp_display_try_reserve_therapy_safe_restart()) {
+                    vTaskDelay(pdMS_TO_TICKS(1000));
+                    continue;
+                }
+                if (!sd_storage_lease_acquire(SD_LEASE_DESTRUCTIVE, 0)) {
+                    bsp_display_cancel_therapy_safe_restart();
+                    if (!announced_defer) {
+                        ESP_LOGW(TAG, "format reboot deferred for storage");
+                        bsp_display_set_notice(
+                            "Card formatted; waiting for storage before restart");
+                        announced_defer = true;
+                    }
+                    vTaskDelay(pdMS_TO_TICKS(1000));
+                    continue;
+                }
+                if (bsp_display_is_therapy_active() ||
+                    sd_storage_recording_active() ||
+                    !bsp_display_try_commit_therapy_safe_restart()) {
+                    sd_storage_lease_release(SD_LEASE_DESTRUCTIVE);
+                    /* Release storage before waking a therapy-start waiter. */
+                    bsp_display_cancel_therapy_safe_restart();
+                    vTaskDelay(pdMS_TO_TICKS(1000));
+                    continue;
+                }
+
+                sd_storage_deinit();
+                esp_restart();
+            }
         }
         ESP_LOGE(TAG, "format_sd_task: failed: %s", esp_err_to_name(ret));
         xSemaphoreTake(s_format_mtx, portMAX_DELAY);
@@ -2435,6 +2675,7 @@ static void format_sd_task(void *arg)
     s_format_progress.done = true;
     s_format_progress.active = false;
     xSemaphoreGive(s_format_mtx);
+    netprov_lifecycle_release();
     psram_task_delete(NULL);
 }
 
@@ -2681,7 +2922,7 @@ static esp_err_t ota_upload_handler(httpd_req_t *req)
     httpd_resp_sendstr(req, "{\"ok\":true}");
 
     /* Reboot after a short delay so the response is sent. */
-    psram_task_create(reboot_task, "ota_reboot", 4096, NULL, 5, tskNO_AFFINITY, NULL, NULL);
+    schedule_reboot("ota_reboot");
     return ESP_OK;
 }
 
@@ -2775,7 +3016,7 @@ static void ota_url_task(void *arg)
     s_ota_progress.active = false;
     s_ota_progress.done = true;
     free(url);
-    psram_task_create(reboot_task, "ota_reboot", 4096, NULL, 5, tskNO_AFFINITY, NULL, NULL);
+    schedule_reboot("ota_reboot");
     vTaskDelete(NULL);
     return;
 
@@ -2958,10 +3199,15 @@ static esp_err_t actions_handler(httpd_req_t *req)
             cJSON_Delete(root);
             return send_busy(req, "therapy recording in progress");
         }
+        if (!netprov_lifecycle_try_claim("format-sd")) {
+            cJSON_Delete(root);
+            return send_busy(req, "update or restart already in progress");
+        }
         xSemaphoreTake(s_format_mtx, portMAX_DELAY);
         if (s_format_progress.active) {
             xSemaphoreGive(s_format_mtx);
             cJSON_Delete(root);
+            netprov_lifecycle_release();
             return send_busy(req, "format already in progress");
         }
         ESP_LOGI(TAG, "action: format SD card (destructive)");
@@ -2971,6 +3217,7 @@ static esp_err_t actions_handler(httpd_req_t *req)
         xSemaphoreGive(s_format_mtx);
         TaskHandle_t h = psram_task_create(format_sd_task, "format_sd", 16384, NULL, 5, 1, NULL, NULL);
         if (!h) {
+            netprov_lifecycle_release();
             xSemaphoreTake(s_format_mtx, portMAX_DELAY);
             s_format_progress.active = false;
             xSemaphoreGive(s_format_mtx);

--- a/main/net_provision.h
+++ b/main/net_provision.h
@@ -108,3 +108,7 @@ void netprov_dns_task(void *arg);
 void netprov_get_mdns_name(char *out, size_t out_len);
 esp_err_t netprov_set_mdns_name(const char *name);
 const char *netprov_mdns_name_cached(void);
+
+/* One owner for background restart/update/format lifecycle operations. */
+bool netprov_lifecycle_try_claim(const char *owner);
+void netprov_lifecycle_release(void);

--- a/main/oximeter.c
+++ b/main/oximeter.c
@@ -30,6 +30,7 @@
 
 #include "oximeter.h"
 #include "oximeter_internal.h"
+#include "oximeter_store.h"
 
 #include "esp_log.h"
 #include "nvs_flash.h"
@@ -47,14 +48,6 @@ static const char *TAG = "oximeter";
 
 static const ox_driver_ops_t *s_active = &oxyii_driver_ops;
 static ox_driver_t s_driver_type = OX_DRIVER_OXYII;
-
-/* Forward declarations for store functions */
-bool ox_store_load_paired(char *serial, size_t serial_sz,
-                          char *firmware, size_t fw_sz,
-                          char *name_prefix, size_t prefix_sz,
-                          char *last_addr, size_t addr_sz,
-                          char *driver, size_t driver_sz,
-                          char *ble_name, size_t ble_name_sz);
 
 static void load_driver_type(void)
 {

--- a/main/oximeter.c
+++ b/main/oximeter.c
@@ -60,9 +60,13 @@ static void load_driver_type(void)
 {
     /* Try NVS first */
     nvs_handle_t h;
+    bool forgotten = false;
     nvs_writer_lock();
     if (nvs_open(OX_NVS_NS, NVS_READONLY, &h) == ESP_OK) {
         uint8_t drv;
+        uint8_t forgotten_value = 0;
+        forgotten = nvs_get_u8(h, "forgotten", &forgotten_value) == ESP_OK &&
+                    forgotten_value == 1;
         if (nvs_get_u8(h, "driver", &drv) == ESP_OK && drv <= OX_DRIVER_LEGACY)
             s_driver_type = (ox_driver_t)drv;
         nvs_close(h);
@@ -70,7 +74,7 @@ static void load_driver_type(void)
     nvs_writer_unlock();
 
     /* Fall back to paired.json on SD */
-    if (s_driver_type == OX_DRIVER_OXYII) {
+    if (!forgotten && s_driver_type == OX_DRIVER_OXYII) {
         char drv[16] = {0};
         if (ox_store_load_paired(NULL, 0, NULL, 0, NULL, 0, NULL, 0,
                                  drv, sizeof(drv), NULL, 0)) {
@@ -234,7 +238,7 @@ static void auto_pair_task(void *arg)
                      esp_err_to_name(rc));
             s_pair_in_progress = false;
             free(pa);
-            vTaskDelete(NULL);
+            psram_task_delete(NULL);
             return;
         }
     }
@@ -252,7 +256,7 @@ static void auto_pair_task(void *arg)
                  s_driver_type == OX_DRIVER_LEGACY ? "Gen1 (Legacy)" : "Gen2 (OxyII)");
         s_pair_in_progress = false;
         free(pa);
-        vTaskDelete(NULL);
+        psram_task_delete(NULL);
         return;
     }
 
@@ -264,7 +268,7 @@ static void auto_pair_task(void *arg)
                  lerr ? lerr : "unknown");
         s_pair_in_progress = false;
         free(pa);
-        vTaskDelete(NULL);
+        psram_task_delete(NULL);
         return;
     }
 
@@ -290,7 +294,7 @@ static void auto_pair_task(void *arg)
                  st ? st : "null", err ? err : "none");
         s_pair_in_progress = false;
         free(pa);
-        vTaskDelete(NULL);
+        psram_task_delete(NULL);
         return;
     }
 
@@ -305,7 +309,7 @@ static void auto_pair_task(void *arg)
                  esp_err_to_name(rc));
         s_pair_in_progress = false;
         free(pa);
-        vTaskDelete(NULL);
+        psram_task_delete(NULL);
         return;
     }
 
@@ -323,7 +327,7 @@ static void auto_pair_task(void *arg)
 
     s_pair_in_progress = false;
     free(pa);
-    vTaskDelete(NULL);
+    psram_task_delete(NULL);
 }
 
 esp_err_t oximeter_pair(const char *addr_str, ox_driver_t driver)
@@ -364,8 +368,7 @@ esp_err_t oximeter_pair(const char *addr_str, ox_driver_t driver)
 
 esp_err_t oximeter_forget(void)
 {
-    s_active->forget();
-    return ESP_OK;
+    return s_active->forget();
 }
 
 const char *oximeter_get_status(void)

--- a/main/oximeter_internal.h
+++ b/main/oximeter_internal.h
@@ -50,8 +50,9 @@ typedef struct {
      * background task.  Stores serial + metadata via ox_store_save_paired. */
     esp_err_t (*pair)(const char *addr_str);
 
-    /* Forget the paired device.  Clears driver-internal state. */
-    void (*forget)(void);
+    /* Forget the paired device.  Clears driver-internal state only after the
+     * durable NVS tombstone commits successfully. */
+    esp_err_t (*forget)(void);
 
     /* Return current status string (one of OX_STATUS_*). */
     const char *(*get_status)(void);

--- a/main/oximeter_legacy.c
+++ b/main/oximeter_legacy.c
@@ -1073,15 +1073,24 @@ static esp_err_t do_save_nvs(void *arg)
     nvs_handle_t h;
     esp_err_t e = nvs_open(OX_NVS_NS, NVS_READWRITE, &h);
     if (e != ESP_OK) return e;
-    nvs_set_str(h, "serial", local.serial);
-    nvs_set_str(h, "firmware", local.firmware);
-    nvs_set_str(h, "name_prefix", local.name_prefix);
-    nvs_set_str(h, "ble_name", local.ble_name);
-    nvs_set_str(h, "last_addr", local.last_addr);
-    nvs_set_u8(h, "driver", (uint8_t)OX_DRIVER_LEGACY);
-    e = nvs_commit(h);
+    e = nvs_set_str(h, "serial", local.serial);
+    if (e == ESP_OK) e = nvs_set_str(h, "firmware", local.firmware);
+    if (e == ESP_OK) e = nvs_set_str(h, "name_prefix", local.name_prefix);
+    if (e == ESP_OK) e = nvs_set_str(h, "ble_name", local.ble_name);
+    if (e == ESP_OK) e = nvs_set_str(h, "last_addr", local.last_addr);
+    if (e == ESP_OK) e = nvs_set_u8(h, "driver", (uint8_t)OX_DRIVER_LEGACY);
+    /* Clear a prior Forget tombstone only after the complete replacement
+     * pairing record has been accepted by NVS. */
+    if (e == ESP_OK) e = nvs_set_u8(h, "forgotten", 0);
+    if (e == ESP_OK) e = nvs_commit(h);
     nvs_close(h);
     return e;
+}
+
+static esp_err_t erase_nvs_key_if_present(nvs_handle_t h, const char *key)
+{
+    esp_err_t e = nvs_erase_key(h, key);
+    return e == ESP_ERR_NVS_NOT_FOUND ? ESP_OK : e;
 }
 
 static esp_err_t do_erase_nvs(void *arg)
@@ -1090,14 +1099,17 @@ static esp_err_t do_erase_nvs(void *arg)
     nvs_handle_t h;
     esp_err_t e = nvs_open(OX_NVS_NS, NVS_READWRITE, &h);
     if (e != ESP_OK) return e;
-    nvs_erase_key(h, "serial");
-    nvs_erase_key(h, "firmware");
-    nvs_erase_key(h, "name_prefix");
-    nvs_erase_key(h, "ble_name");
-    nvs_erase_key(h, "last_addr");
-    nvs_erase_key(h, "driver");
-    nvs_erase_key(h, "probe_mode");
-    e = nvs_commit(h);
+    e = erase_nvs_key_if_present(h, "serial");
+    if (e == ESP_OK) e = erase_nvs_key_if_present(h, "firmware");
+    if (e == ESP_OK) e = erase_nvs_key_if_present(h, "name_prefix");
+    if (e == ESP_OK) e = erase_nvs_key_if_present(h, "ble_name");
+    if (e == ESP_OK) e = erase_nvs_key_if_present(h, "last_addr");
+    if (e == ESP_OK) e = erase_nvs_key_if_present(h, "driver");
+    if (e == ESP_OK) e = erase_nvs_key_if_present(h, "probe_mode");
+    /* Keep this key after erasing the pairing record.  If paired.json cannot
+     * be deleted because the card is busy, reboot must not resurrect it. */
+    if (e == ESP_OK) e = nvs_set_u8(h, "forgotten", 1);
+    if (e == ESP_OK) e = nvs_commit(h);
     nvs_close(h);
     return e;
 }
@@ -1119,34 +1131,39 @@ static ox_probe_mode_t s_probe_mode = OX_PROBE_PERSISTENT;
 static void load_paired_from_nvs(void)
 {
     nvs_handle_t h;
+    bool forgotten = false;
     nvs_writer_lock();
-    if (nvs_open(OX_NVS_NS, NVS_READONLY, &h) != ESP_OK) { nvs_writer_unlock(); return; }
-    size_t len;
+    if (nvs_open(OX_NVS_NS, NVS_READONLY, &h) == ESP_OK) {
+        size_t len;
+        uint8_t forgotten_value = 0;
+        forgotten = nvs_get_u8(h, "forgotten", &forgotten_value) == ESP_OK &&
+                    forgotten_value == 1;
 
-    uint8_t drv;
-    bool driver_matches = nvs_get_u8(h, "driver", &drv) == ESP_OK && drv == OX_DRIVER_LEGACY;
-    len = sizeof(s_serial);
-    if (driver_matches && nvs_get_str(h, "serial", s_serial, &len) == ESP_OK && s_serial[0]) {
-        s_paired = true;
-        len = sizeof(s_firmware);
-        nvs_get_str(h, "firmware", s_firmware, &len);
-        len = sizeof(s_name_prefix);
-        nvs_get_str(h, "name_prefix", s_name_prefix, &len);
-        len = sizeof(s_ble_name);
-        nvs_get_str(h, "ble_name", s_ble_name, &len);
-        len = sizeof(s_paired_addr);
-        nvs_get_str(h, "last_addr", s_paired_addr, &len);
-    } else {
-        s_serial[0] = '\0';
+        uint8_t drv;
+        bool driver_matches = nvs_get_u8(h, "driver", &drv) == ESP_OK && drv == OX_DRIVER_LEGACY;
+        len = sizeof(s_serial);
+        if (driver_matches && nvs_get_str(h, "serial", s_serial, &len) == ESP_OK && s_serial[0]) {
+            s_paired = true;
+            len = sizeof(s_firmware);
+            nvs_get_str(h, "firmware", s_firmware, &len);
+            len = sizeof(s_name_prefix);
+            nvs_get_str(h, "name_prefix", s_name_prefix, &len);
+            len = sizeof(s_ble_name);
+            nvs_get_str(h, "ble_name", s_ble_name, &len);
+            len = sizeof(s_paired_addr);
+            nvs_get_str(h, "last_addr", s_paired_addr, &len);
+        } else {
+            s_serial[0] = '\0';
+        }
+        uint8_t pm;
+        if (nvs_get_u8(h, "probe_mode", &pm) == ESP_OK && pm <= 1)
+            s_probe_mode = (ox_probe_mode_t)pm;
+        nvs_close(h);
     }
-    uint8_t pm;
-    if (nvs_get_u8(h, "probe_mode", &pm) == ESP_OK && pm <= 1)
-        s_probe_mode = (ox_probe_mode_t)pm;
-    nvs_close(h);
     nvs_writer_unlock();
 
     /* Also try loading from paired.json (SD) as fallback */
-    if (!s_paired) {
+    if (!s_paired && !forgotten) {
         char serial[32], fw[16], prefix[16], addr[18], drv[16], bname[40];
         if (ox_store_load_paired(serial, sizeof(serial),
                                  fw, sizeof(fw),
@@ -1181,7 +1198,7 @@ static void pair_task(void *arg)
         set_error("invalid address: %s", addr_str);
         free(pa);
         xSemaphoreGive(s_ops_mtx);
-        vTaskDelete(NULL);
+        psram_task_delete(NULL);
         return;
     }
 
@@ -1189,7 +1206,7 @@ static void pair_task(void *arg)
         do_disconnect();
         free(pa);
         xSemaphoreGive(s_ops_mtx);
-        vTaskDelete(NULL);
+        psram_task_delete(NULL);
         return;
     }
 
@@ -1201,7 +1218,7 @@ static void pair_task(void *arg)
         do_disconnect();
         free(pa);
         xSemaphoreGive(s_ops_mtx);
-        vTaskDelete(NULL);
+        psram_task_delete(NULL);
         return;
     }
 
@@ -1210,7 +1227,7 @@ static void pair_task(void *arg)
         do_disconnect();
         free(pa);
         xSemaphoreGive(s_ops_mtx);
-        vTaskDelete(NULL);
+        psram_task_delete(NULL);
         return;
     }
 
@@ -1228,7 +1245,7 @@ static void pair_task(void *arg)
         do_disconnect();
         free(pa);
         xSemaphoreGive(s_ops_mtx);
-        vTaskDelete(NULL);
+        psram_task_delete(NULL);
         return;
     }
 
@@ -1281,7 +1298,15 @@ static void pair_task(void *arg)
     strlcpy(nvs_arg.name_prefix, prefix, sizeof(nvs_arg.name_prefix));
     strlcpy(nvs_arg.ble_name, display_name, sizeof(nvs_arg.ble_name));
     strlcpy(nvs_arg.last_addr, addr_str, sizeof(nvs_arg.last_addr));
-    nvs_writer_run(do_save_nvs, &nvs_arg);
+    esp_err_t persisted = nvs_writer_run(do_save_nvs, &nvs_arg);
+    if (persisted != ESP_OK) {
+        set_error("pairing storage failed: %s", esp_err_to_name(persisted));
+        do_disconnect();
+        free(pa);
+        xSemaphoreGive(s_ops_mtx);
+        psram_task_delete(NULL);
+        return;
+    }
 
     /* Save to paired.json on SD */
     ox_store_save_paired(serial, firmware, prefix, addr_str, "wellue_legacy", display_name);
@@ -1304,7 +1329,7 @@ static void pair_task(void *arg)
 
     free(pa);
     xSemaphoreGive(s_ops_mtx);
-    vTaskDelete(NULL);
+    psram_task_delete(NULL);
 }
 
 /* ── Low-duty scan (caller holds s_ops_mtx) ─────────────────────────── */
@@ -1419,7 +1444,7 @@ static void pull_task(void *arg)
     }
     if (!as11_ble_is_host_ready()) {
         ESP_LOGW(TAG, "watch: host not ready, aborting");
-        vTaskDelete(NULL);
+        psram_task_delete(NULL);
         return;
     }
 
@@ -1707,8 +1732,18 @@ static esp_err_t legacy_pair(const char *addr_str)
     return ESP_OK;
 }
 
-static void legacy_forget(void)
+static esp_err_t legacy_forget(void)
 {
+    esp_err_t persisted = nvs_writer_run(do_erase_nvs, NULL);
+    if (persisted != ESP_OK) {
+        set_error("forget storage failed: %s", esp_err_to_name(persisted));
+        return persisted;
+    }
+
+    /* The NVS tombstone is authoritative.  paired.json is only a compatibility
+     * mirror, so failure to remove it must not resurrect the device. */
+    ox_store_delete_paired();
+
     s_paired = false;
     s_presence_served = false;
     s_synced_this_idle = false;
@@ -1720,10 +1755,8 @@ static void legacy_forget(void)
     s_ble_name[0] = '\0';
     s_paired_addr[0] = '\0';
 
-    nvs_writer_run(do_erase_nvs, NULL);
-    ox_store_delete_paired();
-
     set_state(OX_STATUS_IDLE);
+    return ESP_OK;
 }
 
 static const char *legacy_get_status(void)

--- a/main/oximeter_legacy.c
+++ b/main/oximeter_legacy.c
@@ -28,6 +28,7 @@
 
 #include "oximeter.h"
 #include "oximeter_internal.h"
+#include "oximeter_store.h"
 #include "sd_storage.h"
 #include "as11_ble.h"
 #include "psram_task.h"
@@ -62,31 +63,6 @@
 #include "host/util/util.h"
 
 static const char *TAG = "ox_legacy";
-
-/* ── Store forward declarations (oximeter_store.c) ─────────────────── */
-void ox_store_ensure_dirs(void);
-bool ox_store_load_paired(char *serial, size_t serial_sz,
-                          char *firmware, size_t fw_sz,
-                          char *name_prefix, size_t prefix_sz,
-                          char *last_addr, size_t addr_sz,
-                          char *driver, size_t driver_sz,
-                          char *ble_name, size_t ble_name_sz);
-void ox_store_save_paired(const char *serial, const char *firmware,
-                          const char *name_prefix, const char *last_addr,
-                          const char *driver, const char *ble_name);
-void ox_store_delete_paired(void);
-int  ox_store_index_check(const char *serial, const char *name);
-int  ox_store_index_conversion_check(const char *serial, const char *name);
-void ox_store_index_add(const char *serial, const char *name,
-                        uint32_t bytes, bool finalised);
-void ox_store_index_mark_converted(const char *serial, const char *name,
-                                   bool converted, const char *error);
-long ox_store_part_size(const char *name);
-esp_err_t ox_store_part_append(const char *name, const uint8_t *data, size_t len);
-bool ox_store_promote_vld3(const char *serial, const char *name);
-bool ox_store_finalize_native(const char *serial, const char *name,
-                              long declared_size);
-void ox_store_part_remove(const char *name);
 
 /* ── Legacy protocol constants ──────────────────────────────────────── */
 #define LEGACY_REQ_LEAD     0xAA
@@ -1390,6 +1366,14 @@ static bool do_pull_and_mark(bool *pulled_any)
     int count = parse_file_list(file_list, names, 32);
     ESP_LOGI(TAG, "file list: %d files", count);
 
+    /* Scanning, connection and device metadata are BLE-only.  Hold the card
+     * gate only across the index/download/conversion transaction. */
+    if (!ox_store_begin_io(0)) {
+        ESP_LOGW(TAG, "O2 pull deferred: SD maintenance active");
+        return false;
+    }
+    ox_store_ensure_dirs();
+
     bool pull_ok = true;
     for (int i = 0; i < count; i++) {
         if (names[i][0] == '\0') continue;
@@ -1427,6 +1411,7 @@ static bool do_pull_and_mark(bool *pulled_any)
         }
         if (pulled_any) *pulled_any = true;
     }
+    ox_store_end_io();
     return pull_ok;
 }
 
@@ -1634,8 +1619,11 @@ static void legacy_init(void)
     }
 
     load_paired_from_nvs();
-    ox_store_ensure_dirs();
-    if (sd_storage_is_ready()) oximetry_canonical_ensure_dirs();
+    if (ox_store_begin_io(0)) {
+        ox_store_ensure_dirs();
+        oximetry_canonical_ensure_dirs();
+        ox_store_end_io();
+    }
 
     if (s_paired)
         set_state(OX_STATUS_PAIRED);

--- a/main/oximeter_oxyii.c
+++ b/main/oximeter_oxyii.c
@@ -27,6 +27,7 @@
 
 #include "oximeter.h"
 #include "oximeter_internal.h"
+#include "oximeter_store.h"
 #include "sd_storage.h"
 #include "as11_ble.h"
 #include "psram_task.h"
@@ -62,29 +63,6 @@
 #include "host/util/util.h"
 
 static const char *TAG = "ox_oxyii";
-
-/* ── Store forward declarations (oximeter_store.c) ─────────────────── */
-void ox_store_ensure_dirs(void);
-bool ox_store_load_paired(char *serial, size_t serial_sz,
-                          char *firmware, size_t fw_sz,
-                          char *name_prefix, size_t prefix_sz,
-                          char *last_addr, size_t addr_sz,
-                          char *driver, size_t driver_sz,
-                          char *ble_name, size_t ble_name_sz);
-void ox_store_save_paired(const char *serial, const char *firmware,
-                          const char *name_prefix, const char *last_addr,
-                          const char *driver, const char *ble_name);
-void ox_store_delete_paired(void);
-int  ox_store_index_check(const char *serial, const char *name);
-int  ox_store_index_conversion_check(const char *serial, const char *name);
-void ox_store_index_add(const char *serial, const char *name,
-                        uint32_t bytes, bool finalised);
-void ox_store_index_mark_converted(const char *serial, const char *name,
-                                   bool converted, const char *error);
-long ox_store_part_size(const char *name);
-esp_err_t ox_store_part_append(const char *name, const uint8_t *data, size_t len);
-bool ox_store_promote(const char *serial, const char *name);
-void ox_store_part_remove(const char *name);
 
 /* ── OxyII protocol constants ──────────────────────────────────────── */
 #define OXYII_LEAD         0xA5
@@ -1585,9 +1563,12 @@ static void canonical_migration_task(void *arg)
     vTaskDelay(pdMS_TO_TICKS(30000));
     while (sd_storage_recording_active())
         vTaskDelay(pdMS_TO_TICKS(5000));
-    if (sd_storage_is_ready()) {
+    if (sd_storage_is_ready() && ox_store_begin_io(5000)) {
         oximetry_canonical_reconcile();
         oximetry_canonical_migrate_all_legacy();
+        ox_store_end_io();
+    } else if (sd_storage_is_ready()) {
+        ESP_LOGW(TAG, "canonical migration deferred: SD maintenance active");
     }
     psram_task_delete(NULL);
 }
@@ -1627,6 +1608,15 @@ static bool do_pull_and_mark(bool *pulled_any)
     s_f1_fail_count = 0;
     ESP_LOGI(TAG, "file list: %d files", count);
 
+    /* The BLE discovery/list exchange above does not touch the card.  Claim
+     * the storage gate only for the index/download/conversion transaction so
+     * format or a controlled unmount cannot invalidate an open FATFS object. */
+    if (!ox_store_begin_io(0)) {
+        ESP_LOGW(TAG, "O2 pull deferred: SD maintenance active");
+        return false;
+    }
+    ox_store_ensure_dirs();
+
     bool pull_ok = true;
     for (int i = 0; i < count; i++) {
         if (names[i][0] == '\0') continue;
@@ -1657,6 +1647,7 @@ static bool do_pull_and_mark(bool *pulled_any)
         }
         if (pulled_any) *pulled_any = true;
     }
+    ox_store_end_io();
     return pull_ok;
 }
 
@@ -2021,8 +2012,11 @@ static void oxyii_init(void)
     }
 
     load_paired_from_nvs();
-    ox_store_ensure_dirs();
-    if (sd_storage_is_ready()) oximetry_canonical_ensure_dirs();
+    if (ox_store_begin_io(0)) {
+        ox_store_ensure_dirs();
+        oximetry_canonical_ensure_dirs();
+        ox_store_end_io();
+    }
 
     if (s_paired)
         set_state(OX_STATUS_PAIRED);

--- a/main/oximeter_oxyii.c
+++ b/main/oximeter_oxyii.c
@@ -1277,15 +1277,24 @@ static esp_err_t do_save_nvs(void *arg)
     nvs_handle_t h;
     esp_err_t e = nvs_open(OX_NVS_NS, NVS_READWRITE, &h);
     if (e != ESP_OK) return e;
-    nvs_set_str(h, "serial", local.serial);
-    nvs_set_str(h, "firmware", local.firmware);
-    nvs_set_str(h, "name_prefix", local.name_prefix);
-    nvs_set_str(h, "ble_name", local.ble_name);
-    nvs_set_str(h, "last_addr", local.last_addr);
-    nvs_set_u8(h, "driver", (uint8_t)OX_DRIVER_OXYII);
-    e = nvs_commit(h);
+    e = nvs_set_str(h, "serial", local.serial);
+    if (e == ESP_OK) e = nvs_set_str(h, "firmware", local.firmware);
+    if (e == ESP_OK) e = nvs_set_str(h, "name_prefix", local.name_prefix);
+    if (e == ESP_OK) e = nvs_set_str(h, "ble_name", local.ble_name);
+    if (e == ESP_OK) e = nvs_set_str(h, "last_addr", local.last_addr);
+    if (e == ESP_OK) e = nvs_set_u8(h, "driver", (uint8_t)OX_DRIVER_OXYII);
+    /* Clear a prior Forget tombstone only after the complete replacement
+     * pairing record has been accepted by NVS. */
+    if (e == ESP_OK) e = nvs_set_u8(h, "forgotten", 0);
+    if (e == ESP_OK) e = nvs_commit(h);
     nvs_close(h);
     return e;
+}
+
+static esp_err_t erase_nvs_key_if_present(nvs_handle_t h, const char *key)
+{
+    esp_err_t e = nvs_erase_key(h, key);
+    return e == ESP_ERR_NVS_NOT_FOUND ? ESP_OK : e;
 }
 
 static esp_err_t do_erase_nvs(void *arg)
@@ -1294,14 +1303,17 @@ static esp_err_t do_erase_nvs(void *arg)
     nvs_handle_t h;
     esp_err_t e = nvs_open(OX_NVS_NS, NVS_READWRITE, &h);
     if (e != ESP_OK) return e;
-    nvs_erase_key(h, "serial");
-    nvs_erase_key(h, "firmware");
-    nvs_erase_key(h, "name_prefix");
-    nvs_erase_key(h, "ble_name");
-    nvs_erase_key(h, "last_addr");
-    nvs_erase_key(h, "driver");
-    nvs_erase_key(h, "probe_mode");
-    e = nvs_commit(h);
+    e = erase_nvs_key_if_present(h, "serial");
+    if (e == ESP_OK) e = erase_nvs_key_if_present(h, "firmware");
+    if (e == ESP_OK) e = erase_nvs_key_if_present(h, "name_prefix");
+    if (e == ESP_OK) e = erase_nvs_key_if_present(h, "ble_name");
+    if (e == ESP_OK) e = erase_nvs_key_if_present(h, "last_addr");
+    if (e == ESP_OK) e = erase_nvs_key_if_present(h, "driver");
+    if (e == ESP_OK) e = erase_nvs_key_if_present(h, "probe_mode");
+    /* Keep this key after erasing the pairing record.  If paired.json cannot
+     * be deleted because the card is busy, reboot must not resurrect it. */
+    if (e == ESP_OK) e = nvs_set_u8(h, "forgotten", 1);
+    if (e == ESP_OK) e = nvs_commit(h);
     nvs_close(h);
     return e;
 }
@@ -1321,52 +1333,57 @@ static esp_err_t do_save_probe_mode(void *arg)
 static void load_paired_from_nvs(void)
 {
     nvs_handle_t h;
+    bool forgotten = false;
     nvs_writer_lock();
-    if (nvs_open(OX_NVS_NS, NVS_READONLY, &h) != ESP_OK) { nvs_writer_unlock(); return; }
-    size_t len;
+    if (nvs_open(OX_NVS_NS, NVS_READONLY, &h) == ESP_OK) {
+        size_t len;
+        uint8_t forgotten_value = 0;
+        forgotten = nvs_get_u8(h, "forgotten", &forgotten_value) == ESP_OK &&
+                    forgotten_value == 1;
 
-    uint8_t drv;
-    bool driver_matches = nvs_get_u8(h, "driver", &drv) == ESP_OK && drv == OX_DRIVER_OXYII;
-    len = sizeof(s_serial);
-    if (driver_matches && nvs_get_str(h, "serial", s_serial, &len) == ESP_OK && s_serial[0]) {
-        s_paired = true;
-        len = sizeof(s_firmware);
-        nvs_get_str(h, "firmware", s_firmware, &len);
-        len = sizeof(s_name_prefix);
-        nvs_get_str(h, "name_prefix", s_name_prefix, &len);
-        len = sizeof(s_ble_name);
-        nvs_get_str(h, "ble_name", s_ble_name, &len);
-        len = sizeof(s_paired_addr);
-        nvs_get_str(h, "last_addr", s_paired_addr, &len);
+        uint8_t drv;
+        bool driver_matches = nvs_get_u8(h, "driver", &drv) == ESP_OK && drv == OX_DRIVER_OXYII;
+        len = sizeof(s_serial);
+        if (driver_matches && nvs_get_str(h, "serial", s_serial, &len) == ESP_OK && s_serial[0]) {
+            s_paired = true;
+            len = sizeof(s_firmware);
+            nvs_get_str(h, "firmware", s_firmware, &len);
+            len = sizeof(s_name_prefix);
+            nvs_get_str(h, "name_prefix", s_name_prefix, &len);
+            len = sizeof(s_ble_name);
+            nvs_get_str(h, "ble_name", s_ble_name, &len);
+            len = sizeof(s_paired_addr);
+            nvs_get_str(h, "last_addr", s_paired_addr, &len);
 
-        /* Validate loaded serial format: if corrupted from pre-AES firmware, clear */
-        size_t slen = strlen(s_serial);
-        bool valid = (slen >= 4);
-        for (size_t i = 0; i < slen; i++) {
-            if ((unsigned char)s_serial[i] < 0x20 || (unsigned char)s_serial[i] > 0x7E) {
-                valid = false;
-                break;
+            /* Validate loaded serial format: if corrupted from pre-AES firmware, clear */
+            size_t slen = strlen(s_serial);
+            bool valid = (slen >= 4);
+            for (size_t i = 0; i < slen; i++) {
+                if ((unsigned char)s_serial[i] < 0x20 || (unsigned char)s_serial[i] > 0x7E) {
+                    valid = false;
+                    break;
+                }
             }
-        }
-        if (!valid) {
-            ESP_LOGW(TAG, "invalid or corrupted serial in NVS ('%s') — clearing paired state", s_serial);
-            s_paired = false;
-            s_serial[0] = '\0';
+            if (!valid) {
+                ESP_LOGW(TAG, "invalid or corrupted serial in NVS ('%s') — clearing paired state", s_serial);
+                s_paired = false;
+                s_serial[0] = '\0';
+            } else {
+                ESP_LOGI(TAG, "paired ring loaded: serial='%s' name='%s' addr='%s'",
+                         s_serial, s_ble_name, s_paired_addr);
+            }
         } else {
-            ESP_LOGI(TAG, "paired ring loaded: serial='%s' name='%s' addr='%s'",
-                     s_serial, s_ble_name, s_paired_addr);
+            s_serial[0] = '\0';
         }
-    } else {
-        s_serial[0] = '\0';
+        uint8_t pm;
+        if (nvs_get_u8(h, "probe_mode", &pm) == ESP_OK && pm <= 1)
+            s_probe_mode = (ox_probe_mode_t)pm;
+        nvs_close(h);
     }
-    uint8_t pm;
-    if (nvs_get_u8(h, "probe_mode", &pm) == ESP_OK && pm <= 1)
-        s_probe_mode = (ox_probe_mode_t)pm;
-    nvs_close(h);
     nvs_writer_unlock();
 
     /* Also try loading from paired.json (SD) as fallback */
-    if (!s_paired) {
+    if (!s_paired && !forgotten) {
         char serial[32], fw[16], prefix[16], addr[18], drv[16], bname[40];
         if (ox_store_load_paired(serial, sizeof(serial),
                                  fw, sizeof(fw),
@@ -1401,7 +1418,7 @@ static void pair_task(void *arg)
         set_error("invalid address: %s", addr_str);
         free(pa);
         xSemaphoreGive(s_ops_mtx);
-        vTaskDelete(NULL);
+        psram_task_delete(NULL);
         return;
     }
 
@@ -1409,7 +1426,7 @@ static void pair_task(void *arg)
         do_disconnect();
         free(pa);
         xSemaphoreGive(s_ops_mtx);
-        vTaskDelete(NULL);
+        psram_task_delete(NULL);
         return;
     }
 
@@ -1418,7 +1435,7 @@ static void pair_task(void *arg)
         do_disconnect();
         free(pa);
         xSemaphoreGive(s_ops_mtx);
-        vTaskDelete(NULL);
+        psram_task_delete(NULL);
         return;
     }
 
@@ -1428,7 +1445,7 @@ static void pair_task(void *arg)
         do_disconnect();
         free(pa);
         xSemaphoreGive(s_ops_mtx);
-        vTaskDelete(NULL);
+        psram_task_delete(NULL);
         return;
     }
 
@@ -1437,7 +1454,7 @@ static void pair_task(void *arg)
         do_disconnect();
         free(pa);
         xSemaphoreGive(s_ops_mtx);
-        vTaskDelete(NULL);
+        psram_task_delete(NULL);
         return;
     }
 
@@ -1455,7 +1472,7 @@ static void pair_task(void *arg)
         do_disconnect();
         free(pa);
         xSemaphoreGive(s_ops_mtx);
-        vTaskDelete(NULL);
+        psram_task_delete(NULL);
         return;
     }
 
@@ -1497,7 +1514,15 @@ static void pair_task(void *arg)
     strlcpy(nvs_arg.name_prefix, prefix, sizeof(nvs_arg.name_prefix));
     strlcpy(nvs_arg.ble_name, display_name, sizeof(nvs_arg.ble_name));
     strlcpy(nvs_arg.last_addr, addr_str, sizeof(nvs_arg.last_addr));
-    nvs_writer_run(do_save_nvs, &nvs_arg);
+    esp_err_t persisted = nvs_writer_run(do_save_nvs, &nvs_arg);
+    if (persisted != ESP_OK) {
+        set_error("pairing storage failed: %s", esp_err_to_name(persisted));
+        do_disconnect();
+        free(pa);
+        xSemaphoreGive(s_ops_mtx);
+        psram_task_delete(NULL);
+        return;
+    }
 
     /* Save to paired.json on SD */
     ox_store_save_paired(serial, firmware, prefix, addr_str, "wellue_oxyii", display_name);
@@ -1520,7 +1545,7 @@ static void pair_task(void *arg)
 
     free(pa);
     xSemaphoreGive(s_ops_mtx);
-    vTaskDelete(NULL);
+    psram_task_delete(NULL);
 }
 
 /* ── Low-duty OxyII scan (caller holds s_ops_mtx) ──────────────────── */
@@ -1564,7 +1589,7 @@ static void canonical_migration_task(void *arg)
         oximetry_canonical_reconcile();
         oximetry_canonical_migrate_all_legacy();
     }
-    vTaskDelete(NULL);
+    psram_task_delete(NULL);
 }
 
 /* ── File pull helper (shared by legacy and persistent paths) ─────── */
@@ -1647,7 +1672,7 @@ static void pull_task(void *arg)
     }
     if (!as11_ble_is_host_ready()) {
         ESP_LOGW(TAG, "watch: host not ready, aborting");
-        vTaskDelete(NULL);
+        psram_task_delete(NULL);
         return;
     }
 
@@ -2098,8 +2123,18 @@ static esp_err_t oxyii_pair(const char *addr_str)
     return ESP_OK;
 }
 
-static void oxyii_forget(void)
+static esp_err_t oxyii_forget(void)
 {
+    esp_err_t persisted = nvs_writer_run(do_erase_nvs, NULL);
+    if (persisted != ESP_OK) {
+        set_error("forget storage failed: %s", esp_err_to_name(persisted));
+        return persisted;
+    }
+
+    /* The NVS tombstone is authoritative.  paired.json is only a compatibility
+     * mirror, so failure to remove it must not resurrect the device. */
+    ox_store_delete_paired();
+
     s_paired = false;
     s_presence_served = false;
     s_synced_this_idle = false;
@@ -2111,10 +2146,8 @@ static void oxyii_forget(void)
     s_ble_name[0] = '\0';
     s_paired_addr[0] = '\0';
 
-    nvs_writer_run(do_erase_nvs, NULL);
-    ox_store_delete_paired();
-
     set_state(OX_STATUS_IDLE);
+    return ESP_OK;
 }
 
 static const char *oxyii_get_status(void)

--- a/main/oximeter_store.c
+++ b/main/oximeter_store.c
@@ -23,6 +23,7 @@
  */
 
 #include "oximeter.h"
+#include "oximeter_store.h"
 #include "oximetry_vld3.h"
 #include "sd_storage.h"
 
@@ -56,23 +57,52 @@ static const uint8_t TRAILER_MAGIC[4] = { 0x48, 0x12, 0x5A, 0xDA };
 #define VLD3_HEADER_LEN OX_VLD3_HEADER_LEN
 #define VLD3_RECORD_LEN OX_VLD3_RECORD_LEN
 
+bool ox_store_begin_io(uint32_t timeout_ms)
+{
+    if (!sd_storage_is_ready() ||
+        !sd_storage_lease_acquire(SD_LEASE_EXPORT, timeout_ms))
+        return false;
+
+    /* The mount may have disappeared before our lease was published. */
+    if (!sd_storage_is_ready()) {
+        sd_storage_lease_release(SD_LEASE_EXPORT);
+        return false;
+    }
+    return true;
+}
+
+void ox_store_end_io(void)
+{
+    sd_storage_lease_release(SD_LEASE_EXPORT);
+}
+
 /* ── Directory helpers ─────────────────────────────────────────────── */
 
-void ox_store_ensure_dirs(void)
+static void ensure_dirs_unlocked(void)
 {
     mkdir(OXY_BASE, 0775);
     mkdir(OXY_INBOX, 0775);
     mkdir(OXY_FILES, 0775);
 }
 
+void ox_store_ensure_dirs(void)
+{
+    if (!ox_store_begin_io(0)) {
+        ESP_LOGW(TAG, "ensure directories deferred: SD unavailable or busy");
+        return;
+    }
+    ensure_dirs_unlocked();
+    ox_store_end_io();
+}
+
 /* ── paired.json ──────────────────────────────────────────────────── */
 
-bool ox_store_load_paired(char *serial, size_t serial_sz,
-                          char *firmware, size_t fw_sz,
-                          char *name_prefix, size_t prefix_sz,
-                          char *last_addr, size_t addr_sz,
-                          char *driver, size_t driver_sz,
-                          char *ble_name, size_t ble_name_sz)
+static bool load_paired_unlocked(char *serial, size_t serial_sz,
+                                 char *firmware, size_t fw_sz,
+                                 char *name_prefix, size_t prefix_sz,
+                                 char *last_addr, size_t addr_sz,
+                                 char *driver, size_t driver_sz,
+                                 char *ble_name, size_t ble_name_sz)
 {
     FILE *f = fopen(OXY_PAIRED_JSON, "r");
     if (!f) return false;
@@ -120,11 +150,26 @@ bool ox_store_load_paired(char *serial, size_t serial_sz,
     return ok;
 }
 
-void ox_store_save_paired(const char *serial, const char *firmware,
-                          const char *name_prefix, const char *last_addr,
-                          const char *driver, const char *ble_name)
+bool ox_store_load_paired(char *serial, size_t serial_sz,
+                          char *firmware, size_t fw_sz,
+                          char *name_prefix, size_t prefix_sz,
+                          char *last_addr, size_t addr_sz,
+                          char *driver, size_t driver_sz,
+                          char *ble_name, size_t ble_name_sz)
 {
-    ox_store_ensure_dirs();
+    if (!ox_store_begin_io(0)) return false;
+    bool loaded = load_paired_unlocked(serial, serial_sz, firmware, fw_sz,
+                                       name_prefix, prefix_sz, last_addr, addr_sz,
+                                       driver, driver_sz, ble_name, ble_name_sz);
+    ox_store_end_io();
+    return loaded;
+}
+
+static void save_paired_unlocked(const char *serial, const char *firmware,
+                                 const char *name_prefix, const char *last_addr,
+                                 const char *driver, const char *ble_name)
+{
+    ensure_dirs_unlocked();
     cJSON *j = cJSON_CreateObject();
     cJSON_AddStringToObject(j, "serial", serial);
     if (firmware) cJSON_AddStringToObject(j, "firmware", firmware);
@@ -144,9 +189,26 @@ void ox_store_save_paired(const char *serial, const char *firmware,
     cJSON_free(json);
 }
 
+void ox_store_save_paired(const char *serial, const char *firmware,
+                          const char *name_prefix, const char *last_addr,
+                          const char *driver, const char *ble_name)
+{
+    if (!ox_store_begin_io(0)) {
+        ESP_LOGW(TAG, "paired metadata save deferred: SD unavailable or busy");
+        return;
+    }
+    save_paired_unlocked(serial, firmware, name_prefix, last_addr, driver, ble_name);
+    ox_store_end_io();
+}
+
 void ox_store_delete_paired(void)
 {
+    if (!ox_store_begin_io(0)) {
+        ESP_LOGW(TAG, "paired metadata delete deferred: SD unavailable or busy");
+        return;
+    }
     remove(OXY_PAIRED_JSON);
+    ox_store_end_io();
 }
 
 /* ── index.json ───────────────────────────────────────────────────── */
@@ -360,7 +422,7 @@ void ox_store_index_mark_converted(const char *serial, const char *name,
     cJSON_Delete(arr);
 }
 
-char *ox_store_conversion_diagnostics_json(void)
+static char *conversion_diagnostics_json_unlocked(void)
 {
     cJSON *index = load_index_array();
     cJSON *out = cJSON_CreateArray();
@@ -380,6 +442,14 @@ char *ox_store_conversion_diagnostics_json(void)
     char *json = cJSON_PrintUnformatted(out);
     cJSON_Delete(out);
     cJSON_Delete(index);
+    return json;
+}
+
+char *ox_store_conversion_diagnostics_json(void)
+{
+    if (!ox_store_begin_io(0)) return NULL;
+    char *json = conversion_diagnostics_json_unlocked();
+    ox_store_end_io();
     return json;
 }
 

--- a/main/oximeter_store.h
+++ b/main/oximeter_store.h
@@ -1,0 +1,41 @@
+/* SomnoTrace O2 Ring storage internals. */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "esp_err.h"
+
+/* Hold this across a complete O2 filesystem transaction.  The export lease
+ * deliberately permits concurrent therapy recording, while excluding format,
+ * unmount/reboot and other replace-in-place O2 operations. */
+bool ox_store_begin_io(uint32_t timeout_ms);
+void ox_store_end_io(void);
+
+void ox_store_ensure_dirs(void);
+bool ox_store_load_paired(char *serial, size_t serial_sz,
+                          char *firmware, size_t fw_sz,
+                          char *name_prefix, size_t prefix_sz,
+                          char *last_addr, size_t addr_sz,
+                          char *driver, size_t driver_sz,
+                          char *ble_name, size_t ble_name_sz);
+void ox_store_save_paired(const char *serial, const char *firmware,
+                          const char *name_prefix, const char *last_addr,
+                          const char *driver, const char *ble_name);
+void ox_store_delete_paired(void);
+int ox_store_index_check(const char *serial, const char *name);
+int ox_store_index_conversion_check(const char *serial, const char *name);
+void ox_store_index_add(const char *serial, const char *name,
+                        uint32_t bytes, bool finalised);
+void ox_store_index_mark_converted(const char *serial, const char *name,
+                                   bool converted, const char *error);
+char *ox_store_conversion_diagnostics_json(void);
+long ox_store_part_size(const char *name);
+esp_err_t ox_store_part_append(const char *name, const uint8_t *data, size_t len);
+bool ox_store_promote(const char *serial, const char *name);
+bool ox_store_promote_vld3(const char *serial, const char *name);
+bool ox_store_finalize_native(const char *serial, const char *name,
+                              long declared_size);
+void ox_store_part_remove(const char *name);

--- a/main/oximetry_canonical.c
+++ b/main/oximetry_canonical.c
@@ -23,6 +23,7 @@
 
 #include "oximetry_canonical.h"
 #include "oximetry_vld3.h"
+#include "oximeter_store.h"
 #include "sd_storage.h"
 #include "time_sync.h"
 #include "as11_time.h"
@@ -42,12 +43,6 @@
 
 #include "esp_log.h"
 #include "esp_rom_crc.h"
-
-int ox_store_index_check(const char *serial, const char *name);
-void ox_store_index_add(const char *serial, const char *name,
-                        uint32_t bytes, bool finalised);
-void ox_store_index_mark_converted(const char *serial, const char *name,
-                                   bool converted, const char *error);
 
 static const char *TAG = "ox_canon";
 

--- a/main/oximetry_http.c
+++ b/main/oximetry_http.c
@@ -22,6 +22,7 @@
 
 #include "oximetry_http.h"
 #include "oximetry_canonical.h"
+#include "oximeter_store.h"
 #include "upload_ox.h"
 
 #include <stdio.h>
@@ -32,7 +33,6 @@
 
 #include "esp_log.h"
 
-char *ox_store_conversion_diagnostics_json(void);
 
 static const char *TAG = "ox_http";
 
@@ -57,29 +57,43 @@ static esp_err_t json_send(httpd_req_t *req, char *json)
 
 static esp_err_t oximetry_recordings_handler(httpd_req_t *req)
 {
+    if (!ox_store_begin_io(0)) {
+        httpd_resp_set_status(req, "503 Service Unavailable");
+        return httpd_resp_sendstr(req, "Oximetry storage busy");
+    }
+
+    char *json = NULL;
     char date_str[16];
     if (query(req, "date", date_str, sizeof(date_str)) && strlen(date_str) == 8) {
         cJSON *arr = NULL;
         if (oximetry_canonical_list_ready_for_day(date_str, &arr) == ESP_OK && arr) {
-            char *s = cJSON_PrintUnformatted(arr);
+            json = cJSON_PrintUnformatted(arr);
             cJSON_Delete(arr);
-            return json_send(req, s);
         }
-        return json_send(req, strdup("[]"));
+        if (!json) json = strdup("[]");
+    } else {
+        json = oximetry_canonical_list_json();
     }
-    return json_send(req, oximetry_canonical_list_json());
+    ox_store_end_io();
+    return json_send(req, json);
 }
 
 static esp_err_t oximetry_days_handler(httpd_req_t *req)
 {
     (void)req;
-    cJSON *arr = NULL;
-    if (oximetry_canonical_list_days(&arr) == ESP_OK && arr) {
-        char *s = cJSON_PrintUnformatted(arr);
-        cJSON_Delete(arr);
-        return json_send(req, s);
+    if (!ox_store_begin_io(0)) {
+        httpd_resp_set_status(req, "503 Service Unavailable");
+        return httpd_resp_sendstr(req, "Oximetry storage busy");
     }
-    return json_send(req, strdup("[]"));
+    cJSON *arr = NULL;
+    char *json = NULL;
+    if (oximetry_canonical_list_days(&arr) == ESP_OK && arr) {
+        json = cJSON_PrintUnformatted(arr);
+        cJSON_Delete(arr);
+    }
+    if (!json) json = strdup("[]");
+    ox_store_end_io();
+    return json_send(req, json);
 }
 
 static esp_err_t oximetry_recording_handler(httpd_req_t *req)
@@ -89,18 +103,30 @@ static esp_err_t oximetry_recording_handler(httpd_req_t *req)
         httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "missing id");
         return ESP_FAIL;
     }
-    return json_send(req, oximetry_canonical_manifest_json(id));
+    if (!ox_store_begin_io(0)) {
+        httpd_resp_set_status(req, "503 Service Unavailable");
+        return httpd_resp_sendstr(req, "Oximetry storage busy");
+    }
+    char *json = oximetry_canonical_manifest_json(id);
+    ox_store_end_io();
+    return json_send(req, json);
 }
 
 static esp_err_t oximetry_uploads_handler(httpd_req_t *req)
 {
-    (void)req;
-    return json_send(req, upload_ox_status_json());
+    if (!ox_store_begin_io(0)) {
+        httpd_resp_set_status(req, "503 Service Unavailable");
+        return httpd_resp_sendstr(req, "Oximetry storage busy");
+    }
+    char *json = upload_ox_status_json();
+    ox_store_end_io();
+    return json_send(req, json);
 }
 
 static esp_err_t oximetry_diagnostics_handler(httpd_req_t *req)
 {
     (void)req;
+    /* The store function owns a short export lease internally. */
     return json_send(req, ox_store_conversion_diagnostics_json());
 }
 
@@ -112,13 +138,19 @@ static esp_err_t oximetry_file_handler(httpd_req_t *req)
         httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "missing id or track");
         return ESP_FAIL;
     }
+    if (!ox_store_begin_io(0)) {
+        httpd_resp_set_status(req, "503 Service Unavailable");
+        return httpd_resp_sendstr(req, "Oximetry storage busy");
+    }
     char path[OXIMETRY_CANONICAL_MAX_PATH];
     if (oximetry_canonical_resolve_track(id, track, path, sizeof(path)) != ESP_OK) {
+        ox_store_end_io();
         httpd_resp_send_err(req, HTTPD_404_NOT_FOUND, "track not found");
         return ESP_FAIL;
     }
     FILE *f = fopen(path, "rb");
     if (!f) {
+        ox_store_end_io();
         httpd_resp_send_err(req, HTTPD_404_NOT_FOUND, "track not found");
         return ESP_FAIL;
     }
@@ -127,6 +159,7 @@ static esp_err_t oximetry_file_handler(httpd_req_t *req)
     fseek(f, 0, SEEK_SET);
     if (size < 0) {
         fclose(f);
+        ox_store_end_io();
         httpd_resp_send_500(req);
         return ESP_FAIL;
     }
@@ -147,7 +180,9 @@ static esp_err_t oximetry_file_handler(httpd_req_t *req)
             if (end >= size) end = size - 1;
             if (start > end || start >= size) {
                 fclose(f); httpd_resp_set_status(req, "416 Range Not Satisfiable");
-                return httpd_resp_send(req, NULL, 0);
+                esp_err_t response = httpd_resp_send(req, NULL, 0);
+                ox_store_end_io();
+                return response;
             }
             char content_range[64];
             snprintf(content_range, sizeof(content_range), "bytes %ld-%ld/%ld", start, end, size);
@@ -158,14 +193,22 @@ static esp_err_t oximetry_file_handler(httpd_req_t *req)
     if (req->method == HTTP_HEAD) {
         char len[24]; snprintf(len, sizeof(len), "%ld", end - start + 1);
         httpd_resp_set_hdr(req, "Content-Length", len);
-        fclose(f); return httpd_resp_send(req, NULL, 0);
+        fclose(f);
+        esp_err_t response = httpd_resp_send(req, NULL, 0);
+        ox_store_end_io();
+        return response;
     }
-    if (fseek(f, start, SEEK_SET) != 0) { fclose(f); return ESP_FAIL; }
+    if (fseek(f, start, SEEK_SET) != 0) {
+        fclose(f);
+        ox_store_end_io();
+        return ESP_FAIL;
+    }
     long remaining = end - start + 1;
     uint8_t *buf = heap_caps_malloc(4096, MALLOC_CAP_SPIRAM);
     if (!buf) buf = malloc(4096);
     if (!buf) {
         fclose(f);
+        ox_store_end_io();
         httpd_resp_send_500(req);
         return ESP_FAIL;
     }
@@ -181,6 +224,7 @@ static esp_err_t oximetry_file_handler(httpd_req_t *req)
     if (e == ESP_OK) e = httpd_resp_send_chunk(req, NULL, 0);
     free(buf);
     fclose(f);
+    ox_store_end_io();
     if (e != ESP_OK) ESP_LOGW(TAG, "track send failed: %s", esp_err_to_name(e));
     return e;
 }

--- a/main/post_therapy.c
+++ b/main/post_therapy.c
@@ -33,6 +33,7 @@
 #include <sys/stat.h>
 #include <time.h>
 #include <errno.h>
+#include <unistd.h>
 
 #include "esp_log.h"
 #include "cJSON.h"
@@ -116,75 +117,87 @@ static void noon_day_from_epoch(int64_t epoch_ms, char *out, size_t out_len)
 
 /* Read a binary file into a malloc'd buffer.
  * Returns NULL on failure.  Caller must free(). */
+/* BLE responses are fully owned in RAM before entering this gate. No
+ * descriptor or storage lease crosses an RPC or a spool wait. */
+static bool post_storage_begin(void)
+{
+    if (!sd_storage_lease_acquire(SD_LEASE_EXPORT, 250)) return false;
+    if (!sd_storage_is_ready() || sd_storage_recording_pending() || sd_storage_recording_active()) {
+        sd_storage_lease_release(SD_LEASE_EXPORT);
+        return false;
+    }
+    return true;
+}
+
 static uint8_t *read_bin_file(const char *path, size_t *out_len)
 {
+    if (out_len) *out_len = 0;
+    if (!post_storage_begin()) return NULL;
     FILE *f = fopen(path, "rb");
-    if (!f) return NULL;
-    fseek(f, 0, SEEK_END);
-    long sz = ftell(f);
-    fseek(f, 0, SEEK_SET);
-    if (sz <= 0) { fclose(f); return NULL; }
-    uint8_t *buf = malloc(sz);
-    if (!buf) { fclose(f); return NULL; }
-    size_t rd = fread(buf, 1, sz, f);
-    fclose(f);
-    if (rd != (size_t)sz) { free(buf); return NULL; }
-    if (out_len) *out_len = rd;
+    uint8_t *buf = NULL;
+    long sz = -1;
+    if (f && fseek(f, 0, SEEK_END) == 0) sz = ftell(f);
+    if (sz > 0 && sz <= 100000 && fseek(f, 0, SEEK_SET) == 0) {
+        buf = malloc((size_t)sz);
+        if (buf && fread(buf, 1, (size_t)sz, f) != (size_t)sz) {
+            free(buf); buf = NULL;
+        }
+    }
+    if (f && fclose(f) != 0) { free(buf); buf = NULL; }
+    sd_storage_lease_release(SD_LEASE_EXPORT);
+    if (buf && out_len) *out_len = (size_t)sz;
     return buf;
 }
 
-static esp_err_t write_bin_file(const char *path, const uint8_t *data, size_t len)
-{
-    FILE *f = fopen(path, "wb");
-    if (!f) {
-        ESP_LOGE(TAG, "failed to open %s for writing: %s", path, strerror(errno));
-        return ESP_FAIL;
-    }
-    size_t written = fwrite(data, 1, len, f);
-    fclose(f);
-    if (written != len) {
-        ESP_LOGE(TAG, "short write to %s: %u/%u", path, (unsigned)written, (unsigned)len);
-        return ESP_FAIL;
-    }
-    return ESP_OK;
-}
-
-/* Atomic-ish write: write to temp file, then rename over target.
- * FAT32 rename() fails with EEXIST, so remove the target first. */
 static esp_err_t write_bin_atomic(const char *path, const uint8_t *data, size_t len)
 {
-    char tmp_path[330];
-    snprintf(tmp_path, sizeof(tmp_path), "%s.tmp", path);
-
-    if (write_bin_file(tmp_path, data, len) != ESP_OK) return ESP_FAIL;
-
-    remove(path);
-    if (rename(tmp_path, path) != 0) {
-        ESP_LOGE(TAG, "rename %s → %s failed: %s", tmp_path, path, strerror(errno));
-        remove(tmp_path);
+    if (!post_storage_begin()) return ESP_ERR_TIMEOUT;
+    char tmp[380], backup[380];
+    snprintf(tmp, sizeof(tmp), "%s.tmp", path);
+    snprintf(backup, sizeof(backup), "%s.bak", path);
+    /* Recover a prior interrupted rename before replacing it. */
+    struct stat st;
+    int recovery_error = 0;
+    if (stat(path, &st) != 0) {
+        if (errno != ENOENT) recovery_error = errno;
+        else if (rename(backup, path) != 0 && errno != ENOENT) recovery_error = errno;
+    }
+    if (recovery_error) {
+        sd_storage_lease_release(SD_LEASE_EXPORT);
+        errno = recovery_error;
         return ESP_FAIL;
     }
-    ESP_LOGD(TAG, "wrote %s (%u bytes)", path, (unsigned)len);
+    FILE *f = fopen(tmp, "wb");
+    int first_error = f ? 0 : (errno ? errno : EIO);
+    if (f) {
+        if (len && fwrite(data, 1, len, f) != len) first_error = errno ? errno : EIO;
+        if (!first_error && fflush(f) != 0) first_error = errno ? errno : EIO;
+        if (!first_error && fsync(fileno(f)) != 0) first_error = errno ? errno : EIO;
+        if (fclose(f) != 0 && !first_error) first_error = errno ? errno : EIO;
+    }
+    bool moved_old = false;
+    if (!first_error) {
+        if (unlink(backup) != 0 && errno != ENOENT) first_error = errno;
+        if (!first_error && rename(path, backup) == 0) moved_old = true;
+        else if (!first_error && errno != ENOENT) first_error = errno;
+        if (!first_error && rename(tmp, path) != 0) first_error = errno;
+        if (first_error && moved_old) rename(backup, path);
+        if (!first_error && moved_old) unlink(backup);
+    }
+    if (first_error) unlink(tmp);
+    /* A failed transaction can still have changed a directory entry. */
+    sd_storage_lease_release(SD_LEASE_EXPORT);
+    if (first_error) { errno = first_error; return ESP_FAIL; }
     return ESP_OK;
 }
 
 static esp_err_t write_json_file(const char *path, const cJSON *json)
 {
-    char *str = cJSON_Print(json);
-    if (!str) return ESP_FAIL;
-
-    FILE *f = fopen(path, "w");
-    if (!f) {
-        ESP_LOGE(TAG, "failed to open %s: %s", path, strerror(errno));
-        free(str);
-        return ESP_FAIL;
-    }
-    fputs(str, f);
-    fputc('\n', f);
-    fclose(f);
+    char *str = cJSON_PrintUnformatted(json);
+    if (!str) return ESP_ERR_NO_MEM;
+    esp_err_t ret = write_bin_atomic(path, (const uint8_t *)str, strlen(str));
     free(str);
-    ESP_LOGI(TAG, "wrote %s", path);
-    return ESP_OK;
+    return ret;
 }
 
 static void epoch_ms_to_iso_utc(int64_t epoch_ms, char *out, size_t out_len)
@@ -262,7 +275,8 @@ static esp_err_t collect_summary_spool(int64_t clock_drift_ms)
                 char spool_path[300];
                 snprintf(spool_path, sizeof(spool_path), "%s/%s.spool",
                          SD_SUMMARIES_DIR, day_label);
-                write_bin_atomic(spool_path, rec, rec_len);
+                ret = write_bin_atomic(spool_path, rec, rec_len);
+                if (ret != ESP_OK) { free(data); return ret; }
                 days_written++;
             }
             pos += flen;
@@ -301,20 +315,11 @@ static esp_err_t collect_resp_events(const char *dir, const char *prefix,
         return ret;
     }
 
-    if (data && len > 0) {
-        char path[330];
-        snprintf(path, sizeof(path), "%s/%s_resp_events.bin", dir, prefix);
-        write_bin_file(path, data, len);
-    } else {
-        ESP_LOGI(TAG, "resp events spool is empty");
-        char path[330];
-        snprintf(path, sizeof(path), "%s/%s_resp_events.bin", dir, prefix);
-        FILE *f = fopen(path, "wb");
-        if (f) fclose(f);
-    }
-
+    char path[330];
+    snprintf(path, sizeof(path), "%s/%s_resp_events.bin", dir, prefix);
+    ret = write_bin_atomic(path, data, len);
     free(data);
-    return ESP_OK;
+    return ret;
 }
 
 /* ── Device identification via Get RPC ──────────────────────────────── */
@@ -352,9 +357,9 @@ static esp_err_t collect_identification(const char *dir, const char *prefix)
 
     char path[330];
     snprintf(path, sizeof(path), "%s/%s_ident.json", dir, prefix);
-    write_json_file(path, ident);
+    esp_err_t ret = write_json_file(path, ident);
     cJSON_Delete(ident);
-    return ESP_OK;
+    return ret;
 }
 
 static esp_err_t collect_settings(const char *dir, const char *prefix)
@@ -377,7 +382,7 @@ static esp_err_t collect_settings(const char *dir, const char *prefix)
 
     char path[330];
     snprintf(path, sizeof(path), "%s/%s_settings.json", dir, prefix);
-    write_json_file(path, settings);
+    esp_err_t ret = write_json_file(path, settings);
 
     /* Also save to summaries directory for fast O(1) STR.edf lookup */
     const char *slash = strrchr(dir, '/');
@@ -386,11 +391,12 @@ static esp_err_t collect_settings(const char *dir, const char *prefix)
         char sum_settings_path[300];
         snprintf(sum_settings_path, sizeof(sum_settings_path), "%s/%s.settings.json",
                  SD_SUMMARIES_DIR, day_label);
-        write_json_file(sum_settings_path, settings);
+        esp_err_t mirror = write_json_file(sum_settings_path, settings);
+        if (ret == ESP_OK) ret = mirror;
     }
 
     cJSON_Delete(settings);
-    return ESP_OK;
+    return ret;
 }
 
 /* ── Spool staleness detection ──────────────────────────────────────── */
@@ -520,7 +526,8 @@ static esp_err_t refresh_today_summary_spool(int64_t end_epoch_ms,
                 char spool_path[300];
                 snprintf(spool_path, sizeof(spool_path), "%s/%s.spool",
                          SD_SUMMARIES_DIR, day_label);
-                write_bin_atomic(spool_path, rec, rec_len);
+                ret = write_bin_atomic(spool_path, rec, rec_len);
+                if (ret != ESP_OK) { free(data); return ret; }
                 days_written++;
             }
             pos += flen;
@@ -601,7 +608,7 @@ esp_err_t post_therapy_collect(const char *session_dir, const char *file_prefix,
     cJSON_AddBoolToObject(manifest, "spool_current", fresh);
     char mpath[330];
     snprintf(mpath, sizeof(mpath), "%s/%s_manifest.json", session_dir, file_prefix);
-    write_json_file(mpath, manifest);
+    if (!manifest || write_json_file(mpath, manifest) != ESP_OK) errors++;
     cJSON_Delete(manifest);
 
     ESP_LOGI(TAG, "=== POST-THERAPY COLLECTION DONE (%d errors, spool %s) ===",

--- a/main/psram_task.c
+++ b/main/psram_task.c
@@ -22,10 +22,64 @@
  */
 
 #include "psram_task.h"
+#include <stdlib.h>
 #include "esp_heap_caps.h"
 #include "esp_log.h"
+#include "freertos/idf_additions.h"
+#include "freertos/queue.h"
 
 static const char *TAG = "psram_task";
+
+#define PSRAM_REAPER_QUEUE_DEPTH 8
+#define PSRAM_REAPER_PRIORITY    (configMAX_PRIORITIES - 1)
+
+static StaticQueue_t s_reaper_queue_control;
+static uint8_t s_reaper_queue_storage[
+    PSRAM_REAPER_QUEUE_DEPTH * sizeof(TaskHandle_t)];
+static QueueHandle_t s_reaper_queue;
+static StaticTask_t s_reaper_task_control;
+static StackType_t s_reaper_task_stack[configMINIMAL_STACK_SIZE];
+static TaskHandle_t s_reaper_task;
+
+static void psram_task_reaper(void *arg)
+{
+    (void)arg;
+    while (true) {
+        TaskHandle_t victim = NULL;
+        if (xQueueReceive(s_reaper_queue, &victim, portMAX_DELAY) == pdTRUE &&
+            victim != NULL) {
+            /* This is deliberately never a self-delete. ESP-IDF therefore
+             * reclaims the WithCaps buffers directly and does not allocate its
+             * temporary cleanup task. */
+            vTaskDeleteWithCaps(victim);
+        }
+    }
+}
+
+esp_err_t psram_task_init(void)
+{
+    if (s_reaper_task != NULL)
+        return ESP_OK;
+
+    s_reaper_queue = xQueueCreateStatic(
+        PSRAM_REAPER_QUEUE_DEPTH, sizeof(TaskHandle_t),
+        s_reaper_queue_storage, &s_reaper_queue_control);
+    if (s_reaper_queue == NULL) {
+        ESP_LOGE(TAG, "failed to create retained task-reaper queue");
+        return ESP_ERR_NO_MEM;
+    }
+
+    s_reaper_task = xTaskCreateStaticPinnedToCore(
+        psram_task_reaper, "psram_reaper", configMINIMAL_STACK_SIZE, NULL,
+        PSRAM_REAPER_PRIORITY, s_reaper_task_stack, &s_reaper_task_control,
+        tskNO_AFFINITY);
+    if (s_reaper_task == NULL) {
+        ESP_LOGE(TAG, "failed to create retained task reaper");
+        s_reaper_queue = NULL;
+        return ESP_ERR_NO_MEM;
+    }
+    return ESP_OK;
+}
 
 TaskHandle_t psram_task_create(TaskFunction_t task_func,
                                const char *name,
@@ -36,28 +90,53 @@ TaskHandle_t psram_task_create(TaskFunction_t task_func,
                                StackType_t **out_stack,
                                StaticTask_t **out_tcb)
 {
-    StackType_t *stack = heap_caps_malloc(stack_size, MALLOC_CAP_SPIRAM);
-    StaticTask_t *tcb  = heap_caps_malloc(sizeof(StaticTask_t), MALLOC_CAP_INTERNAL);
-    if (!stack || !tcb) {
-        ESP_LOGE(TAG, "failed to allocate %s: stack=%u PSRAM free=%u, tcb internal free=%u",
+    /* xTaskCreateStaticPinnedToCore() cannot reclaim caller-provided buffers
+     * when a task deletes itself. ESP-IDF's WithCaps pair records the PSRAM
+     * stack/internal-TCB ownership; our retained reaper performs deletion. */
+    if (out_stack) *out_stack = NULL;
+    if (out_tcb) *out_tcb = NULL;
+
+    if (s_reaper_task == NULL) {
+        ESP_LOGE(TAG, "cannot create %s before psram_task_init", name);
+        return NULL;
+    }
+
+    TaskHandle_t h = NULL;
+    BaseType_t created = xTaskCreatePinnedToCoreWithCaps(
+        task_func, name, stack_size, arg, priority, &h, core_id,
+        MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    if (created != pdPASS || !h) {
+        ESP_LOGE(TAG,
+                 "failed to allocate %s: stack=%u PSRAM free=%u, internal free=%u",
                  name, (unsigned)stack_size,
                  (unsigned)heap_caps_get_free_size(MALLOC_CAP_SPIRAM),
                  (unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL));
-        free(stack);
-        free(tcb);
         return NULL;
     }
-
-    TaskHandle_t h = xTaskCreateStaticPinnedToCore(
-        task_func, name, stack_size, arg, priority, stack, tcb, core_id);
-    if (!h) {
-        ESP_LOGE(TAG, "xTaskCreateStaticPinnedToCore failed for %s", name);
-        free(stack);
-        free(tcb);
-        return NULL;
-    }
-
-    if (out_stack) *out_stack = stack;
-    if (out_tcb)   *out_tcb   = tcb;
     return h;
+}
+
+void psram_task_delete(TaskHandle_t task)
+{
+    TaskHandle_t current = xTaskGetCurrentTaskHandle();
+    if (task != NULL && task != current) {
+        vTaskDeleteWithCaps(task);
+        return;
+    }
+
+    if (s_reaper_task == NULL || s_reaper_queue == NULL) {
+        ESP_LOGE(TAG, "retained task reaper unavailable");
+        abort();
+    }
+
+    if (xQueueSend(s_reaper_queue, &current, portMAX_DELAY) != pdTRUE) {
+        ESP_LOGE(TAG, "could not enqueue task for reclamation");
+        abort();
+    }
+
+    /* The higher-priority reaper normally deletes us before this executes.
+     * Suspending also makes the handoff correct if it runs on the other core. */
+    vTaskSuspend(NULL);
+    ESP_LOGE(TAG, "reclaimed task unexpectedly resumed");
+    abort();
 }

--- a/main/psram_task.h
+++ b/main/psram_task.h
@@ -23,8 +23,19 @@
 
 #pragma once
 
+#include "esp_err.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+
+/**
+ * Start the retained internal-RAM task that reclaims WithCaps tasks.
+ *
+ * ESP-IDF's self-delete path creates a temporary cleanup task for every
+ * vTaskDeleteWithCaps(NULL).  That allocation aborts when internal RAM is
+ * exhausted.  SomnoTrace instead creates one static reaper during boot, while
+ * memory pressure is bounded, and routes all later self-deletion through it.
+ */
+esp_err_t psram_task_init(void);
 
 /**
  * Create a FreeRTOS task with its stack in PSRAM and TCB in internal RAM.
@@ -33,13 +44,14 @@
  * by moving the stack to the 8 MB PSRAM.  Requires
  * CONFIG_FREERTOS_TASK_CREATE_ALLOW_EXT_MEM=y (already enabled).
  *
- * The StaticTask_t (TCB, ~92 bytes) stays in internal RAM (FreeRTOS
- * requirement).  The stack is allocated with MALLOC_CAP_SPIRAM.
+ * The StaticTask_t (TCB) stays in internal RAM (FreeRTOS requirement).  The
+ * stack is allocated with MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT.
  *
  * For long-lived tasks (run forever): just call this once and forget.
- * For self-deleting tasks: the caller must keep the out_stack/out_tcb
- * pointers and free them after the task has exited (e.g. on next
- * invocation — "deferred free" pattern).
+ * A self-deleting task MUST call psram_task_delete(NULL), never
+ * vTaskDelete(NULL).  The retained reaper then calls the ESP-IDF WithCaps
+ * deletion API from another task, reclaiming both the PSRAM stack and internal
+ * TCB without allocating a one-shot cleanup task under peak memory pressure.
  *
  * @param task_func   Task function
  * @param name        FreeRTOS task name
@@ -47,8 +59,8 @@
  * @param arg         Task argument
  * @param priority    Task priority
  * @param core_id     Core affinity (0, 1, or tskNO_AFFINITY)
- * @param out_stack   If non-NULL, receives the PSRAM stack pointer (caller frees)
- * @param out_tcb     If non-NULL, receives the internal TCB pointer (caller frees)
+ * @param out_stack   Deprecated; always set to NULL. Memory is helper-owned.
+ * @param out_tcb     Deprecated; always set to NULL. Memory is helper-owned.
  * @return Task handle, or NULL on failure
  */
 TaskHandle_t psram_task_create(TaskFunction_t task_func,
@@ -59,3 +71,9 @@ TaskHandle_t psram_task_create(TaskFunction_t task_func,
                                BaseType_t core_id,
                                StackType_t **out_stack,
                                StaticTask_t **out_tcb);
+
+/**
+ * Delete a task created by psram_task_create() and reclaim its WithCaps stack
+ * and TCB. Pass NULL for self-deletion, matching vTaskDelete(NULL) semantics.
+ */
+void psram_task_delete(TaskHandle_t task);

--- a/main/sd_storage.c
+++ b/main/sd_storage.c
@@ -30,6 +30,7 @@
 #include <dirent.h>
 
 #include "esp_log.h"
+#include "esp_timer.h"
 #include "esp_vfs_fat.h"
 #include "sdmmc_cmd.h"
 #include "driver/sdmmc_host.h"
@@ -41,8 +42,21 @@
 static const char *TAG = "sd_storage";
 
 static bool s_mounted = false;
-static sdmmc_card_t *s_card = NULL;
+/* Invalidates RAM history snapshots even for same-length, same-FAT-timestamp
+ * rewrites. Writers publish the epoch before releasing their exclusive claim. */
+static uint32_t s_content_generation = 1;
+uint32_t sd_storage_content_generation(void)
+{
+    return __atomic_load_n(&s_content_generation, __ATOMIC_ACQUIRE);
+}
+void sd_storage_content_changed(void)
+{
+    __atomic_add_fetch(&s_content_generation, 1U, __ATOMIC_RELEASE);
+}
+/* Optional FTP integration callback; keeps the third-party component independent
+ * of main's headers and component dependency graph. */
 
+static sdmmc_card_t *s_card = NULL;
 /* Capacity is sampled by explicit storage work, never by a status request.
  * Keep the pair behind one critical section: uint64_t reads/writes can tear on
  * the ESP32-S3's 32-bit cores. */
@@ -87,7 +101,13 @@ static void capacity_cache_store(uint64_t free_bytes, uint64_t total_bytes)
 static SemaphoreHandle_t s_lease_mutex = NULL;   /* guards the counters  */
 static SemaphoreHandle_t s_export_sem = NULL;    /* EXPORT/DESTRUCTIVE   */
 static volatile int s_recording = 0;
+static volatile int s_recording_waiters = 0;
+static uint32_t s_recording_intents = 0;
 static volatile int s_uploading = 0;
+static volatile int s_destructive = 0;
+
+#define SD_RECORDING_PRIORITY_WAIT_MS 500U
+#define SD_RECORDING_PRIORITY_POLL_MS 5U
 
 static void lease_init_once(void)
 {
@@ -123,9 +143,39 @@ static void sdmmc_config_default(sdmmc_host_t *host, sdmmc_slot_config_t *slot)
     *slot = s;
 }
 
+static esp_err_t sdmmc_mount_with_fallback(
+    sdmmc_host_t *host,
+    sdmmc_slot_config_t *slot,
+    const esp_vfs_fat_sdmmc_mount_config_t *mount_config,
+    sdmmc_card_t **card)
+{
+    esp_err_t ret = esp_vfs_fat_sdmmc_mount(
+        SD_MOUNT_POINT, host, slot, mount_config, card);
+
+    if (ret != ESP_OK && slot->width != 1) {
+        ESP_LOGW(TAG, "4-bit mount failed (%s), trying 1-bit high speed",
+                 esp_err_to_name(ret));
+        slot->width = 1;
+        ret = esp_vfs_fat_sdmmc_mount(
+            SD_MOUNT_POINT, host, slot, mount_config, card);
+    }
+
+    if (ret != ESP_OK && host->max_freq_khz > SDMMC_FREQ_DEFAULT) {
+        ESP_LOGW(TAG, "high-speed mount failed (%s), trying %d kHz",
+                 esp_err_to_name(ret), SDMMC_FREQ_DEFAULT);
+        host->max_freq_khz = SDMMC_FREQ_DEFAULT;
+        ret = esp_vfs_fat_sdmmc_mount(
+            SD_MOUNT_POINT, host, slot, mount_config, card);
+    }
+    return ret;
+}
+
 esp_err_t sd_storage_init(void)
 {
+    sd_storage_content_changed();
+    capacity_cache_invalidate();
     ESP_LOGI(TAG, "initialising SDMMC 4-bit mode...");
+
 
     sdmmc_host_t host;
     sdmmc_slot_config_t slot_config;
@@ -138,22 +188,19 @@ esp_err_t sd_storage_init(void)
     };
 
     sdmmc_card_t *card;
-    esp_err_t ret = esp_vfs_fat_sdmmc_mount(SD_MOUNT_POINT, &host, &slot_config,
-                                             &mount_config, &card);
-    if (ret != ESP_OK) {
-        ESP_LOGW(TAG, "4-bit mount failed (%s), trying 1-bit mode", esp_err_to_name(ret));
-        slot_config.width = 1;
-        ret = esp_vfs_fat_sdmmc_mount(SD_MOUNT_POINT, &host, &slot_config,
-                                       &mount_config, &card);
-    }
+    esp_err_t ret = sdmmc_mount_with_fallback(
+        &host, &slot_config, &mount_config, &card);
     if (ret != ESP_OK) {
         ESP_LOGE(TAG, "failed to mount SD card: %s (0x%x)", esp_err_to_name(ret), ret);
         ESP_LOGE(TAG, "check: SD card inserted? pull-ups? GPIO pins 13-18?");
+
+        bsp_display_set_sd_ready(false);
         return ret;
     }
 
     s_mounted = true;
     s_card = card;
+    bsp_display_set_sd_ready(true);
     lease_init_once();
 
     sdmmc_card_print_info(stdout, card);
@@ -175,6 +222,11 @@ esp_err_t sd_storage_init(void)
     mkdir(SD_SDCARD_DATALOG, 0775);
     mkdir(SD_SDCARD_SETTINGS, 0775);
 
+    uint64_t initial_free = 0;
+    uint64_t initial_total = 0;
+    if (sd_storage_get_free(&initial_free, &initial_total) != ESP_OK)
+        ESP_LOGW(TAG, "initial free-space query failed");
+
     ESP_LOGI(TAG, "SD mounted at %s, directory tree ready", SD_MOUNT_POINT);
 
     return ESP_OK;
@@ -186,20 +238,6 @@ bool sd_storage_is_ready(void)
 }
 
 /* ── Free space ───────────────────────────────────────────────────── */
-
-bool sd_storage_get_cached_free(uint64_t *free_bytes, uint64_t *total_bytes)
-{
-    bool valid;
-    portENTER_CRITICAL(&s_capacity_lock);
-    valid = s_capacity_cache_valid;
-    if (valid) {
-        if (free_bytes) *free_bytes = s_cached_free_bytes;
-        if (total_bytes) *total_bytes = s_cached_total_bytes;
-    }
-    portEXIT_CRITICAL(&s_capacity_lock);
-    return valid;
-}
-
 
 esp_err_t sd_storage_get_free(uint64_t *free_bytes, uint64_t *total_bytes)
 {
@@ -217,6 +255,19 @@ esp_err_t sd_storage_get_free(uint64_t *free_bytes, uint64_t *total_bytes)
     if (total_bytes) *total_bytes = total;
     if (free_bytes) *free_bytes = free;
     return ESP_OK;
+}
+
+bool sd_storage_get_cached_free(uint64_t *free_bytes, uint64_t *total_bytes)
+{
+    bool valid;
+    portENTER_CRITICAL(&s_capacity_lock);
+    valid = s_capacity_cache_valid;
+    if (valid) {
+        if (free_bytes) *free_bytes = s_cached_free_bytes;
+        if (total_bytes) *total_bytes = s_cached_total_bytes;
+    }
+    portEXIT_CRITICAL(&s_capacity_lock);
+    return valid;
 }
 
 /* Reclaim derived (regenerable) output so raw capture can proceed.
@@ -238,9 +289,11 @@ bool sd_storage_reserve_for_recording(void)
     if (!s_mounted) return false;
 
     uint64_t free_bytes = 0, total = 0;
-    if (sd_storage_get_free(&free_bytes, &total) != ESP_OK) {
-        /* Cannot tell — do not block therapy recording on a failed query. */
-        ESP_LOGW(TAG, "free-space query failed; allowing recording");
+    if (!sd_storage_get_cached_free(&free_bytes, &total)) {
+        /* START is latency- and memory-sensitive: never allocate an SDMMC DMA
+         * buffer here.  Mount and explicit capacity refreshes prime this
+         * cache; an unavailable value must not block raw therapy capture. */
+        ESP_LOGW(TAG, "free-space cache unavailable; allowing recording");
         return true;
     }
 
@@ -255,37 +308,109 @@ bool sd_storage_reserve_for_recording(void)
         if (free_bytes < SD_FLOOR_BYTES) {
             ESP_LOGE(TAG, "below hard floor (%llu KB) — refusing to record",
                      (unsigned long long)(free_bytes / 1024));
-            bsp_display_set_notice("SD full");
+            bsp_display_set_critical_notice("microSD full");
             return false;
         }
     }
 
-    bsp_display_set_notice("SD nearly full");
+    bsp_display_set_notice("microSD nearly full");
     return true;
 }
 
 /* ── Arbitration ──────────────────────────────────────────────────── */
 
-void sd_storage_recording_begin(void)
+bool sd_storage_reserve_for_recording_cached(void)
+{
+    if (!s_mounted) return false;
+    uint64_t free_bytes = 0;
+    /* Match the existing missing-cache admission policy without probing FAT,
+     * reclaiming output, or calling a display notice from an ingest callback. */
+    return !sd_storage_get_cached_free(&free_bytes, NULL) ||
+           free_bytes >= SD_FLOOR_BYTES;
+}
+
+bool sd_storage_recording_try_begin(void)
+{
+    /* Mount initializes arbitration. A notification retry must not allocate
+     * mutexes, poll a reader, or wait behind another arbitration transition. */
+    if (!s_export_sem || !s_lease_mutex ||
+        xSemaphoreTake(s_lease_mutex, 0) != pdTRUE)
+        return false;
+    bool claimed = s_destructive == 0 && s_uploading == 0;
+    if (claimed) __atomic_add_fetch(&s_recording, 1, __ATOMIC_RELEASE);
+    xSemaphoreGive(s_lease_mutex);
+    return claimed;
+}
+
+bool sd_storage_recording_begin(void)
 {
     lease_init_once();
-    if (!s_lease_mutex) { s_recording++; return; }
+    if (!s_lease_mutex) return false;
+
+    const int64_t deadline_us = esp_timer_get_time() +
+        (int64_t)SD_RECORDING_PRIORITY_WAIT_MS * 1000;
     xSemaphoreTake(s_lease_mutex, portMAX_DELAY);
-    s_recording++;
+    __atomic_add_fetch(&s_recording_waiters, 1, __ATOMIC_RELEASE);
+    bool claimed = false;
+    while (s_destructive == 0) {
+        if (s_uploading == 0) {
+            __atomic_add_fetch(&s_recording, 1, __ATOMIC_RELEASE);
+            claimed = true;
+            break;
+        }
+        if (esp_timer_get_time() >= deadline_us)
+            break;
+        xSemaphoreGive(s_lease_mutex);
+        vTaskDelay(pdMS_TO_TICKS(SD_RECORDING_PRIORITY_POLL_MS));
+        xSemaphoreTake(s_lease_mutex, portMAX_DELAY);
+    }
+    __atomic_sub_fetch(&s_recording_waiters, 1, __ATOMIC_RELEASE);
     xSemaphoreGive(s_lease_mutex);
+    if (!claimed) {
+        ESP_LOGW(TAG, "recording claim timed out behind card maintenance");
+    }
+    return claimed;
 }
 
 void sd_storage_recording_end(void)
 {
-    if (!s_lease_mutex) { if (s_recording > 0) s_recording--; return; }
+    sd_storage_content_changed();
+    if (!s_lease_mutex) {
+        if (s_recording > 0) __atomic_sub_fetch(&s_recording, 1, __ATOMIC_RELEASE);
+        return;
+    }
     xSemaphoreTake(s_lease_mutex, portMAX_DELAY);
-    if (s_recording > 0) s_recording--;
+    if (s_recording > 0) __atomic_sub_fetch(&s_recording, 1, __ATOMIC_RELEASE);
     xSemaphoreGive(s_lease_mutex);
 }
 
 bool sd_storage_recording_active(void)
 {
-    return s_recording > 0;
+    return __atomic_load_n(&s_recording, __ATOMIC_ACQUIRE) > 0;
+}
+
+void sd_storage_recording_intent_begin(void)
+{
+    lease_init_once();
+    if (s_lease_mutex) xSemaphoreTake(s_lease_mutex, portMAX_DELAY);
+    __atomic_add_fetch(&s_recording_intents, 1U, __ATOMIC_RELEASE);
+    if (s_lease_mutex) xSemaphoreGive(s_lease_mutex);
+}
+
+void sd_storage_recording_intent_end(void)
+{
+    if (s_lease_mutex) xSemaphoreTake(s_lease_mutex, portMAX_DELAY);
+    uint32_t count = __atomic_load_n(&s_recording_intents, __ATOMIC_ACQUIRE);
+    /* Also safe before the arbitration mutex exists; never underflow. */
+    while (count && !__atomic_compare_exchange_n(&s_recording_intents,
+            &count, count - 1, false, __ATOMIC_RELEASE, __ATOMIC_RELAXED)) {}
+    if (s_lease_mutex) xSemaphoreGive(s_lease_mutex);
+}
+
+bool sd_storage_recording_pending(void)
+{
+    return __atomic_load_n(&s_recording_intents, __ATOMIC_ACQUIRE) > 0 ||
+           __atomic_load_n(&s_recording_waiters, __ATOMIC_ACQUIRE) > 0;
 }
 
 bool sd_storage_lease_acquire(sd_lease_t role, uint32_t timeout_ms)
@@ -297,24 +422,24 @@ bool sd_storage_lease_acquire(sd_lease_t role, uint32_t timeout_ms)
 
     switch (role) {
     case SD_LEASE_DESTRUCTIVE:
-        /* Never destroy data while it is being produced or consumed. */
-        if (s_recording > 0) {
-            ESP_LOGW(TAG, "destructive op refused: recording in progress");
-            return false;
-        }
-        if (s_uploading > 0) {
-            ESP_LOGW(TAG, "destructive op refused: upload in progress");
-            return false;
-        }
+        /* Take the file-operation gate first, then publish the destructive
+         * claim under the same mutex used by recording_begin(). This closes
+         * the old check-then-act window where recording could begin after the
+         * final check but before destructive I/O started. */
         if (xSemaphoreTakeRecursive(s_export_sem, wait) != pdTRUE) {
             ESP_LOGW(TAG, "destructive op refused: export in progress");
             return false;
         }
-        if (s_recording > 0) {   /* re-check after acquiring */
+        xSemaphoreTake(s_lease_mutex, portMAX_DELAY);
+        if (s_recording > 0 || sd_storage_recording_pending() ||
+            s_uploading > 0 || s_destructive > 0) {
+            xSemaphoreGive(s_lease_mutex);
             xSemaphoreGiveRecursive(s_export_sem);
-            ESP_LOGW(TAG, "destructive op refused: recording started");
+            ESP_LOGW(TAG, "destructive op refused: card owner active");
             return false;
         }
+        s_destructive++;
+        xSemaphoreGive(s_lease_mutex);
         return true;
 
     case SD_LEASE_EXPORT:
@@ -328,13 +453,21 @@ bool sd_storage_lease_acquire(sd_lease_t role, uint32_t timeout_ms)
         return true;
 
     case SD_LEASE_UPLOAD:
-        /* Held for the duration of the upload so a day can never be read
-         * while it is being replaced by a rebuild. */
+        /* The reader claim and recording claim are mutually exclusive under
+         * s_lease_mutex. Whichever publishes first wins; there is no gap in
+         * which a session can start after History's readiness check. */
         if (xSemaphoreTakeRecursive(s_export_sem, wait) != pdTRUE) {
             ESP_LOGW(TAG, "upload lease busy (export in progress)");
             return false;
         }
         xSemaphoreTake(s_lease_mutex, portMAX_DELAY);
+        if (s_recording > 0 || sd_storage_recording_pending() ||
+            s_destructive > 0) {
+            xSemaphoreGive(s_lease_mutex);
+            xSemaphoreGiveRecursive(s_export_sem);
+            ESP_LOGW(TAG, "upload lease refused: recording in progress");
+            return false;
+        }
         s_uploading++;
         xSemaphoreGive(s_lease_mutex);
         return true;
@@ -342,13 +475,18 @@ bool sd_storage_lease_acquire(sd_lease_t role, uint32_t timeout_ms)
     return false;
 }
 
-void sd_storage_lease_release(sd_lease_t role)
+void sd_storage_lease_release_unchanged(sd_lease_t role)
 {
     if (!s_export_sem || !s_lease_mutex) return;
 
     switch (role) {
     case SD_LEASE_EXPORT:
+        xSemaphoreGiveRecursive(s_export_sem);
+        break;
     case SD_LEASE_DESTRUCTIVE:
+        xSemaphoreTake(s_lease_mutex, portMAX_DELAY);
+        if (s_destructive > 0) s_destructive--;
+        xSemaphoreGive(s_lease_mutex);
         xSemaphoreGiveRecursive(s_export_sem);
         break;
     case SD_LEASE_UPLOAD:
@@ -360,10 +498,18 @@ void sd_storage_lease_release(sd_lease_t role)
     }
 }
 
+void sd_storage_lease_release(sd_lease_t role)
+{
+    /* Preserve conservative invalidation for existing writer call sites.
+     * Publish before giving the file-operation gate to the next reader. */
+    if (role != SD_LEASE_UPLOAD) sd_storage_content_changed();
+    sd_storage_lease_release_unchanged(role);
+}
+
 esp_err_t sd_storage_format(void)
 {
-    capacity_cache_invalidate();
     ESP_LOGW(TAG, "format: formatting SD card — ALL DATA WILL BE LOST");
+    capacity_cache_invalidate();
 
     /* Report the card as unavailable for the whole operation: the volume is
      * unmounted while f_mkfs runs, and other subsystems (log flush, oximetry
@@ -428,14 +574,15 @@ esp_err_t sd_storage_format(void)
             .allocation_unit_size   = SD_FORMAT_ALLOC_UNIT,
         };
 
-        /* Single 4-bit attempt.  A 1-bit retry after this fails is a no-op:
-         * esp_vfs_fat_sdmmc_mount() leaves the VFS path registered on failure,
-         * so the retry just returns ESP_ERR_INVALID_STATE and hides the real
-         * error.  sd_storage_init() already handles 4->1-bit for normal mounts. */
+        /* The IDF 5.5 mount helper unregisters FATFS and deinitialises the host
+         * on failure, so the same width/frequency fallback used at boot is safe
+         * here too. This matters for marginal cards that initialise at 20 MHz
+         * but not at the preferred 40 MHz. */
         sdmmc_card_t *card = NULL;
-        ret = esp_vfs_fat_sdmmc_mount(SD_MOUNT_POINT, &host, &slot, &cfg, &card);
+        ret = sdmmc_mount_with_fallback(&host, &slot, &cfg, &card);
         if (ret != ESP_OK) {
             ESP_LOGE(TAG, "format: mount+format failed: %s", esp_err_to_name(ret));
+            bsp_display_set_sd_ready(false);
             return ret;
         }
         s_card    = card;
@@ -455,12 +602,19 @@ esp_err_t sd_storage_format(void)
     mkdir(SD_SDCARD_DATALOG, 0775);
     mkdir(SD_SDCARD_SETTINGS, 0775);
 
+    uint64_t formatted_free = 0;
+    uint64_t formatted_total = 0;
+    if (sd_storage_get_free(&formatted_free, &formatted_total) != ESP_OK)
+        ESP_LOGW(TAG, "format: initial free-space query failed");
+
     ESP_LOGI(TAG, "format: SD card formatted and directory tree recreated");
+    bsp_display_set_sd_ready(true);
     return ESP_OK;
 }
 
 void sd_storage_deinit(void)
 {
+    sd_storage_content_changed();
     capacity_cache_invalidate();
     if (!s_mounted || !s_card) return;
 
@@ -475,4 +629,5 @@ void sd_storage_deinit(void)
 
     s_mounted = false;
     s_card = NULL;
+    bsp_display_set_sd_ready(false);
 }

--- a/main/sd_storage.c
+++ b/main/sd_storage.c
@@ -43,6 +43,30 @@ static const char *TAG = "sd_storage";
 static bool s_mounted = false;
 static sdmmc_card_t *s_card = NULL;
 
+/* Capacity is sampled by explicit storage work, never by a status request.
+ * Keep the pair behind one critical section: uint64_t reads/writes can tear on
+ * the ESP32-S3's 32-bit cores. */
+static portMUX_TYPE s_capacity_lock = portMUX_INITIALIZER_UNLOCKED;
+static uint64_t s_cached_free_bytes;
+static uint64_t s_cached_total_bytes;
+static bool s_capacity_cache_valid;
+
+static void capacity_cache_invalidate(void)
+{
+    portENTER_CRITICAL(&s_capacity_lock);
+    s_capacity_cache_valid = false;
+    portEXIT_CRITICAL(&s_capacity_lock);
+}
+
+static void capacity_cache_store(uint64_t free_bytes, uint64_t total_bytes)
+{
+    portENTER_CRITICAL(&s_capacity_lock);
+    s_cached_free_bytes = free_bytes;
+    s_cached_total_bytes = total_bytes;
+    s_capacity_cache_valid = true;
+    portEXIT_CRITICAL(&s_capacity_lock);
+}
+
 /* ── Space policy thresholds ──────────────────────────────────────────
  * A night of raw stream data is ~3-4 MB, plus derived EDFs.  The reserve
  * keeps enough room for the session about to start plus its recovery
@@ -79,6 +103,7 @@ static void lease_init_once(void)
  * stay in sync. */
 static void sdmmc_config_default(sdmmc_host_t *host, sdmmc_slot_config_t *slot)
 {
+    capacity_cache_invalidate();
     sdmmc_host_t h = SDMMC_HOST_DEFAULT();
     h.slot = SDMMC_HOST_SLOT_1;
     h.max_freq_khz = SDMMC_FREQ_HIGHSPEED;
@@ -162,6 +187,20 @@ bool sd_storage_is_ready(void)
 
 /* ── Free space ───────────────────────────────────────────────────── */
 
+bool sd_storage_get_cached_free(uint64_t *free_bytes, uint64_t *total_bytes)
+{
+    bool valid;
+    portENTER_CRITICAL(&s_capacity_lock);
+    valid = s_capacity_cache_valid;
+    if (valid) {
+        if (free_bytes) *free_bytes = s_cached_free_bytes;
+        if (total_bytes) *total_bytes = s_cached_total_bytes;
+    }
+    portEXIT_CRITICAL(&s_capacity_lock);
+    return valid;
+}
+
+
 esp_err_t sd_storage_get_free(uint64_t *free_bytes, uint64_t *total_bytes)
 {
     if (!s_mounted) return ESP_ERR_INVALID_STATE;
@@ -172,10 +211,11 @@ esp_err_t sd_storage_get_free(uint64_t *free_bytes, uint64_t *total_bytes)
     if (f_getfree("0:", &free_clst, &fs) != FR_OK || !fs) {
         return ESP_FAIL;
     }
-    if (total_bytes)
-        *total_bytes = (uint64_t)fs->n_fatent * fs->csize * fs->ssize;
-    if (free_bytes)
-        *free_bytes = (uint64_t)free_clst * fs->csize * fs->ssize;
+    uint64_t total = (uint64_t)(fs->n_fatent - 2) * fs->csize * fs->ssize;
+    uint64_t free = (uint64_t)free_clst * fs->csize * fs->ssize;
+    capacity_cache_store(free, total);
+    if (total_bytes) *total_bytes = total;
+    if (free_bytes) *free_bytes = free;
     return ESP_OK;
 }
 
@@ -322,6 +362,7 @@ void sd_storage_lease_release(sd_lease_t role)
 
 esp_err_t sd_storage_format(void)
 {
+    capacity_cache_invalidate();
     ESP_LOGW(TAG, "format: formatting SD card — ALL DATA WILL BE LOST");
 
     /* Report the card as unavailable for the whole operation: the volume is
@@ -420,6 +461,7 @@ esp_err_t sd_storage_format(void)
 
 void sd_storage_deinit(void)
 {
+    capacity_cache_invalidate();
     if (!s_mounted || !s_card) return;
 
     /* The VFS unmount runs f_unmount, which syncs the FAT window and issues a

--- a/main/sd_storage.c
+++ b/main/sd_storage.c
@@ -38,6 +38,10 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/semphr.h"
 #include "bsp_display.h"
+#include "sdkconfig.h"
+#if CONFIG_SOMNOTRACE_BOARD_WAVESHARE_7B
+#include "board_waveshare_7b.h"
+#endif
 
 static const char *TAG = "sd_storage";
 
@@ -130,6 +134,17 @@ static void sdmmc_config_default(sdmmc_host_t *host, sdmmc_slot_config_t *slot)
     *host = h;
 
     sdmmc_slot_config_t s = SDMMC_SLOT_CONFIG_DEFAULT();
+#if CONFIG_SOMNOTRACE_BOARD_WAVESHARE_7B
+    /* The 7B routes its TF socket as one-bit SD: CLK=12, CMD=11, D0=13.
+     * DAT3/CS is held high by EXIO4 on the CH32V003 I/O controller. */
+    s.clk   = GPIO_NUM_12;
+    s.cmd   = GPIO_NUM_11;
+    s.d0    = GPIO_NUM_13;
+    s.d1    = GPIO_NUM_NC;
+    s.d2    = GPIO_NUM_NC;
+    s.d3    = GPIO_NUM_NC;
+    s.width = 1;
+#else
     s.clk   = GPIO_NUM_16;
     s.cmd   = GPIO_NUM_15;
     s.d0    = GPIO_NUM_17;
@@ -137,6 +152,7 @@ static void sdmmc_config_default(sdmmc_host_t *host, sdmmc_slot_config_t *slot)
     s.d2    = GPIO_NUM_13;
     s.d3    = GPIO_NUM_14;
     s.width = 4;
+#endif
     /* Internal pull-ups are often too weak for SD cards.
      * The Waveshare board should have external pull-ups on the SD lines. */
     s.flags = SDMMC_SLOT_FLAG_INTERNAL_PULLUP;
@@ -174,7 +190,17 @@ esp_err_t sd_storage_init(void)
 {
     sd_storage_content_changed();
     capacity_cache_invalidate();
+#if CONFIG_SOMNOTRACE_BOARD_WAVESHARE_7B
+    esp_err_t prep = waveshare_7b_prepare_sd();
+    if (prep != ESP_OK) {
+        ESP_LOGE(TAG, "failed to enable 7B TF interface: %s", esp_err_to_name(prep));
+        bsp_display_set_sd_ready(false);
+        return prep;
+    }
+    ESP_LOGI(TAG, "initialising onboard TF card in SDMMC 1-bit mode...");
+#else
     ESP_LOGI(TAG, "initialising SDMMC 4-bit mode...");
+#endif
 
 
     sdmmc_host_t host;
@@ -192,8 +218,12 @@ esp_err_t sd_storage_init(void)
         &host, &slot_config, &mount_config, &card);
     if (ret != ESP_OK) {
         ESP_LOGE(TAG, "failed to mount SD card: %s (0x%x)", esp_err_to_name(ret), ret);
+#if CONFIG_SOMNOTRACE_BOARD_WAVESHARE_7B
+        ESP_LOGE(TAG, "check: TF card inserted and FAT32; CLK=12 CMD=11 D0=13");
+#else
         ESP_LOGE(TAG, "check: SD card inserted? pull-ups? GPIO pins 13-18?");
 
+#endif
         bsp_display_set_sd_ready(false);
         return ret;
     }

--- a/main/sd_storage.h
+++ b/main/sd_storage.h
@@ -123,3 +123,6 @@ esp_err_t sd_storage_format(void);
  * called just before a deliberate reboot so a hard reset never lands on top of
  * unflushed filesystem state.  Safe to call when nothing is mounted. */
 void sd_storage_deinit(void);
+
+/* Return the last coherent capacity sample without touching FATFS. */
+bool sd_storage_get_cached_free(uint64_t *free_bytes, uint64_t *total_bytes);

--- a/main/sd_storage.h
+++ b/main/sd_storage.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <stdbool.h>
+#include <stdint.h>
 #include "esp_err.h"
 
 #define SD_MOUNT_POINT   "/somnotrace"
@@ -70,6 +71,13 @@ bool sd_storage_is_ready(void);
  * a therapy recording on. */
 esp_err_t sd_storage_get_free(uint64_t *free_bytes, uint64_t *total_bytes);
 
+/* Return the last successful free-space query without touching FATFS or the
+ * SDMMC driver. Intended for frequently-polled status surfaces, where a card
+ * read would contend with recording/export and may require scarce DMA memory.
+ * Returns false until the first successful query, and after unmount/format
+ * invalidates the cached sample. */
+bool sd_storage_get_cached_free(uint64_t *free_bytes, uint64_t *total_bytes);
+
 /* Space policy for raw capture.  Raw session data is the source of truth;
  * SDCARD/ is derived and regenerable, so derived output is reclaimed before
  * recording is ever refused.
@@ -77,6 +85,9 @@ esp_err_t sd_storage_get_free(uint64_t *free_bytes, uint64_t *total_bytes);
  * Returns true if a new session may start.  Warns (on screen) when free
  * space is low, and only returns false below the hard floor. */
 bool sd_storage_reserve_for_recording(void);
+/* Cached-only admission for ingest callbacks: no FAT probe, reclaim, or UI.
+ * An unavailable cache permits capture; a known value below the floor does not. */
+bool sd_storage_reserve_for_recording_cached(void);
 
 /* ── Storage arbitration ───────────────────────────────────────────────
  * The card is shared by the raw writer, EDF generation, the uploader, FTP,
@@ -85,14 +96,16 @@ bool sd_storage_reserve_for_recording(void);
  * itself and can be refused while a session is recording.
  *
  * Roles:
- *   EXPORT      — EDF generation / day rebuild.  Mutually exclusive with
- *                 other EXPORT work and with DESTRUCTIVE work.  Allowed
- *                 during recording (a mask-off break starts a new session
- *                 while the previous one still needs exporting).
+ *   EXPORT      — EDF generation / day rebuild and O2 Ring filesystem I/O.
+ *                 Mutually exclusive with other EXPORT work and with
+ *                 DESTRUCTIVE work.  Allowed during recording (a mask-off
+ *                 break starts a new session while the previous one still
+ *                 needs exporting).
  *   DESTRUCTIVE — recreate/delete/reset/format.  Refused while recording
  *                 or while an export or upload is in progress.
  *   UPLOAD      — reads a day folder.  Excluded from concurrent EXPORT so
- *                 it can never read a day that is being replaced.
+ *                 it can never read a day that is being replaced, and from
+ *                 recording so a long reader cannot contend with raw writes.
  */
 typedef enum {
     SD_LEASE_EXPORT = 0,
@@ -100,17 +113,37 @@ typedef enum {
     SD_LEASE_UPLOAD,
 } sd_lease_t;
 
-/* Mark a therapy recording as active/inactive (called by the session
- * writer).  Destructive operations are refused while this is non-zero. */
-void sd_storage_recording_begin(void);
+/* Atomically claim/release the card for a therapy recording (called by the
+ * session writer). The begin claim fails while an UPLOAD reader or
+ * DESTRUCTIVE operation owns the card; callers may retry after it finishes. */
+bool sd_storage_recording_begin(void);
+/* Immediate version: no polling, allocation, or wait for the arbitration
+ * mutex. Requires mount-initialized arbitration; false leaves no claim. */
+bool sd_storage_recording_try_begin(void);
 void sd_storage_recording_end(void);
 bool sd_storage_recording_active(void);
+/* Pair once per pending start owner, not once per retry. Retain intent across
+ * bounded recording_begin attempts; end after successful writer admission or
+ * explicit stop/cancel. recording_begin does not consume this reference.
+ * Intent excludes new UPLOAD/DESTRUCTIVE admission but never revokes a lease. */
+void sd_storage_recording_intent_begin(void);
+void sd_storage_recording_intent_end(void);
+/* True for retained start intent OR a bounded recording_begin waiter.
+ * Lock-free read for cancellation callbacks. */
+bool sd_storage_recording_pending(void);
 
 /* Acquire/release a storage lease.  timeout_ms may be 0 to fail fast.
  * Returns false if the lease could not be acquired (busy, or refused
  * because a recording is in progress). */
 bool sd_storage_lease_acquire(sd_lease_t role, uint32_t timeout_ms);
+/* Default release conservatively invalidates History sources for EXPORT and
+ * DESTRUCTIVE, even on failure (a partial write may have changed a source). */
 void sd_storage_lease_release(sd_lease_t role);
+/* Release the same ownership without advancing the History source epoch.
+ * Use only when the entire lease left History inputs unchanged: read-only
+ * work, derived caches, or writes confined to logs. Never use after a failed
+ * source write unless it is known that no source bytes/metadata changed. */
+void sd_storage_lease_release_unchanged(sd_lease_t role);
 
 /* Format the SD card filesystem (FAT32).  All data on the card is lost.
  * Unmounts, formats, remounts, and recreates the directory tree.
@@ -124,5 +157,11 @@ esp_err_t sd_storage_format(void);
  * unflushed filesystem state.  Safe to call when nothing is mounted. */
 void sd_storage_deinit(void);
 
-/* Return the last coherent capacity sample without touching FATFS. */
-bool sd_storage_get_cached_free(uint64_t *free_bytes, uint64_t *total_bytes);
+/* Monotonic process-local epoch for possible History source mutations.
+ * Read while holding a lease. Default non-UPLOAD release bumps it; callers
+ * proving no source mutation may use the explicit unchanged release. */
+uint32_t sd_storage_content_generation(void);
+
+/* Notify source mutations not followed by a default mutation release (for
+ * example FTP imports). Call after closing/publishing. */
+void sd_storage_content_changed(void);

--- a/main/session_writer.c
+++ b/main/session_writer.c
@@ -87,6 +87,7 @@
 #include "esp_log.h"
 #include "esp_timer.h"
 #include "esp_system.h"
+#include "esp_random.h"
 #include "esp_heap_caps.h"
 #include "esp_rom_crc.h"
 #include "cJSON.h"
@@ -382,7 +383,12 @@ static char s_client_id[64] = {0};
 
 static void sw_request_finalize(session_writer_t *s, const char *state,
                                 int64_t end_epoch_ms, bool allow_ble);
-static void pending_export_mark(const char *day);
+static bool pending_export_mark(const char *day);
+static bool pending_export_mark_session(const char *key, const char *day);
+static void pending_export_ack_session(const char *key);
+static bool pending_upload_ready(const char *path, char *out_day, char *out_generation);
+static bool pending_update(const char *path, const char *day, int attempts,
+                           bool stalled, esp_err_t err);
 
 /* OPEN is lifecycle work, but it also creates the next producer.  It may not
  * consume the final free slot: that slot belongs to the new session's future
@@ -1175,7 +1181,18 @@ static void storage_finalize(session_writer_t *s, const sw_cmd_t *cmd)
      * between a trustworthy manifest and a plausible-looking lie. */
     const char *state = cmd->state;
     if (s->storage_failed) state = "storage_failed";
-    write_manifest(s, state);
+    char export_day[16];
+    as11_time_noon_day(s->start_epoch_ms - cmd->clock_drift_ms,
+                       export_day, sizeof(export_day));
+    /* Immutable session identity prevents an older export from acknowledging
+     * newer work for the same day. Do not publish a terminal manifest unless
+     * reboot can discover its export intent. */
+    if (pending_export_mark_session(s->session_id, export_day)) {
+        write_manifest(s, state);
+    } else {
+        io_fail(s, "export intent");
+        ESP_LOGE(TAG, "terminal manifest deferred until export intent is durable");
+    }
 
     /* A stopped producer is not yet safe for History to inspect: queued
      * batches, open stdio descriptors and the terminal manifest all belong to
@@ -1244,12 +1261,13 @@ static void storage_finish_and_dispatch(session_writer_t *s,
 
         if (xQueueSend(s_post_q, &job, 0) != pdTRUE) {
             char day[16];
-            noon_day_folder_local((time_t)(s->start_epoch_ms / 1000),
-                                  day, sizeof(day));
+            as11_time_noon_day(s->start_epoch_ms - s->clock_drift_ms,
+                               day, sizeof(day));
             ESP_LOGW(TAG, "post queue full — raw session %s is safe; "
                           "deferring day %s export",
                      s->session_id, day);
-            pending_export_mark(day);
+            /* The session marker predates finalization and survives this
+             * queue overflow; no second, coarser day marker is necessary. */
         }
     } else if (s->storage_failed) {
         ESP_LOGE(TAG, "post: storage failed for %s — skipping export",
@@ -1435,7 +1453,7 @@ static void sw_storage_task(void *arg)
  * crashed night stayed on the card and never reached SDCARD/, SMB or SleepHQ.
  *
  * The publication state is therefore durable and independent of the manifest
- * state: one marker file per noon-day under SD_PENDING_EXPORT_DIR.  Design
+ * state: session-scoped marker files under SD_PENDING_EXPORT_DIR.  Design
  * points that matter:
  *
  *  - Marker first.  The marker is created before the recovered manifest is
@@ -1443,9 +1461,8 @@ static void sw_storage_task(void *arg)
  *    where a reset makes recovery skip the session (its manifest is final)
  *    while no marker exists to schedule the export — exactly the silent loss
  *    being fixed.  A marker without a repaired manifest is harmless.
- *  - Per day, not per session.  A day rebuild enumerates every manifest in
- *    the folder, so several interruptions in one night collapse to one
- *    rebuild.
+ *  - Session-scoped markers cannot erase a newer session's intent. Legacy
+ *    per-day markers remain readable; each retry rebuilds the whole day.
  *  - Drained by the existing post worker when it is otherwise idle, never
  *    inline during boot recovery: recovery runs before BLE starts, and a
  *    multi-minute rebuild there would delay reconnect and risk losing live
@@ -1471,7 +1488,7 @@ static void sw_storage_task(void *arg)
 /* Internal heap floor.  A rebuild allocates EDF buffers and can run while
  * BLE, Wi-Fi and TLS are all up; better to wait than to fail and burn an
  * attempt. */
-#define PENDING_MIN_FREE_HEAP  (48 * 1024)
+#define PENDING_MIN_FREE_HEAP  (12 * 1024)
 
 static volatile bool s_deferred_export_enabled = false;
 
@@ -1482,102 +1499,275 @@ static void pending_path(const char *day, char *out, size_t out_len)
 
 /* Record that `day` needs its export rebuilt.  Idempotent: an existing
  * marker (possibly carrying an attempt count) is left alone. */
-static void pending_export_mark(const char *day)
+static bool pending_export_mark_session(const char *key, const char *day)
 {
-    if (!day || strlen(day) != 8) return;
-
+    if (!key || !day || strlen(day) != 8 || strchr(key, '/')) return false;
     mkdir(SD_APP_DIR, 0775);
     mkdir(SD_PENDING_EXPORT_DIR, 0775);
-
-    char path[128];
-    pending_path(day, path, sizeof(path));
-
+    char path[160], tmp[172];
+    pending_path(key, path, sizeof(path));
     struct stat st;
-    if (stat(path, &st) == 0) {
-        ESP_LOGI(TAG, "export already pending for day %s", day);
-        return;
-    }
-
-    char tmp[140];
+    if (stat(path, &st) == 0) return true;
+    if (errno != ENOENT) return false;
     snprintf(tmp, sizeof(tmp), "%s.tmp", path);
     FILE *f = fopen(tmp, "w");
-    if (!f) {
-        ESP_LOGE(TAG, "cannot create pending-export marker for %s", day);
-        return;
-    }
-    fprintf(f, "{\"day\":\"%s\",\"attempts\":0,\"reason\":\"recovered\","
-               "\"first_seen_epoch_ms\":%lld}\n",
-            day, (long long)((int64_t)time(NULL) * 1000));
-    bool ok = (fflush(f) == 0) && (fsync(fileno(f)) == 0);
+    if (!f) return false;
+    bool ok = fprintf(f, "{\"day\":\"%s\",\"attempts\":0,\"reason\":\"export_pending\"}\n", day) > 0;
+    if (ok && fflush(f) != 0) ok = false;
+    if (ok && fsync(fileno(f)) != 0) ok = false;
     if (fclose(f) != 0) ok = false;
-    if (ok) ok = (rename(tmp, path) == 0);
-    if (!ok) {
-        unlink(tmp);
-        ESP_LOGE(TAG, "failed to persist pending-export marker for %s", day);
-        return;
-    }
-    ESP_LOGW(TAG, "day %s queued for automatic export rebuild", day);
+    if (ok && rename(tmp, path) != 0) ok = false;
+    if (!ok) unlink(tmp);
+    return ok;
 }
 
-/* Read the attempt count and whether the day was already given up on. */
-static void pending_read(const char *path, int *out_attempts, bool *out_stalled)
+static bool pending_export_mark(const char *day)
+{
+    if (!pending_export_mark_session(day, day)) return false;
+    char path[160];
+    pending_path(day, path, sizeof(path));
+    /* Boot recovery may discover new work under a legacy day key whose
+     * previous export was awaiting invalidation. Request a rebuild again. */
+    return !pending_upload_ready(path, NULL, NULL) || pending_update(path, day, 0, false, ESP_OK);
+}
+
+static void pending_export_ack_session(const char *key)
+{
+    if (!sd_storage_lease_acquire(SD_LEASE_EXPORT, 250)) return;
+    if (sd_storage_is_ready()) {
+        char path[160];
+        pending_path(key, path, sizeof(path));
+        unlink(path); /* Failure safely leaves retryable work. */
+    }
+    sd_storage_lease_release(SD_LEASE_EXPORT);
+}
+
+/* Marker updates append complete JSON lines. Never unlink durable intent to
+ * update an attempt counter: a torn tail is ignored and the prior line wins.
+ * Existing single-object markers remain readable. */
+static void pending_read(const char *path, int *out_attempts, bool *out_stalled,
+                         char *out_day)
 {
     if (out_attempts) *out_attempts = 0;
     if (out_stalled) *out_stalled = false;
-
+    if (out_day) out_day[0] = '\0';
     FILE *f = fopen(path, "r");
     if (!f) return;
-    char buf[512];
-    size_t rd = fread(buf, 1, sizeof(buf) - 1, f);
+    char line[512];
+    while (fgets(line, sizeof(line), f)) {
+        if (!strchr(line, '\n')) continue;
+        cJSON *root = cJSON_Parse(line);
+        if (!root) continue;
+        cJSON *d = cJSON_GetObjectItem(root, "day");
+        if (d && cJSON_IsString(d) && strlen(d->valuestring) == 8) {
+            if (out_day) memcpy(out_day, d->valuestring, 9);
+            cJSON *a = cJSON_GetObjectItem(root, "attempts");
+            if (a && cJSON_IsNumber(a) && out_attempts) *out_attempts = (int)a->valuedouble;
+            cJSON *v = cJSON_GetObjectItem(root, "stalled");
+            if (out_stalled) *out_stalled = v && cJSON_IsTrue(v);
+        }
+        cJSON_Delete(root);
+    }
     fclose(f);
-    buf[rd] = '\0';
-
-    cJSON *root = cJSON_Parse(buf);
-    if (!root) return;
-    cJSON *a = cJSON_GetObjectItem(root, "attempts");
-    if (a && cJSON_IsNumber(a) && out_attempts) *out_attempts = (int)a->valuedouble;
-    cJSON *s = cJSON_GetObjectItem(root, "stalled");
-    if (s && cJSON_IsTrue(s) && out_stalled) *out_stalled = true;
-    cJSON_Delete(root);
 }
 
-/* Update a marker after a failed attempt.  `stalled` means "do not retry
- * automatically" — the day stays visible in the status API so a persistent
- * problem is actionable instead of looping for ever. */
-static void pending_update(const char *day, int attempts, bool stalled,
-                           esp_err_t err)
+/* Read the last complete valid journal state, failing closed on read/close
+ * errors. A later ordinary retry record clears the upload-pending phase. */
+static bool pending_upload_ready(const char *path, char *out_day, char *out_generation)
 {
-    char path[300], tmp[320];
-    pending_path(day, path, sizeof(path));
-    snprintf(tmp, sizeof(tmp), "%s.tmp", path);
-
-    FILE *f = fopen(tmp, "w");
-    if (!f) return;
-    fprintf(f, "{\"day\":\"%s\",\"attempts\":%d,\"stalled\":%s,"
-               "\"last_error\":\"%s\",\"last_try_epoch_ms\":%lld}\n",
-            day, attempts, stalled ? "true" : "false", esp_err_to_name(err),
-            (long long)((int64_t)time(NULL) * 1000));
-    bool ok = (fflush(f) == 0) && (fsync(fileno(f)) == 0);
-    if (fclose(f) != 0) ok = false;
-    if (ok) {
-        unlink(path);
-        ok = (rename(tmp, path) == 0);
+    if (out_day) out_day[0] = '\0';
+    if (out_generation) out_generation[0] = '\0';
+    FILE *f = fopen(path, "r");
+    if (!f) return false;
+    char line[512];
+    bool ready = false;
+    while (fgets(line, sizeof(line), f)) {
+        if (!strchr(line, '\n')) continue;
+        cJSON *j = cJSON_Parse(line);
+        cJSON *day = cJSON_GetObjectItem(j, "day");
+        if (day && cJSON_IsString(day) && strlen(day->valuestring) == 8) {
+            cJSON *phase = cJSON_GetObjectItem(j, "phase");
+            cJSON *generation = cJSON_GetObjectItem(j, "generation");
+            ready = phase && cJSON_IsString(phase) &&
+                    strcmp(phase->valuestring, "upload_pending") == 0 &&
+                    generation && cJSON_IsString(generation) && strlen(generation->valuestring) == 32;
+            if (ready) {
+                for (int i = 0; i < 32; ++i) {
+                    char c = generation->valuestring[i];
+                    if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'))) ready = false;
+                }
+            }
+            if (out_day) memcpy(out_day, day->valuestring, 9);
+            if (ready && out_generation) memcpy(out_generation, generation->valuestring, 33);
+        }
+        cJSON_Delete(j);
     }
-    if (!ok) unlink(tmp);
+    bool failed = ferror(f) != 0;
+    if (fclose(f) != 0) failed = true;
+    if (failed && out_day) out_day[0] = '\0';
+    return ready && !failed;
+}
+
+/* The original intent remains until the scheduler has durably forgotten the
+ * old uploaded generation. Queue messages are only optional wakeups. */
+static bool pending_mark_upload_ready(const char *path, const char *day)
+{
+    FILE *f = fopen(path, "a");
+    if (!f) return false;
+    /* Persisted nonce fences same-day publication across reboot and marker
+     * reuse. 128 random bits avoid relying on wall-clock or boot-time order. */
+    uint32_t nonce[4];
+    esp_fill_random(nonce, sizeof(nonce));
+    bool ok = fprintf(f, "\n{\"day\":\"%s\",\"attempts\":0,\"stalled\":false,"
+                        "\"phase\":\"upload_pending\","
+                        "\"generation\":\"%08lx%08lx%08lx%08lx\","
+                        "\"last_error\":\"upload_invalidation_pending\"}\n", day,
+                        (unsigned long)nonce[0], (unsigned long)nonce[1],
+                        (unsigned long)nonce[2], (unsigned long)nonce[3]) > 0;
+    if (ok && fflush(f) != 0) ok = false;
+    if (ok && fsync(fileno(f)) != 0) ok = false;
+    if (fclose(f) != 0) ok = false;
+    return ok;
+}
+
+/* Called under the rebuild's EXPORT lease before its publish sentinel is
+ * retired. Recursive admission also makes direct use safe. The day marker
+ * supersedes earlier invalidations only for that same exported day. */
+esp_err_t session_writer_mark_upload_invalidation(const char *day)
+{
+    if (!day || strlen(day) != 8) return ESP_ERR_INVALID_ARG;
+    for (int i = 0; i < 8; ++i)
+        if (day[i] < '0' || day[i] > '9') return ESP_ERR_INVALID_ARG;
+    if (!sd_storage_lease_acquire(SD_LEASE_EXPORT, 0)) return ESP_ERR_TIMEOUT;
+    esp_err_t ret = ESP_ERR_INVALID_STATE;
+    if (sd_storage_is_ready()) {
+        char key[32], path[160];
+        snprintf(key, sizeof(key), "rebuild_%s", day);
+        pending_path(key, path, sizeof(path));
+        ret = pending_export_mark_session(key, day) && pending_mark_upload_ready(path, day)
+                  ? ESP_OK : ESP_FAIL;
+    }
+    sd_storage_lease_release(SD_LEASE_EXPORT);
+    return ret;
+}
+
+static bool pending_key_valid(const char *key)
+{
+    if (!key || !key[0] || strlen(key) >= 80) return false;
+    for (const char *p = key; *p; ++p)
+        if (!((*p >= '0' && *p <= '9') || (*p >= 'a' && *p <= 'z') ||
+              (*p >= 'A' && *p <= 'Z') || *p == '_' || *p == '-')) return false;
+    return true;
+}
+
+bool session_writer_next_upload_invalidation(uint32_t *day, char *token, size_t token_len)
+{
+    if (!day || !token || token_len < 2) return false;
+    *day = 0;
+    token[0] = '\0';
+    if (!sd_storage_lease_acquire(SD_LEASE_EXPORT, 0)) return false;
+    DIR *dir = sd_storage_is_ready() ? opendir(SD_PENDING_EXPORT_DIR) : NULL;
+    bool found = false;
+    if (dir) {
+        struct dirent *ent;
+        while ((ent = readdir(dir)) != NULL) {
+            size_t len = strlen(ent->d_name);
+            if (len <= 5 || len >= 80 || strcmp(ent->d_name + len - 5, ".json")) continue;
+            if (len - 5 + 1 + 32 >= token_len) continue;
+            char key[80], path[300], day_text[16], generation[33];
+            memcpy(key, ent->d_name, len - 5);
+            key[len - 5] = '\0';
+            if (!pending_key_valid(key)) continue;
+            snprintf(path, sizeof(path), "%s/%s", SD_PENDING_EXPORT_DIR, ent->d_name);
+            if (!pending_upload_ready(path, day_text, generation)) continue;
+            bool digits = true;
+            for (int i = 0; i < 8; ++i)
+                if (day_text[i] < '0' || day_text[i] > '9') digits = false;
+            if (!digits) continue;
+            uint32_t number = (uint32_t)strtoul(day_text, NULL, 10);
+            if (!number) continue;
+            *day = number;
+            snprintf(token, token_len, "%s:%s", key, generation);
+            found = true;
+            break;
+        }
+        if (closedir(dir) != 0) found = false;
+    }
+    sd_storage_lease_release_unchanged(SD_LEASE_EXPORT);
+    if (!found) { *day = 0; token[0] = '\0'; }
+    return found;
+}
+
+esp_err_t session_writer_ack_upload_invalidation(uint32_t day, const char *token)
+{
+    if (!day || !token || strlen(token) >= 128) return ESP_ERR_INVALID_ARG;
+    const char *colon = strchr(token, ':');
+    if (!colon || colon - token <= 0 || colon - token >= 80 || strlen(colon + 1) != 32)
+        return ESP_ERR_INVALID_ARG;
+    char key[80];
+    memcpy(key, token, (size_t)(colon - token));
+    key[colon - token] = '\0';
+    if (!pending_key_valid(key)) return ESP_ERR_INVALID_ARG;
+    if (!sd_storage_lease_acquire(SD_LEASE_EXPORT, 0)) return ESP_ERR_TIMEOUT;
+    esp_err_t ret = ESP_ERR_INVALID_STATE;
+    if (sd_storage_is_ready()) {
+        char path[160], day_text[16], generation[33];
+        pending_path(key, path, sizeof(path));
+        if (pending_upload_ready(path, day_text, generation) &&
+            (uint32_t)strtoul(day_text, NULL, 10) == day && !strcmp(generation, colon + 1))
+            ret = unlink(path) == 0 ? ESP_OK : ESP_FAIL;
+    }
+    if (ret == ESP_OK) sd_storage_lease_release(SD_LEASE_EXPORT);
+    else sd_storage_lease_release_unchanged(SD_LEASE_EXPORT);
+    return ret;
+}
+
+static void pending_reason(const char *path, char *out, size_t out_len)
+{
+    strlcpy(out, "export_pending", out_len);
+    FILE *f = fopen(path, "r");
+    if (!f) return;
+    char line[512];
+    while (fgets(line, sizeof(line), f)) {
+        if (!strchr(line, '\n')) continue;
+        cJSON *j = cJSON_Parse(line);
+        cJSON *v = cJSON_GetObjectItem(j, "last_error");
+        if (v && cJSON_IsString(v)) strlcpy(out, v->valuestring, out_len);
+        cJSON_Delete(j);
+    }
+    fclose(f);
+}
+
+static bool pending_update(const char *path, const char *day, int attempts,
+                           bool stalled, esp_err_t err)
+{
+    FILE *f = fopen(path, "a");
+    if (!f) return false;
+    /* Leading newline resynchronizes after a previous torn append. */
+    bool ok = fprintf(f, "\n{\"day\":\"%s\",\"attempts\":%d,\"stalled\":%s,"
+                        "\"last_error\":\"%s\"}\n", day, attempts,
+                        stalled ? "true" : "false",
+                        err == EDF_GEN_ERR_POSITION_GAPS ? "positioned_gaps_require_discontinuous_export" : esp_err_to_name(err)) > 0;
+    if (ok && fflush(f) != 0) ok = false;
+    if (ok && fsync(fileno(f)) != 0) ok = false;
+    if (fclose(f) != 0) ok = false;
+    if (!ok) ESP_LOGE(TAG, "pending-export update failed; retaining prior intent");
+    return ok;
 }
 
 /* Failures a retry cannot fix.  Retrying these would spin for ever and hide
  * the real problem behind an ever-growing attempt count. */
 static bool pending_error_is_permanent(esp_err_t err)
 {
-    return err == ESP_ERR_INVALID_ARG ||    /* malformed day */
+    return err == EDF_GEN_ERR_POSITION_GAPS ||
+           err == ESP_ERR_INVALID_ARG ||    /* malformed day */
            err == ESP_ERR_INVALID_SIZE ||   /* > REBUILD_MAX_SESSIONS */
            err == ESP_ERR_NOT_FOUND;        /* no usable manifest in the day */
 }
 
 /* Service at most one pending day, then return so the worker stays responsive
  * to real post-stop jobs. */
-static void pending_export_service(void)
+static void pending_export_service_unlocked(void)
 {
     if (!s_deferred_export_enabled) return;
     if (!sd_storage_is_ready()) return;
@@ -1603,7 +1793,7 @@ static void pending_export_service(void)
     while ((ent = readdir(dir)) != NULL) {
         if (ent->d_name[0] == '.') continue;
         size_t len = strlen(ent->d_name);
-        if (len != 13 || strcmp(ent->d_name + 8, ".json") != 0) continue;
+        if (len < 13 || len >= 80 || strcmp(ent->d_name + len - 5, ".json") != 0) continue;
 
         char cand[16];
         memcpy(cand, ent->d_name, 8);
@@ -1613,10 +1803,34 @@ static void pending_export_service(void)
         snprintf(cand_path, sizeof(cand_path), "%s/%s",
                  SD_PENDING_EXPORT_DIR, ent->d_name);
 
+        /* Handoff work belongs to the scheduler and must not monopolize
+         * another raw day's conversion while it waits for acknowledgement. */
+        if (pending_upload_ready(cand_path, NULL, NULL)) continue;
+
         int cand_attempts = 0;
         bool cand_stalled = false;
-        pending_read(cand_path, &cand_attempts, &cand_stalled);
+        pending_read(cand_path, &cand_attempts, &cand_stalled, cand);
+        if (!cand[0]) continue;
         if (cand_stalled || cand_attempts >= PENDING_MAX_ATTEMPTS) continue;
+
+        /* Missing/transiently unreadable source is unresolved work, not an
+         * eligible rebuild. Retain it and continue this scan so a stable
+         * directory order cannot starve another healthy day indefinitely. */
+        char day_streams[300];
+        snprintf(day_streams, sizeof(day_streams), "%s/%s", SD_STREAMS_DIR, cand);
+        struct stat st;
+        int stat_result = stat(day_streams, &st);
+        if (stat_result != 0 || !S_ISDIR(st.st_mode)) {
+            esp_err_t unavailable = stat_result != 0 && errno == ENOENT
+                                      ? ESP_ERR_NOT_FOUND : ESP_FAIL;
+            char reason[96];
+            pending_reason(cand_path, reason, sizeof(reason));
+            /* Do not grow the journal on every idle poll of the same fault.
+             * This is a retryable observation, never a permanent stall. */
+            if (strcmp(reason, esp_err_to_name(unavailable)) != 0)
+                pending_update(cand_path, cand, cand_attempts, false, unavailable);
+            continue;
+        }
 
         strlcpy(day, cand, sizeof(day));
         strlcpy(path, cand_path, sizeof(path));
@@ -1629,68 +1843,43 @@ static void pending_export_service(void)
 
     if (!day[0]) return;
 
-    /* Reconcile: the raw day may have been deleted or the card swapped since
-     * the marker was written. */
-    char day_streams[300];
-    snprintf(day_streams, sizeof(day_streams), "%s/%s", SD_STREAMS_DIR, day);
-    struct stat st;
-    if (stat(day_streams, &st) != 0) {
-        ESP_LOGW(TAG, "pending export: day %s no longer on the card — "
-                 "dropping marker", day);
-        unlink(path);
-        return;
-    }
-
-    /* Probe the export lease without waiting.  This runs on the post-therapy
-     * worker, which also services therapy-stop jobs; blocking here for the
-     * rebuild's own 120 s lease timeout would stall those behind it.  If the
-     * uploader still holds the lease, leave the marker and try again on the
-     * next idle pass — the marker is durable, and this path deliberately does
-     * not count as an attempt, since nothing was attempted.
-     *
-     * The lease is released again immediately: this is a "busy right now?"
-     * question, not a hand-off.  edf_gen_rebuild_day() acquires it properly.
-     * If another task takes it in between, the rebuild falls back to its own
-     * timeout, which is exactly today's behaviour. */
-    if (!sd_storage_lease_acquire(SD_LEASE_EXPORT, 0)) {
-        ESP_LOGI(TAG, "pending export: day %s left pending — export lease busy",
-                 day);
-        return;
-    }
-    sd_storage_lease_release(SD_LEASE_EXPORT);
-
     ESP_LOGW(TAG, "pending export: rebuilding day %s (attempt %d)",
              day, attempts + 1);
     crash_diag_note_activity("rebuild_day");
 
     esp_err_t ret = edf_gen_rebuild_day(day);
     if (ret == ESP_OK) {
-        /* Re-offer the day, then retire the marker.
-         *
-         * Deliberately NOT uploader_on_day_invalidated(): that forgets the
-         * whole day's upload index, so every session group from the night is
-         * re-offered as new.  A backend that opens an import batch per offer
-         * (SleepHQ) would then import a second time any earlier session from
-         * that night which had already uploaded cleanly.
-         * uploader_on_export_complete() reconciles instead — it marks only new
-         * or changed groups pending and leaves finished ones alone. */
-        uploader_on_export_complete(day);
-        unlink(path);
-        ESP_LOGW(TAG, "pending export: day %s rebuilt and queued for upload",
-                 day);
+        /* The shared rebuild path durably created its generation-fenced
+         * upload_pending marker before returning. Retire this raw-work marker
+         * only when it is not itself that handoff marker. */
+        char handoff_key[32], handoff_path[160];
+        snprintf(handoff_key, sizeof(handoff_key), "rebuild_%s", day);
+        pending_path(handoff_key, handoff_path, sizeof(handoff_path));
+        if (strcmp(path, handoff_path) != 0) unlink(path);
+        uploader_request_scan(); /* optional nudge; polling owns delivery */
+        ESP_LOGW(TAG, "pending export: day %s rebuilt; durable upload invalidation pending", day);
     } else if (pending_error_is_permanent(ret)) {
         ESP_LOGE(TAG, "pending export: day %s failed permanently (%s) — "
                  "needs attention, not retrying", day, esp_err_to_name(ret));
-        pending_update(day, attempts + 1, true, ret);
+        pending_update(path, day, attempts + 1, true, ret);
     } else {
         int next = attempts + 1;
         bool give_up = (next >= PENDING_MAX_ATTEMPTS);
         ESP_LOGE(TAG, "pending export: day %s failed (%s), attempt %d/%d%s",
                  day, esp_err_to_name(ret), next, PENDING_MAX_ATTEMPTS,
                  give_up ? " — giving up, needs attention" : "");
-        pending_update(day, next, give_up, ret);
+        pending_update(path, day, next, give_up, ret);
     }
     crash_diag_note_activity("idle");
+}
+
+static void pending_export_service(void)
+{
+    if (!s_deferred_export_enabled || sd_storage_recording_active() ||
+        sd_storage_recording_pending()) return;
+    if (!sd_storage_lease_acquire(SD_LEASE_EXPORT, 0)) return;
+    if (sd_storage_is_ready()) pending_export_service_unlocked();
+    sd_storage_lease_release(SD_LEASE_EXPORT);
 }
 
 void session_writer_enable_deferred_export(void)
@@ -1700,7 +1889,7 @@ void session_writer_enable_deferred_export(void)
     ESP_LOGI(TAG, "deferred export of recovered days enabled");
 }
 
-esp_err_t session_writer_pending_export_json(char **out_json)
+static esp_err_t pending_export_json_unlocked(char **out_json)
 {
     if (!out_json) return ESP_ERR_INVALID_ARG;
 
@@ -1713,21 +1902,22 @@ esp_err_t session_writer_pending_export_json(char **out_json)
         while ((ent = readdir(dir)) != NULL) {
             if (ent->d_name[0] == '.') continue;
             size_t len = strlen(ent->d_name);
-            if (len != 13 || strcmp(ent->d_name + 8, ".json") != 0) continue;
+            if (len < 13 || len >= 80 || strcmp(ent->d_name + len - 5, ".json") != 0) continue;
 
             char cand_path[300];
             snprintf(cand_path, sizeof(cand_path), "%s/%s",
                      SD_PENDING_EXPORT_DIR, ent->d_name);
             int attempts = 0;
             bool stalled = false;
-            pending_read(cand_path, &attempts, &stalled);
-
-            cJSON *o = cJSON_CreateObject();
             char day[16];
-            memcpy(day, ent->d_name, 8);
-            day[8] = '\0';
+            pending_read(cand_path, &attempts, &stalled, day);
+            if (!day[0]) continue;
+            cJSON *o = cJSON_CreateObject();
             cJSON_AddStringToObject(o, "day", day);
             cJSON_AddNumberToObject(o, "attempts", attempts);
+            char reason[96];
+            pending_reason(cand_path, reason, sizeof(reason));
+            cJSON_AddStringToObject(o, "reason", reason);
             cJSON_AddBoolToObject(o, "needs_attention",
                                   stalled || attempts >= PENDING_MAX_ATTEMPTS);
             cJSON_AddItemToArray(arr, o);
@@ -1738,6 +1928,17 @@ esp_err_t session_writer_pending_export_json(char **out_json)
     *out_json = cJSON_PrintUnformatted(arr);
     cJSON_Delete(arr);
     return *out_json ? ESP_OK : ESP_ERR_NO_MEM;
+}
+
+esp_err_t session_writer_pending_export_json(char **out_json)
+{
+    if (!out_json) return ESP_ERR_INVALID_ARG;
+    *out_json = NULL;
+    if (!sd_storage_lease_acquire(SD_LEASE_EXPORT, 0)) return ESP_ERR_TIMEOUT;
+    esp_err_t ret = sd_storage_is_ready() ? pending_export_json_unlocked(out_json)
+                                           : ESP_ERR_INVALID_STATE;
+    sd_storage_lease_release(SD_LEASE_EXPORT);
+    return ret;
 }
 
 /* ── Post-stop pipeline task ──────────────────────────────────────── */
@@ -1758,6 +1959,8 @@ static void post_wait_for_storage_quiet(void)
         vTaskDelay(pdMS_TO_TICKS(250));
     }
 }
+
+/* Optional derived IO yields to a new recording, just like History reads. */
 
 
 static void sw_post_task(void *arg)
@@ -1831,22 +2034,18 @@ static void sw_post_task(void *arg)
                            day_folder, sizeof(day_folder));
         if (ret == ESP_OK) {
             uploader_on_export_complete(day_folder);
-        } else if (ret == ESP_ERR_TIMEOUT) {
-            /* The export lease was held by a long upload run (edf_gen_generate
-             * gives up after 120 s).  Nothing is wrong with the session itself,
-             * so leave a pending-export marker and let the idle worker rebuild
-             * the day rather than losing the night.
-             *
-             * Only this error defers.  A malformed session or an invalid
-             * timestamp fails identically on every retry, so marking those
-             * would burn the attempt budget and end in a stalled marker that
-             * needs attention, having achieved nothing. */
-            ESP_LOGW(TAG, "post: export lease busy, marking day %s "
-                     "for deferred export", day_folder);
-            pending_export_mark(day_folder);
+            pending_export_ack_session(job.session_id);
         } else {
-            ESP_LOGW(TAG, "post: EDF generation failed (%s), not triggering upload",
+            ESP_LOGW(TAG, "post: EDF generation failed (%s), retaining export intent",
                      esp_err_to_name(ret));
+            if (sd_storage_lease_acquire(SD_LEASE_EXPORT, 250)) {
+                char marker[160], day[16];
+                pending_path(job.session_id, marker, sizeof(marker));
+                as11_time_noon_day(job.start_epoch_ms - job.clock_drift_ms,
+                                   day, sizeof(day));
+                pending_update(marker, day, 1, pending_error_is_permanent(ret), ret);
+                sd_storage_lease_release(SD_LEASE_EXPORT);
+            }
         }
 
         UBaseType_t free_bytes = uxTaskGetStackHighWaterMark(NULL) * sizeof(StackType_t);
@@ -2394,7 +2593,6 @@ static void publish_live_stream(const int16_t *flow_vals, int flow_n,
         bsp_display_push_leak(pld_vals[3] * 0.6f);
 
 }
-
 
 bool session_writer_try_stream_data_raw(const char *json, int len)
 {
@@ -3323,7 +3521,10 @@ void session_writer_recover(void)
              * final.  If the order were reversed, a reset in between would
              * leave a session that recovery skips (final manifest) and that
              * nothing schedules for export — the silent loss this fixes. */
-            pending_export_mark(ent->d_name);
+            if (!pending_export_mark(ent->d_name)) {
+                ESP_LOGE(TAG, "recover: export intent unavailable; retaining nonterminal source");
+                continue;
+            }
 
             /* Write the manifest atomically. */
             snprintf(ctx->tmp, sizeof(ctx->tmp), "%s.tmp", ctx->json_path);

--- a/main/session_writer.c
+++ b/main/session_writer.c
@@ -31,11 +31,11 @@
  *                 header update, fsync, close, manifest write, checkpoint.
  *                 Created once at init with a static command queue.
  *
- *   sw_post     — owns the post-stop pipeline: the stop-time GetDateTime
- *                 RPC, post-therapy spool collection, EDF generation and
- *                 the upload trigger.  Created once at init; no per-stop
- *                 task allocation (a failed allocation used to leave a
- *                 session that was never finalised).
+ *   sw_post     — owns the post-stop pipeline: post-therapy spool
+ *                 collection, EDF generation and the upload trigger.
+ *                 Storage finalisation happens first; this worker receives
+ *                 copied metadata and never owns live FILE pointers.
+ *                 Created once at init; no per-stop task allocation.
  *
  *  The BLE notification path performs NO filesystem I/O.  It appends
  *  samples to a producer-owned batch and enqueues:
@@ -93,6 +93,34 @@
 #include "psram_task.h"
 
 static const char *TAG = "session";
+
+/* The notification owner retains payloads; the writer owns admission intent. */
+static bool s_start_intent;
+static int64_t s_pending_start_us;
+static int64_t s_pending_start_epoch_ms;
+static bool s_transport_uncertain;
+static uint32_t s_stream_epoch;
+
+uint32_t session_writer_stream_epoch(void)
+{
+    return s_stream_epoch;
+}
+
+static void sw_start_intent_begin(void)
+{
+    if (s_start_intent) return;
+    sd_storage_recording_intent_begin();
+    s_start_intent = true;
+    s_pending_start_us = esp_timer_get_time();
+    s_pending_start_epoch_ms = (int64_t)time(NULL) * 1000;
+}
+
+static void sw_start_intent_end(void)
+{
+    if (!s_start_intent) return;
+    s_start_intent = false;
+    sd_storage_recording_intent_end();
+}
 
 /* ── Recovery journal (.ckpt) ─────────────────────────────────────────
  * Fixed-size binary journal with two alternating slots.  A checkpoint is
@@ -160,8 +188,14 @@ typedef struct __attribute__((packed)) {
 #define SW_START_DEBOUNCE_MS    15000
 
 #define SW_STORAGE_QUEUE_LEN    24
+#define SW_STORAGE_TERMINAL_RESERVE 1
 #define SW_POST_QUEUE_LEN        4
 #define MAX_SESSION_DIR_LEN    128
+
+/* A rapid stop/start sequence must not run BLE pulls or derived-file writes
+ * alongside the next raw recording.  Require storage to remain idle for this
+ * long before beginning each expensive post-stop phase. */
+#define SW_POST_QUIET_MS       5000
 
 /* ── Stream batch ─────────────────────────────────────────────────────
  * Immutable once handed to the storage worker.  Flow and pressure share
@@ -171,11 +205,18 @@ typedef struct {
     int16_t  brp_flow[BRP_CAP];
     int16_t  brp_press[BRP_CAP];
     uint32_t n_brp;
+    uint32_t brp_position[BRP_CAP];
+    uint32_t brp_end;
     int16_t  sa2_hr[SA2_CAP];
     int16_t  sa2_spo2[SA2_CAP];
     uint32_t n_sa2;
+    uint32_t sa2_position[SA2_CAP];
+    uint32_t sa2_end;
     int16_t  pld[PLD_CAP][12];
     uint32_t n_pld;
+    uint32_t pld_position[PLD_CAP];
+    uint32_t pld_end;
+    bool timing_uncertain;
     int64_t  elapsed_us;      /* monotonic span covered by this batch */
     int64_t  last_stream_us;
 } stream_batch_t;
@@ -186,6 +227,7 @@ typedef enum {
     SW_CMD_OPEN = 0,   /* create dir, open files, sync headers        */
     SW_CMD_BATCH,      /* write one detached batch                    */
     SW_CMD_EVENT,      /* write one pre-formatted JSON event line     */
+    SW_CMD_COMMIT,     /* FIFO durability barrier, ordered with events */
     SW_CMD_FINALIZE,   /* final commit, close, write manifest         */
 } sw_cmd_type_t;
 
@@ -201,16 +243,22 @@ typedef struct {
     const char       *drift_source;
     int64_t           drift_measured_at_ms;
     const char       *state;        /* static string                   */
-    bool              free_session; /* worker owns the struct (no sw_post) */
-    SemaphoreHandle_t done;
+    bool              queue_post;   /* dispatch immutable post work after close */
+    bool              allow_ble;
 } sw_cmd_t;
 
 /* ── Post-stop pipeline job ───────────────────────────────────────── */
 
 typedef struct {
-    session_writer_t *s;            /* freed by sw_post when done      */
+    char              session_dir[MAX_SESSION_DIR_LEN];
+    char              session_id[40];
+    int64_t           start_epoch_ms;
     int64_t           end_epoch_ms;
-    const char       *state;        /* "completed" | "timed_out" | ... */
+    int64_t           stop_boot_us;
+    int64_t           clock_drift_ms;
+    bool              drift_valid;
+    char              drift_source[24];
+    int64_t           drift_measured_at_ms;
     bool              allow_ble;    /* false when BLE is the reason    */
 } sw_post_job_t;
 
@@ -219,7 +267,8 @@ typedef struct {
 typedef struct {
     FILE    *f_l0;
     FILE    *f_l1;
-    uint32_t sample_count;   /* durable records written (per channel) */
+    uint32_t sample_count;   /* records written (per channel) */
+    bool position_gap;       /* header provenance durable before missing slots */
 } stream_files_t;
 
 struct session_writer {
@@ -233,24 +282,23 @@ struct session_writer {
 
     /* ── producer state ──────────────────────────────────────────── */
     volatile bool     active;
+    bool              finalize_requested;
+    /* Held from publication until the storage worker has closed every file
+     * and committed the terminal manifest.  `active` only describes whether
+     * producers may append; it is deliberately cleared earlier. */
+    bool              recording_claim_held;
     SemaphoreHandle_t fill_mutex;
     stream_batch_t   *fill;          /* current producer batch          */
     QueueHandle_t     batch_pool;    /* free stream_batch_t*            */
     stream_batch_t   *batches[SW_BATCH_POOL];
 
-    uint8_t  sa2_countdown;
-    uint8_t  pld_countdown;
-
-    /* missing-packet compensation / hold-last-value cache */
+    /* Source positions; no hold-last-value compensation. */
     int64_t  prev_stream_ms;
     bool     prev_stream_ms_valid;
-    int16_t  last_flow, last_press;
-    bool     last_brp_valid;
-    int16_t  last_hr, last_spo2;
-    bool     last_hr_valid, last_spo2_valid;
-    int16_t  last_pld[12];
-    bool     last_pld_valid;
-
+    uint64_t stream_elapsed_ms;
+    bool stream_position_valid;
+    uint32_t next_sa2_position;
+    uint32_t next_pld_position;
     /* ── stats (producer writes, worker reads at finalize) ────────── */
     uint32_t stream_notifications;
     uint32_t gap_events;
@@ -276,11 +324,15 @@ struct session_writer {
     FILE    *f_events;
     FILE    *f_ckpt;
     uint32_t flow_mm_count;
+    uint8_t flow_mm_fill;
+    int16_t flow_mm_min, flow_mm_max;
+    bool flow_mm_missing;
     uint32_t ckpt_seq;
     int64_t  committed_elapsed_us;
     int64_t  committed_last_stream_us;
     bool     files_open;
     bool     have_uncommitted;
+    bool     commit_queued;    /* storage-owned; producer fill lock protects enqueue */
 
     /* ── failure state (worker writes, anyone reads) ──────────────── */
     volatile bool storage_failed;
@@ -330,6 +382,28 @@ static char s_client_id[64] = {0};
 
 static void sw_request_finalize(session_writer_t *s, const char *state,
                                 int64_t end_epoch_ms, bool allow_ble);
+static void pending_export_mark(const char *day);
+
+/* OPEN is lifecycle work, but it also creates the next producer.  It may not
+ * consume the final free slot: that slot belongs to the new session's future
+ * FINALIZE.  The worker keeps draining while this bounded wait runs. */
+static bool storage_queue_send_open(const sw_cmd_t *cmd, uint32_t timeout_ms)
+{
+    TickType_t started = xTaskGetTickCount();
+    TickType_t wait = pdMS_TO_TICKS(timeout_ms);
+
+    do {
+        if (uxQueueSpacesAvailable(s_storage_q) >
+                SW_STORAGE_TERMINAL_RESERVE &&
+            xQueueSend(s_storage_q, cmd, 0) == pdTRUE) {
+            return true;
+        }
+        if (wait == 0 || (xTaskGetTickCount() - started) >= wait) break;
+        vTaskDelay(1);
+    } while (true);
+
+    return false;
+}
 
 /* ── Helpers ──────────────────────────────────────────────────────── */
 
@@ -435,7 +509,7 @@ static void io_fail(session_writer_t *s, const char *what)
                  what, strerror(errno));
         ESP_LOGE(TAG, "STORAGE FAILURE (%s) — errno=%d (%s)",
                  what, errno, strerror(errno));
-        bsp_display_set_notice("SD write error");
+        bsp_display_set_critical_notice("microSD write error");
     } else {
         ESP_LOGW(TAG, "storage error #%u (%s)", (unsigned)s->io_errors, what);
     }
@@ -500,6 +574,8 @@ static void batch_reset(stream_batch_t *b)
     b->n_brp = 0;
     b->n_sa2 = 0;
     b->n_pld = 0;
+    b->brp_end = b->sa2_end = b->pld_end = 0;
+    b->timing_uncertain = false;
     b->elapsed_us = 0;
     b->last_stream_us = 0;
 }
@@ -545,6 +621,24 @@ static void batch_pool_destroy(session_writer_t *s)
     s->fill = NULL;
 }
 
+/* Dispose of a not-yet-published session start. The recording claim is kept
+ * through allocation teardown so destructive storage cannot enter while any
+ * session-owned buffer or queue still exists. */
+static void session_start_discard(session_writer_t *s)
+{
+    if (!s) return;
+    batch_pool_destroy(s);
+    if (s->fill_mutex) {
+        vSemaphoreDelete(s->fill_mutex);
+        s->fill_mutex = NULL;
+    }
+    if (s->recording_claim_held) {
+        s->recording_claim_held = false;
+        sd_storage_recording_end();
+    }
+    free(s);
+}
+
 /* Hand the current fill batch to the storage worker and take a fresh one.
  * Caller holds fill_mutex.  Returns false if the batch could not be handed
  * off (pool exhausted or queue full) — the caller keeps filling and the
@@ -552,7 +646,8 @@ static void batch_pool_destroy(session_writer_t *s)
 static bool swap_and_enqueue_locked(session_writer_t *s)
 {
     if (!s->fill || s->fill->n_brp == 0) {
-        if (!s->fill || (s->fill->n_sa2 == 0 && s->fill->n_pld == 0))
+        if (!s->fill || (s->fill->n_sa2 == 0 && s->fill->n_pld == 0 &&
+                         s->fill->brp_end == 0 && !s->fill->timing_uncertain))
             return true;   /* nothing to commit */
     }
 
@@ -567,7 +662,11 @@ static bool swap_and_enqueue_locked(session_writer_t *s)
     full->elapsed_us = esp_timer_get_time() - s->start_time_us;
 
     sw_cmd_t cmd = { .type = SW_CMD_BATCH, .s = s, .batch = full };
-    if (xQueueSend(s_storage_q, &cmd, 0) != pdTRUE) {
+    /* BATCH and EVENT producers are serialised by fill_mutex.  Keep one
+     * queue slot unavailable to regular work so STOP can always enqueue the
+     * terminal command without blocking the sole BLE notification consumer. */
+    if (uxQueueSpacesAvailable(s_storage_q) <= SW_STORAGE_TERMINAL_RESERVE ||
+        xQueueSend(s_storage_q, &cmd, 0) != pdTRUE) {
         /* Put the spare back; keep filling the current batch. */
         xQueueSend(s->batch_pool, &next, 0);
         s->batch_dropped++;
@@ -579,19 +678,11 @@ static bool swap_and_enqueue_locked(session_writer_t *s)
     return true;
 }
 
-static void producer_commit(session_writer_t *s)
-{
-    if (!s || !s->fill_mutex) return;
-    xSemaphoreTake(s->fill_mutex, portMAX_DELAY);
-    swap_and_enqueue_locked(s);
-    xSemaphoreGive(s->fill_mutex);
-}
-
 /* ── Checkpoint ───────────────────────────────────────────────────── */
 
 static void ckpt_write(session_writer_t *s)
 {
-    if (!s->f_ckpt) return;
+    if (!s->f_ckpt || s->storage_failed) return;
 
     snt_ckpt_t c = {
         .magic = CKPT_MAGIC,
@@ -741,60 +832,123 @@ static void storage_open(session_writer_t *s)
     ESP_LOGI(TAG, "dir: %s", s->dir);
 }
 
-/* Write one detached batch.  No locks held: the batch is immutable. */
+/* Persist provenance before writing a newly introduced gap. A crash cannot
+ * leave positioned missing slots behind an apparently gap-free header. */
+static bool storage_mark_position_gap(session_writer_t *s, stream_files_t *stream)
+{
+    if (stream->position_gap) return true;
+    long pos = ftell(stream->f_l0);
+    uint16_t flags = SNT_POSITION_GAP_FLAG;
+    if (pos < 0 || fseek(stream->f_l0, offsetof(snt_header_t, reserved), SEEK_SET) != 0 ||
+        !write_exact(s, stream->f_l0, &flags, sizeof(flags), "gap provenance") ||
+        fflush(stream->f_l0) != 0 || fsync(fileno(stream->f_l0)) != 0 ||
+        fseek(stream->f_l0, pos, SEEK_SET) != 0) {
+        io_fail(s, "gap provenance");
+        return false;
+    }
+    stream->position_gap = true;
+    return true;
+}
+
+static bool storage_write_brp_frame(session_writer_t *s, int16_t flow, int16_t press)
+{
+    if (flow == SNT_MISSING && !storage_mark_position_gap(s, &s->flow)) return false;
+    if (press == SNT_MISSING && !storage_mark_position_gap(s, &s->press)) return false;
+    if (!write_exact(s, s->flow.f_l0, &flow, sizeof(flow), "flow write") ||
+        !write_exact(s, s->press.f_l0, &press, sizeof(press), "press write")) return false;
+    s->flow.sample_count++;
+    s->press.sample_count++;
+    if (s->flow_mm_fill == 0) {
+        s->flow_mm_min = INT16_MAX;
+        s->flow_mm_max = INT16_MIN;
+        s->flow_mm_missing = false;
+    }
+    if (flow == SNT_MISSING) s->flow_mm_missing = true;
+    else {
+        if (flow < s->flow_mm_min) s->flow_mm_min = flow;
+        if (flow > s->flow_mm_max) s->flow_mm_max = flow;
+    }
+    if (++s->flow_mm_fill == 25) {
+        int16_t mm[2] = {s->flow_mm_min, s->flow_mm_max};
+        if (s->flow_mm_missing) mm[0] = mm[1] = SNT_MISSING;
+        if (s->flow.f_l1 && !write_exact(s, s->flow.f_l1, mm, sizeof(mm), "flow_mm write")) return false;
+        s->flow_mm_count++;
+        s->flow_mm_fill = 0;
+    }
+    return true;
+}
+
+static bool storage_fill_brp_until(session_writer_t *s, uint32_t position)
+{
+    if (s->flow.sample_count >= position) return true;
+    if (!storage_mark_position_gap(s, &s->flow) ||
+        !storage_mark_position_gap(s, &s->press)) return false;
+    while (s->flow.sample_count < position) {
+        if (!storage_write_brp_frame(s, SNT_MISSING, SNT_MISSING)) return false;
+        if ((s->flow.sample_count & 255U) == 0) vTaskDelay(1);
+    }
+    return true;
+}
+
+static bool storage_fill_stream_until(session_writer_t *s, stream_files_t *stream,
+                                      uint32_t position, unsigned channels)
+{
+    if (stream->sample_count >= position) return true;
+    if (!storage_mark_position_gap(s, stream)) return false;
+    int16_t missing[12];
+    for (unsigned i = 0; i < channels; i++) missing[i] = SNT_MISSING;
+    while (stream->sample_count < position) {
+        if (!write_exact(s, stream->f_l0, missing, channels * sizeof(int16_t), "missing write")) return false;
+        stream->sample_count++;
+        if ((stream->sample_count & 255U) == 0) vTaskDelay(1);
+    }
+    return true;
+}
+
+/* Immutable positions let the storage owner materialize gaps without using
+ * producer capacity or replaying held measurements. Ends also retain a clipped
+ * tail when STOP occurs before another valid sample can be queued. */
 static void storage_write_batch(session_writer_t *s, stream_batch_t *b)
 {
     if (!s->files_open) return;
-
-    /* flow (L0) + 1 Hz MinMax sidecar (L1) */
+    if (b->timing_uncertain &&
+        (!storage_mark_position_gap(s, &s->flow) ||
+         !storage_mark_position_gap(s, &s->press) ||
+         !storage_mark_position_gap(s, &s->sa2) ||
+         !storage_mark_position_gap(s, &s->pld_f))) return;
     for (uint32_t i = 0; i < b->n_brp; i++) {
-        if (!write_exact(s, s->flow.f_l0, &b->brp_flow[i], sizeof(int16_t),
-                         "flow write")) return;
+        if (b->brp_position[i] < s->flow.sample_count) continue;
+        if (!storage_fill_brp_until(s, b->brp_position[i]) ||
+            !storage_write_brp_frame(s, b->brp_flow[i], b->brp_press[i])) return;
     }
-    if (s->flow.f_l1) {
-        uint32_t n_sec = b->n_brp / 25;
-        for (uint32_t sec = 0; sec < n_sec; sec++) {
-            uint32_t base = sec * 25;
-            int16_t fmn = INT16_MAX, fmx = INT16_MIN;
-            for (int j = 0; j < 25; j++) {
-                int16_t fv = b->brp_flow[base + j];
-                if (fv != SNT_MISSING) {
-                    if (fv < fmn) fmn = fv;
-                    if (fv > fmx) fmx = fv;
-                }
-            }
-            if (fmn == INT16_MAX) { fmn = fmx = SNT_MISSING; }
-            int16_t mm[2] = { fmn, fmx };
-            if (!write_exact(s, s->flow.f_l1, mm, sizeof(mm), "flow_mm write"))
-                return;
-            s->flow_mm_count++;
-        }
-    }
-    /* pressure — same count as flow, by construction */
-    for (uint32_t i = 0; i < b->n_brp; i++) {
-        if (!write_exact(s, s->press.f_l0, &b->brp_press[i], sizeof(int16_t),
-                         "press write")) return;
-    }
-    s->flow.sample_count += b->n_brp;
-    s->press.sample_count += b->n_brp;
-
+    if (!storage_fill_brp_until(s, b->brp_end)) return;
     for (uint32_t i = 0; i < b->n_sa2; i++) {
-        int16_t pair[2] = { b->sa2_hr[i], b->sa2_spo2[i] };
+        if (b->sa2_position[i] < s->sa2.sample_count) continue;
+        if (!storage_fill_stream_until(s, &s->sa2, b->sa2_position[i], 2)) return;
+        int16_t pair[2] = {b->sa2_hr[i], b->sa2_spo2[i]};
+        if ((pair[0] == SNT_MISSING || pair[1] == SNT_MISSING) &&
+            !storage_mark_position_gap(s, &s->sa2)) return;
         if (!write_exact(s, s->sa2.f_l0, pair, sizeof(pair), "sa2 write")) return;
+        s->sa2.sample_count++;
     }
-    s->sa2.sample_count += b->n_sa2;
-
+    if (!storage_fill_stream_until(s, &s->sa2, b->sa2_end, 2)) return;
     for (uint32_t i = 0; i < b->n_pld; i++) {
-        if (!write_exact(s, s->pld_f.f_l0, b->pld[i], sizeof(int16_t) * 12,
-                         "pld write")) return;
+        if (b->pld_position[i] < s->pld_f.sample_count) continue;
+        if (!storage_fill_stream_until(s, &s->pld_f, b->pld_position[i], 12)) return;
+        for (unsigned ch = 0; ch < 12; ++ch)
+            if (b->pld[i][ch] == SNT_MISSING &&
+                !storage_mark_position_gap(s, &s->pld_f)) return;
+        if (!write_exact(s, s->pld_f.f_l0, b->pld[i], sizeof(b->pld[i]), "pld write")) return;
+        s->pld_f.sample_count++;
     }
-    s->pld_f.sample_count += b->n_pld;
-
-    if (b->elapsed_us > s->committed_elapsed_us)
-        s->committed_elapsed_us = b->elapsed_us;
-    if (b->last_stream_us > s->committed_last_stream_us)
-        s->committed_last_stream_us = b->last_stream_us;
-
+    if (!storage_fill_stream_until(s, &s->pld_f, b->pld_end, 12)) return;
+    if (b->elapsed_us > s->committed_elapsed_us) s->committed_elapsed_us = b->elapsed_us;
+    /* Replay may drain much faster than source time. Recovery must not use
+     * processing duration to truncate a correctly positioned raw stream. */
+    int64_t source_extent_us = (int64_t)s->flow.sample_count * 40000;
+    if (source_extent_us > s->committed_elapsed_us)
+        s->committed_elapsed_us = source_extent_us;
+    if (b->last_stream_us > s->committed_last_stream_us) s->committed_last_stream_us = b->last_stream_us;
     s->have_uncommitted = true;
 }
 
@@ -832,8 +986,10 @@ static void storage_commit(session_writer_t *s)
         if (fsync(fileno(s->f_events)) != 0) io_fail(s, "events fsync");
     }
 
-    /* Only now may the checkpoint claim these counts are durable. */
+    /* Failed payload/header/event sync must never advance the checkpoint. */
+    if (s->storage_failed) return;
     ckpt_write(s);
+    if (s->storage_failed) return;
     s->have_uncommitted = false;
 
     ESP_LOGI(TAG, "commit: flow=%u press=%u sa2=%u pld=%u seq=%u",
@@ -857,6 +1013,7 @@ static void write_manifest(session_writer_t *s, const char *state)
     snprintf(tmp, sizeof(tmp), "%s.tmp", path);
 
     cJSON *root = cJSON_CreateObject();
+    if (!root) { errno = ENOMEM; io_fail(s, "manifest allocation"); return; }
     cJSON_AddStringToObject(root, "id", s->session_id);
     cJSON_AddNumberToObject(root, "start_epoch_ms", (double)s->start_epoch_ms);
     if (s->end_epoch_ms > 0)
@@ -877,6 +1034,7 @@ static void write_manifest(session_writer_t *s, const char *state)
 
     cJSON_AddStringToObject(root, "state", state);
     cJSON_AddNumberToObject(root, "fmt", 2);
+    cJSON_AddBoolToObject(root, "position_gaps", s->flow.position_gap || s->press.position_gap || s->sa2.position_gap || s->pld_f.position_gap);
 
     cJSON_AddNumberToObject(root, "brp_samples", (double)s->flow.sample_count);
     cJSON_AddNumberToObject(root, "brp_mm_samples", (double)s->flow_mm_count);
@@ -938,27 +1096,30 @@ static void write_manifest(session_writer_t *s, const char *state)
 
     char *json_str = cJSON_Print(root);
     cJSON_Delete(root);
-    if (!json_str) return;
+    if (!json_str) { errno = ENOMEM; io_fail(s, "manifest encoding"); return; }
 
     /* temp → checked write → fflush → fsync → rename.  A crash must never
      * leave a half-written manifest that recovery would trust. */
-    bool ok = false;
+    int first_error = 0;
     int64_t t_man = lat_begin();
     size_t len = strlen(json_str);
     FILE *f = fopen(tmp, "w");
-    if (f) {
-        ok = (fwrite(json_str, 1, len, f) == len);
-        if (ok && fflush(f) != 0) ok = false;
-        if (ok && fsync(fileno(f)) != 0) ok = false;
-        if (fclose(f) != 0) ok = false;
+    if (!f) first_error = errno ? errno : EIO;
+    else {
+        if (fwrite(json_str, 1, len, f) != len) first_error = errno ? errno : EIO;
+        if (!first_error && fflush(f) != 0) first_error = errno ? errno : EIO;
+        if (!first_error && fsync(fileno(f)) != 0) first_error = errno ? errno : EIO;
+        if (fclose(f) != 0 && !first_error) first_error = errno ? errno : EIO;
     }
-    if (ok) {
-        unlink(path);                       /* FATFS cannot rename-over */
-        if (rename(tmp, path) != 0) ok = false;
+    if (!first_error) {
+        if (unlink(path) != 0 && errno != ENOENT) first_error = errno;
+        if (!first_error && rename(tmp, path) != 0) first_error = errno;
     }
+    bool ok = first_error == 0;
     lat_end(SW_OP_MANIFEST, t_man);
     if (!ok) {
         unlink(tmp);
+        errno = first_error;
         io_fail(s, "manifest write");
         ESP_LOGE(TAG, "failed to write %s", path);
     } else {
@@ -967,24 +1128,47 @@ static void write_manifest(session_writer_t *s, const char *state)
     free(json_str);
 }
 
+static void close_session_file(session_writer_t *s, FILE **file,
+                               const char *label)
+{
+    if (!file || !*file) return;
+    FILE *owned = *file;
+    *file = NULL;
+    if (fclose(owned) != 0) io_fail(s, label);
+}
+
 static void storage_finalize(session_writer_t *s, const sw_cmd_t *cmd)
 {
     s->end_epoch_ms = cmd->end_epoch_ms;
-    s->end_time_us = esp_timer_get_time();
+    if (s->end_time_us <= 0) s->end_time_us = esp_timer_get_time();
     s->clock_drift_ms = cmd->clock_drift_ms;
     s->clock_drift_valid = cmd->drift_valid;
     s->clock_drift_source = cmd->drift_source;
     s->clock_drift_measured_at_ms = cmd->drift_measured_at_ms;
 
-    storage_commit(s);
+    /* The terminal fill deliberately bypasses the bounded regular-command
+     * path.  Producers are disabled, so the storage owner writes it after all
+     * older FIFO batches/events and before the durability commit. */
+    if (s->fill &&
+        (s->fill->n_brp > 0 || s->fill->n_sa2 > 0 || s->fill->n_pld > 0 ||
+         s->fill->brp_end > 0 || s->fill->timing_uncertain)) {
+        s->fill->last_stream_us = s->last_stream_us;
+        s->fill->elapsed_us = s->end_time_us - s->start_time_us;
+        storage_write_batch(s, s->fill);
+        batch_reset(s->fill);
+    }
 
-    if (s->flow.f_l0)  { fclose(s->flow.f_l0);  s->flow.f_l0 = NULL; }
-    if (s->flow.f_l1)  { fclose(s->flow.f_l1);  s->flow.f_l1 = NULL; }
-    if (s->press.f_l0) { fclose(s->press.f_l0); s->press.f_l0 = NULL; }
-    if (s->sa2.f_l0)   { fclose(s->sa2.f_l0);   s->sa2.f_l0 = NULL; }
-    if (s->pld_f.f_l0) { fclose(s->pld_f.f_l0); s->pld_f.f_l0 = NULL; }
-    if (s->f_events)   { fclose(s->f_events);   s->f_events = NULL; }
-    if (s->f_ckpt)     { fclose(s->f_ckpt);     s->f_ckpt = NULL; }
+    storage_commit(s);
+    int64_t positioned_end_ms = s->start_epoch_ms + s->committed_elapsed_us / 1000;
+    if (positioned_end_ms > s->end_epoch_ms) s->end_epoch_ms = positioned_end_ms;
+
+    close_session_file(s, &s->flow.f_l0,  "flow close");
+    close_session_file(s, &s->flow.f_l1,  "flow_mm close");
+    close_session_file(s, &s->press.f_l0, "pressure close");
+    close_session_file(s, &s->sa2.f_l0,   "sa2 close");
+    close_session_file(s, &s->pld_f.f_l0, "pld close");
+    close_session_file(s, &s->f_events,   "events close");
+    close_session_file(s, &s->f_ckpt,     "checkpoint close");
     s->files_open = false;
 
     /* Never claim "completed" when storage failed — that is the difference
@@ -992,6 +1176,15 @@ static void storage_finalize(session_writer_t *s, const sw_cmd_t *cmd)
     const char *state = cmd->state;
     if (s->storage_failed) state = "storage_failed";
     write_manifest(s, state);
+
+    /* A stopped producer is not yet safe for History to inspect: queued
+     * batches, open stdio descriptors and the terminal manifest all belong to
+     * the recording lifecycle.  Publish storage-idle only after those are
+     * complete, otherwise an immediate History refresh races FATFS finalise. */
+    if (s->recording_claim_held) {
+        s->recording_claim_held = false;
+        sd_storage_recording_end();
+    }
 
     ESP_LOGI(TAG, "=== SESSION STOPPED: %s (%s) ===", s->session_id, state);
     ESP_LOGI(TAG, "flow=%u press=%u sa2=%u pld=%u total samples",
@@ -1025,25 +1218,126 @@ static void storage_finalize(session_writer_t *s, const sw_cmd_t *cmd)
     if (s->fill_mutex) { vSemaphoreDelete(s->fill_mutex); s->fill_mutex = NULL; }
 }
 
+/* Raw files are closed on the storage worker before any slow BLE spool pull or
+ * EDF generation begins. The post queue owns copied metadata, never a live
+ * session or its seven FATFS descriptors. */
+static void storage_finish_and_dispatch(session_writer_t *s,
+                                        const sw_cmd_t *cmd)
+{
+    storage_finalize(s, cmd);
+
+    if (cmd->queue_post && !s->storage_failed) {
+        sw_post_job_t job = {
+            .start_epoch_ms = s->start_epoch_ms,
+            .end_epoch_ms = s->end_epoch_ms,
+            .stop_boot_us = s->end_time_us,
+            .clock_drift_ms = s->clock_drift_ms,
+            .drift_valid = s->clock_drift_valid,
+            .drift_measured_at_ms = s->clock_drift_measured_at_ms,
+            .allow_ble = cmd->allow_ble,
+        };
+        strlcpy(job.session_dir, s->dir, sizeof(job.session_dir));
+        strlcpy(job.session_id, s->session_id, sizeof(job.session_id));
+        strlcpy(job.drift_source,
+                s->clock_drift_source ? s->clock_drift_source : "none",
+                sizeof(job.drift_source));
+
+        if (xQueueSend(s_post_q, &job, 0) != pdTRUE) {
+            char day[16];
+            noon_day_folder_local((time_t)(s->start_epoch_ms / 1000),
+                                  day, sizeof(day));
+            ESP_LOGW(TAG, "post queue full — raw session %s is safe; "
+                          "deferring day %s export",
+                     s->session_id, day);
+            pending_export_mark(day);
+        }
+    } else if (s->storage_failed) {
+        ESP_LOGE(TAG, "post: storage failed for %s — skipping export",
+                 s->session_id);
+    }
+
+    free(s);
+}
+
 /* ── Storage worker task ──────────────────────────────────────────── */
+
+/* Pin the active session against finalisation while a producer touches it.
+ * Lock order is always active lifecycle -> fill.  Finalise takes the same
+ * order, clears publication, then waits for this lock before queueing the
+ * terminal command. */
+static session_writer_t *active_session_lock(void)
+{
+    session_writer_t *s = NULL;
+    xSemaphoreTake(s_active_mutex, portMAX_DELAY);
+    if (s_active && s_active->active && !s_active->finalize_requested &&
+        s_active->fill_mutex) {
+        s = s_active;
+        xSemaphoreTake(s->fill_mutex, portMAX_DELAY);
+    }
+    xSemaphoreGive(s_active_mutex);
+    return s;
+}
+
+/* Storage is the sole queue consumer, so it must never wait for the lifecycle
+ * gate: an external STOP may be holding that gate while waiting for queue
+ * capacity.  Failing the try-lock simply skips this periodic pass and lets the
+ * worker drain another command. */
+static session_writer_t *active_session_try_lock(bool *gate_acquired)
+{
+    session_writer_t *s = NULL;
+    if (gate_acquired) *gate_acquired = false;
+    if (xSemaphoreTake(s_active_mutex, 0) != pdTRUE) return NULL;
+    if (s_active && s_active->active && !s_active->finalize_requested &&
+        s_active->fill_mutex) {
+        if (xSemaphoreTake(s_active->fill_mutex, 0) != pdTRUE) {
+            xSemaphoreGive(s_active_mutex);
+            return NULL;
+        }
+        s = s_active;
+    }
+    if (gate_acquired) *gate_acquired = true;
+    xSemaphoreGive(s_active_mutex);
+    return s;
+}
+
+static void active_session_unlock(session_writer_t *s)
+{
+    if (s && s->fill_mutex) xSemaphoreGive(s->fill_mutex);
+}
 
 static void sw_storage_task(void *arg)
 {
     (void)arg;
+    /* session_writer_init() creates both persistent workers transactionally.
+     * Park before touching any shared queue so a later creation failure can
+     * delete this task and its queues without an SMP use-after-free. */
+    vTaskSuspend(NULL);
     ESP_LOGI(TAG, "storage worker started on core %d", xPortGetCoreID());
 
     int64_t last_commit_us = esp_timer_get_time();
+    session_writer_t *file_owner = NULL;
 
     while (1) {
         sw_cmd_t cmd;
         if (xQueueReceive(s_storage_q, &cmd, pdMS_TO_TICKS(500)) == pdTRUE) {
             switch (cmd.type) {
             case SW_CMD_OPEN:
+                if (file_owner != NULL) {
+                    ESP_LOGE(TAG, "lifecycle violation: duplicate/overlapping OPEN");
+                    break;
+                }
+                file_owner = cmd.s;
                 storage_open(cmd.s);
                 last_commit_us = esp_timer_get_time();
                 break;
 
             case SW_CMD_BATCH:
+                if (file_owner != cmd.s) {
+                    /* Never dereference a non-owner: if an invariant was
+                     * violated, FINALIZE may already have freed it. */
+                    ESP_LOGE(TAG, "lifecycle violation: BATCH owner mismatch");
+                    break;
+                }
                 storage_write_batch(cmd.s, cmd.batch);
                 /* Return the buffer to the producer pool immediately. */
                 if (cmd.s->batch_pool)
@@ -1051,7 +1345,10 @@ static void sw_storage_task(void *arg)
                 break;
 
             case SW_CMD_EVENT:
-                if (cmd.s->f_events && cmd.event_json) {
+                if (file_owner != cmd.s) {
+                    ESP_LOGE(TAG, "lifecycle violation: EVENT owner mismatch");
+                } else if (cmd.s->f_events && cmd.event_json) {
+                    cmd.s->have_uncommitted = true;
                     if (fputs(cmd.event_json, cmd.s->f_events) < 0 ||
                         fputc('\n', cmd.s->f_events) < 0) {
                         io_fail(cmd.s, "event write");
@@ -1060,14 +1357,24 @@ static void sw_storage_task(void *arg)
                 free(cmd.event_json);
                 break;
 
+            case SW_CMD_COMMIT:
+                if (file_owner != cmd.s) {
+                    ESP_LOGE(TAG, "lifecycle violation: COMMIT owner mismatch");
+                    break;
+                }
+                storage_commit(cmd.s);
+                cmd.s->commit_queued = false;
+                last_commit_us = esp_timer_get_time();
+                break;
+
             case SW_CMD_FINALIZE: {
-                session_writer_t *fs = cmd.s;
-                bool own = cmd.free_session;
-                storage_finalize(fs, &cmd);
-                if (cmd.done) xSemaphoreGive(cmd.done);
-                /* Normally sw_post owns the struct and frees it after the
-                 * export pipeline; only the fallback path hands it to us. */
-                if (own) free(fs);
+                session_writer_t *finished = cmd.s;
+                if (file_owner != finished) {
+                    ESP_LOGE(TAG, "lifecycle violation: FINALIZE owner mismatch");
+                    break;
+                }
+                storage_finish_and_dispatch(finished, &cmd);
+                file_owner = NULL;
                 break;
             }
             }
@@ -1076,37 +1383,44 @@ static void sw_storage_task(void *arg)
              * stale-session watchdog. */
         }
 
-        /* Periodic: bound uncommitted time, and close orphaned sessions. */
-        session_writer_t *s = s_active;
+        /* Periodic: bound uncommitted time, and close orphaned sessions.  Pin
+         * the writer while sampling producer state; storage itself owns the
+         * object and therefore may safely finish a queued batch after unlock. */
+        bool lifecycle_sampled = false;
+        session_writer_t *s = active_session_try_lock(&lifecycle_sampled);
         int64_t now = esp_timer_get_time();
 
-        if (s && s->active) {
-            if ((now - last_commit_us) / 1000 >= SW_COMMIT_INTERVAL_MS) {
-                producer_commit(s);          /* swap producer buffer  */
-                last_commit_us = now;
-                /* The batch lands on the queue; drain it before committing so
-                 * the checkpoint covers it. */
-                sw_cmd_t pending;
-                while (xQueuePeek(s_storage_q, &pending, 0) == pdTRUE &&
-                       pending.type == SW_CMD_BATCH) {
-                    if (xQueueReceive(s_storage_q, &pending, 0) != pdTRUE) break;
-                    storage_write_batch(pending.s, pending.batch);
-                    if (pending.s->batch_pool)
-                        xQueueSend(pending.s->batch_pool, &pending.batch, 0);
+        if (!lifecycle_sampled) continue;
+
+        if (s && s == file_owner) {
+            bool commit_due =
+                ((now - last_commit_us) / 1000 >= SW_COMMIT_INTERVAL_MS);
+            int64_t idle_ms = (now - s->last_stream_us) / 1000;
+            bool stale = s->last_stream_us > 0 &&
+                         idle_ms >= SW_STALE_TIMEOUT_MS;
+
+            if (commit_due && !s->commit_queued) {
+                /* Keep the terminal reserve. A failed enqueue leaves the
+                 * deadline due; the next pass retries after draining work. */
+                if (swap_and_enqueue_locked(s) &&
+                    uxQueueSpacesAvailable(s_storage_q) > SW_STORAGE_TERMINAL_RESERVE) {
+                    sw_cmd_t barrier = { .type = SW_CMD_COMMIT, .s = s };
+                    if (xQueueSend(s_storage_q, &barrier, 0) == pdTRUE)
+                        s->commit_queued = true;
                 }
-                storage_commit(s);
             }
+            active_session_unlock(s);
 
             /* Stale-session watchdog: monotonic, so a wall-clock step or an
              * AS11 time-of-day jump cannot defeat it. */
-            int64_t idle_ms = (now - s->last_stream_us) / 1000;
-            if (s->last_stream_us > 0 && idle_ms >= SW_STALE_TIMEOUT_MS) {
+            if (stale) {
                 ESP_LOGW(TAG, "no StreamData for %lld ms — closing orphaned session",
                          (long long)idle_ms);
                 sw_request_finalize(s, "timed_out",
                                     (int64_t)time(NULL) * 1000, false);
             }
-        } else if (s == NULL) {
+        } else {
+            active_session_unlock(s);
             last_commit_us = now;
         }
     }
@@ -1428,9 +1742,30 @@ esp_err_t session_writer_pending_export_json(char **out_json)
 
 /* ── Post-stop pipeline task ──────────────────────────────────────── */
 
+static void post_wait_for_storage_quiet(void)
+{
+    int64_t quiet_since_us = 0;
+
+    while (1) {
+        int64_t now_us = esp_timer_get_time();
+        if (sd_storage_recording_active()) {
+            quiet_since_us = 0;
+        } else if (quiet_since_us == 0) {
+            quiet_since_us = now_us;
+        } else if ((now_us - quiet_since_us) / 1000 >= SW_POST_QUIET_MS) {
+            return;
+        }
+        vTaskDelay(pdMS_TO_TICKS(250));
+    }
+}
+
+
 static void sw_post_task(void *arg)
 {
     (void)arg;
+    /* See sw_storage_task(): init resumes both workers only after every
+     * shared resource exists and s_ready has been published. */
+    vTaskSuspend(NULL);
     ESP_LOGI(TAG, "post worker started on core %d (idle; waiting for jobs)",
              xPortGetCoreID());
 
@@ -1444,115 +1779,56 @@ static void sw_post_task(void *arg)
             pending_export_service();
             continue;
         }
-        session_writer_t *s = job.s;
-        if (!s) continue;
+        /* Raw files and the terminal manifest are already closed.  A quiet
+         * window absorbs rapid UI start/stop cycles and keeps the next raw
+         * session ahead of optional BLE and EDF work. */
+        post_wait_for_storage_quiet();
+        ESP_LOGI(TAG, "post: processing closed session %s", job.session_id);
 
-        /* 1. Establish drift with honest provenance.
-         *
-         * The stop-time GetDateTime RPC is the authoritative source, but it
-         * is unavailable exactly when the link dropped — which is the common
-         * case for a timed-out session.  Never block on it there. */
-        int64_t drift_ms = 0;
-        bool drift_valid = false;
-        const char *drift_source = "none";
-        int64_t drift_at = job.end_epoch_ms;
-
-        if (job.allow_ble) {
-            int64_t as11_ms = 0;
-            if (as11_ble_get_datetime(&as11_ms) == ESP_OK) {
-                drift_ms = job.end_epoch_ms - as11_ms;
-                drift_valid = true;
-                drift_source = "measured_stop";
-                ESP_LOGI(TAG, "clock_drift_ms = %lld (stop-time)", (long long)drift_ms);
-            } else if (as11_ble_get_clock_drift(&drift_ms) == ESP_OK) {
-                drift_valid = true;
-                drift_source = "measured_prestream";
-                ESP_LOGI(TAG, "clock_drift_ms = %lld (pre-stream)", (long long)drift_ms);
-            }
-        }
-        if (!drift_valid) {
-            time_drift_snapshot_t snap;
-            if (time_sync_get_drift_snapshot(&snap) && snap.available) {
-                drift_ms = snap.drift_ms;
-                drift_at = snap.measured_at_ms;
-                drift_source = snap.source;   /* "nvs" | "sd" */
-                ESP_LOGW(TAG, "clock_drift_ms = %lld (estimate from %s)",
-                         (long long)drift_ms, drift_source);
-            } else {
-                ESP_LOGW(TAG, "clock_drift_ms unavailable");
-            }
-        }
-
-        /* 2. Hand the drift to the storage worker and wait for the files to
-         * be finalised, so the manifest is complete before anything reads it. */
-        SemaphoreHandle_t done = xSemaphoreCreateBinary();
-        sw_cmd_t fin = {
-            .type = SW_CMD_FINALIZE,
-            .s = s,
-            .end_epoch_ms = job.end_epoch_ms,
-            .clock_drift_ms = drift_ms,
-            .drift_valid = drift_valid,
-            .drift_source = drift_source,
-            .drift_measured_at_ms = drift_at,
-            .state = job.state,
-            .done = done,
-        };
-        xQueueSend(s_storage_q, &fin, portMAX_DELAY);
-        if (done) {
-            xSemaphoreTake(done, pdMS_TO_TICKS(60000));
-            vSemaphoreDelete(done);
-        }
-
-        /* 3. Persist drift only when the clock was NTP-authoritative, else a
+        /* Persist drift only when the clock was NTP-authoritative, else a
          * degraded-mode session would feed its own estimate back in. */
-        if (drift_valid && time_source_get() == TIME_SRC_NTP) {
-            time_sync_save_drift(drift_ms, job.end_epoch_ms);
-        }
-
-        char session_dir[MAX_SESSION_DIR_LEN];
-        char session_id[40];
-        strlcpy(session_dir, s->dir, sizeof(session_dir));
-        strlcpy(session_id, s->session_id, sizeof(session_id));
-        int64_t start_epoch_ms = s->start_epoch_ms;
-        int64_t end_epoch_ms = s->end_epoch_ms;
-        int64_t stop_boot_us = s->end_time_us;
-        bool storage_failed = s->storage_failed;
-
-        free(s);
-        s = NULL;
-
-        if (storage_failed) {
-            ESP_LOGE(TAG, "post: storage failed for %s — skipping export",
-                     session_id);
-            continue;
+        if (job.drift_valid && time_source_get() == TIME_SRC_NTP) {
+            time_sync_save_drift(job.clock_drift_ms,
+                                 job.drift_measured_at_ms > 0
+                                     ? job.drift_measured_at_ms
+                                     : job.end_epoch_ms);
         }
 
         /* 4. Post-therapy collection (BLE spool pulls + Get RPC). */
         bool spool_current = false;
         if (job.allow_ble) {
             ESP_LOGI(TAG, "post: starting post-therapy collection");
-            post_therapy_collect(session_dir, session_id, start_epoch_ms,
-                                 drift_ms, end_epoch_ms, &spool_current);
+            post_therapy_collect(job.session_dir, job.session_id,
+                                 job.start_epoch_ms, job.clock_drift_ms,
+                                 job.end_epoch_ms, &spool_current);
             if (!spool_current) {
                 ESP_LOGI(TAG, "post: waiting for Summary spool to become current");
-                bool fresh = post_therapy_wait_spool_current(end_epoch_ms, drift_ms);
-                int64_t elapsed_ms = (esp_timer_get_time() - stop_boot_us) / 1000;
+                bool fresh = post_therapy_wait_spool_current(job.end_epoch_ms,
+                                                              job.clock_drift_ms);
+                int64_t elapsed_ms =
+                    (esp_timer_get_time() - job.stop_boot_us) / 1000;
                 ESP_LOGI(TAG, "post: spool %s after %lld ms from stop",
                          fresh ? "CURRENT" : "STALE (timeout)",
                          (long long)elapsed_ms);
             }
         } else {
             ESP_LOGW(TAG, "post: BLE unavailable, skipping spool collection for %s",
-                     session_id);
+                     job.session_id);
         }
+
+        /* A new recording may have begun during a BLE RPC.  Wait it out before
+         * opening the much heavier EDF generation pass. */
+        if (sd_storage_recording_active()) post_wait_for_storage_quiet();
 
         /* 5. EDF generation + upload trigger.  Runs here rather than in a
          * per-stop task: one persistent worker means no allocation can fail
          * at the exact moment a session needs exporting. */
-        esp_err_t ret = edf_gen_generate(session_dir, session_id,
-                                        start_epoch_ms, end_epoch_ms, drift_ms);
+        esp_err_t ret = edf_gen_generate(job.session_dir, job.session_id,
+                                         job.start_epoch_ms, job.end_epoch_ms,
+                                         job.clock_drift_ms);
         char day_folder[32];
-        as11_time_noon_day(start_epoch_ms - drift_ms, day_folder, sizeof(day_folder));
+        as11_time_noon_day(job.start_epoch_ms - job.clock_drift_ms,
+                           day_folder, sizeof(day_folder));
         if (ret == ESP_OK) {
             uploader_on_export_complete(day_folder);
         } else if (ret == ESP_ERR_TIMEOUT) {
@@ -1586,6 +1862,45 @@ static void sw_post_task(void *arg)
 
 /* ── Public API ───────────────────────────────────────────────────── */
 
+/* A newly-created worker self-suspends before reading module state. Observing
+ * eSuspended is therefore a real startup join (rather than remotely suspending
+ * a possibly-running task) and makes partial-init teardown safe on SMP. */
+static void sw_wait_startup_parked(TaskHandle_t task)
+{
+    while (task && eTaskGetState(task) != eSuspended) {
+        vTaskDelay(1);
+    }
+}
+
+static void session_writer_init_unwind(void)
+{
+    s_ready = false;
+    s_active = NULL;
+
+    /* Init waits for each created worker to self-park before proceeding, so
+     * neither task can still reference a queue when it is deleted here. */
+    if (s_post_task) {
+        psram_task_delete(s_post_task);
+        s_post_task = NULL;
+    }
+    if (s_storage_task) {
+        psram_task_delete(s_storage_task);
+        s_storage_task = NULL;
+    }
+    if (s_post_q) {
+        vQueueDelete(s_post_q);
+        s_post_q = NULL;
+    }
+    if (s_storage_q) {
+        vQueueDelete(s_storage_q);
+        s_storage_q = NULL;
+    }
+    if (s_active_mutex) {
+        vSemaphoreDelete(s_active_mutex);
+        s_active_mutex = NULL;
+    }
+}
+
 esp_err_t session_writer_init(void)
 {
     if (s_ready) return ESP_OK;
@@ -1597,7 +1912,7 @@ esp_err_t session_writer_init(void)
     s_post_q = xQueueCreate(SW_POST_QUEUE_LEN, sizeof(sw_post_job_t));
     if (!s_storage_q || !s_post_q) {
         ESP_LOGE(TAG, "session writer queue alloc failed");
-        return ESP_ERR_NO_MEM;
+        goto no_mem;
     }
 
     /* Persistent workers, created once.  If either cannot be created the
@@ -1607,74 +1922,89 @@ esp_err_t session_writer_init(void)
                                        NULL, 8, tskNO_AFFINITY, NULL, NULL);
     if (!s_storage_task) {
         ESP_LOGE(TAG, "storage worker creation failed");
-        return ESP_ERR_NO_MEM;
+        goto no_mem;
     }
+    sw_wait_startup_parked(s_storage_task);
     s_post_task = psram_task_create(sw_post_task, "sw_post", 16384,
                                     NULL, 5, 1, NULL, NULL);
     if (!s_post_task) {
         ESP_LOGE(TAG, "post worker creation failed");
-        return ESP_ERR_NO_MEM;
+        goto no_mem;
     }
+    sw_wait_startup_parked(s_post_task);
 
     s_ready = true;
+    vTaskResume(s_storage_task);
+    vTaskResume(s_post_task);
     ESP_LOGI(TAG, "session writer initialised (commit interval %d ms, "
              "stale timeout %d ms)", SW_COMMIT_INTERVAL_MS, SW_STALE_TIMEOUT_MS);
     return ESP_OK;
+
+no_mem:
+    session_writer_init_unwind();
+    return ESP_ERR_NO_MEM;
 }
 
 session_writer_t *session_writer_start(void)
 {
+    bool first_attempt = !s_start_intent;
+    sw_start_intent_begin();
     if (!s_ready) {
-        ESP_LOGE(TAG, "cannot start session: writer not initialised");
+        if (first_attempt) ESP_LOGE(TAG, "cannot start session: writer not initialised");
         return NULL;
     }
     if (!sd_storage_is_ready()) {
-        ESP_LOGE(TAG, "cannot start session: SD not ready");
+        if (first_attempt) ESP_LOGE(TAG, "cannot start session: SD not ready");
         return NULL;
     }
-    if (!sd_storage_reserve_for_recording()) {
-        ESP_LOGE(TAG, "cannot start session: insufficient free space");
+    if (!sd_storage_reserve_for_recording_cached()) {
+        if (first_attempt) ESP_LOGE(TAG, "cannot start session: insufficient free space");
         return NULL;
     }
 
-    /* Rotate any previous session through the normal stop pipeline. */
+    /* Rotate any previous session through the normal stop pipeline.  Do not
+     * pre-clear s_active: the finalise helper owns that state transition and
+     * orders FINALIZE on the storage queue before this START can enqueue OPEN. */
     xSemaphoreTake(s_active_mutex, portMAX_DELAY);
     session_writer_t *prev = s_active;
-    s_active = NULL;
     xSemaphoreGive(s_active_mutex);
     if (prev) {
         ESP_LOGW(TAG, "session already active, rotating");
-        prev->active = false;
         sw_request_finalize(prev, "rotated", (int64_t)time(NULL) * 1000, true);
+    }
+
+    /* Admit the storage owner before allocating the session and its large
+     * PSRAM batch pool. This is the atomic admission boundary against
+     * History/upload/format; every failed start below releases the claim. */
+    if (!sd_storage_recording_try_begin()) {
+        if (first_attempt) ESP_LOGW(TAG, "cannot start session: microSD reader or maintenance active");
+        return NULL;
     }
 
     session_writer_t *s = heap_caps_calloc(1, sizeof(session_writer_t), MALLOC_CAP_SPIRAM);
     if (!s) s = calloc(1, sizeof(session_writer_t));
-    if (!s) return NULL;
+    if (!s) {
+        sd_storage_recording_end();
+        return NULL;
+    }
+    s->recording_claim_held = true;
 
     s->fill_mutex = xSemaphoreCreateMutex();
-    if (!s->fill_mutex) { free(s); return NULL; }
+    if (!s->fill_mutex) {
+        session_start_discard(s);
+        return NULL;
+    }
     if (!batch_pool_create(s)) {
-        batch_pool_destroy(s);
-        vSemaphoreDelete(s->fill_mutex);
-        free(s);
+        session_start_discard(s);
         return NULL;
     }
 
-    s->pld_countdown = 1;
-    s->sa2_countdown = 1;
     s->clock_drift_source = "none";
-    s->start_time_us = esp_timer_get_time();
-    s->start_epoch_ms = (int64_t)time(NULL) * 1000;
+    s->start_time_us = s_pending_start_us;
+    s->start_epoch_ms = s_pending_start_epoch_ms;
     s->last_stream_us = s->start_time_us;
 
     make_session_id(s->session_id, sizeof(s->session_id));
-    /* Leave a breadcrumb in RTC memory: if the firmware dies mid-session, the
-     * next boot can name the session that was recording even when no core
-     * dump could be written. */
-    crash_diag_note_session(s->session_id);
-    crash_diag_note_activity("session_open");
-
     int64_t drift_ms = 0;
     as11_ble_get_clock_drift(&drift_ms);
 
@@ -1682,33 +2012,39 @@ session_writer_t *session_writer_start(void)
     as11_time_noon_day(s->start_epoch_ms - drift_ms, noon_day, sizeof(noon_day));
     snprintf(s->dir, sizeof(s->dir), "%s/%s", SD_STREAMS_DIR, noon_day);
 
-    s->active = true;
-    /* Declare the recording so destructive maintenance actions are refused
-     * for its duration (raw capture outranks derived output). */
-    sd_storage_recording_begin();
-
-    /* Publish before the files exist on purpose.  The producer can start
-     * filling immediately while the worker creates and syncs the headers,
-     * so the notifications that arrive during file setup are buffered
-     * rather than dropped — mid-therapy auto-start is detected from the
-     * very first StreamData notification. */
+    /* Queue OPEN before publishing the pointer.  Once published, producers
+     * can start filling while the worker creates the files, but FIFO ordering
+     * guarantees no BATCH or FINALIZE can overtake OPEN.  Holding the active
+     * mutex also orders this OPEN after a preceding session's FINALIZE. */
     xSemaphoreTake(s_active_mutex, portMAX_DELAY);
-    s_active = s;
-    xSemaphoreGive(s_active_mutex);
-
-    sw_cmd_t cmd = { .type = SW_CMD_OPEN, .s = s };
-    if (xQueueSend(s_storage_q, &cmd, pdMS_TO_TICKS(100)) != pdTRUE) {
-        ESP_LOGE(TAG, "failed to enqueue session open");
-        xSemaphoreTake(s_active_mutex, portMAX_DELAY);
-        if (s_active == s) s_active = NULL;
+    if (s_active && s_active->active) {
+        /* A concurrent duplicate start won the race while this session was
+         * being allocated.  Keep that healthy session instead of replacing
+         * it with a second set of seven files. */
+        session_writer_t *existing = s_active;
         xSemaphoreGive(s_active_mutex);
+        session_start_discard(s);
+        sw_start_intent_end();
+        return existing;
+    }
+
+    s->active = true;
+    /* Leave a breadcrumb only after duplicate arbitration has selected this
+     * start. If OPEN cannot be queued, clear it with the rest of the start. */
+    crash_diag_note_session(s->session_id);
+    crash_diag_note_activity("session_open");
+    sw_cmd_t cmd = { .type = SW_CMD_OPEN, .s = s };
+    if (!storage_queue_send_open(&cmd, 0)) {
+        ESP_LOGE(TAG, "failed to enqueue session open");
         s->active = false;
-        sd_storage_recording_end();
-        batch_pool_destroy(s);
-        vSemaphoreDelete(s->fill_mutex);
-        free(s);
+        xSemaphoreGive(s_active_mutex);
+        crash_diag_note_session(NULL);
+        session_start_discard(s);
         return NULL;
     }
+    s_active = s;
+    xSemaphoreGive(s_active_mutex);
+    sw_start_intent_end();
 
     return s;
 }
@@ -1721,54 +2057,95 @@ static void sw_request_finalize(session_writer_t *s, const char *state,
 {
     if (!s) return;
 
-    /* Clear s_active first so a TherapyStart arriving during the stop
-     * pipeline creates a fresh session instead of writing into this one. */
-    xSemaphoreTake(s_active_mutex, portMAX_DELAY);
-    bool was_active = s->active;
+    /* The active mutex is also the lifecycle queue-order gate.  START holds it
+     * from OPEN enqueue through publication, while STOP holds it from detach
+     * through FINALIZE enqueue.  A later OPEN therefore cannot overtake this
+     * close even when UI and BLE callbacks arrive on different tasks. */
+    bool on_storage_worker =
+        (xTaskGetCurrentTaskHandle() == s_storage_task);
+    if (xSemaphoreTake(s_active_mutex, on_storage_worker ? 0 : portMAX_DELAY) !=
+        pdTRUE) {
+        /* The queue owner must remain able to drain capacity for an external
+         * STOP that is holding this gate.  Its watchdog will retry later. */
+        return;
+    }
+    /* Pointer comparison is safe even if the caller held an obsolete handle;
+     * do not dereference it unless it is still the published active owner. */
+    if (s_active != s) {
+        xSemaphoreGive(s_active_mutex);
+        return;
+    }
+    if (s->finalize_requested) {
+        xSemaphoreGive(s_active_mutex);
+        return;
+    }
+
+    s->finalize_requested = true;
     s->active = false;
     if (s_active == s) s_active = NULL;
-    xSemaphoreGive(s_active_mutex);
-    if (was_active) sd_storage_recording_end();
+    s->end_time_us = esp_timer_get_time();
 
-    crash_diag_note_activity(state ? state : "finalize");
-    crash_diag_note_session(NULL);
+    /* Wait behind any producer that already passed its active check.  Once
+     * this barrier completes, the terminal fill batch is immutable; the
+     * storage worker writes it directly after all older queued commands. */
+    if (s->fill_mutex) {
+        xSemaphoreTake(s->fill_mutex, portMAX_DELAY);
+        xSemaphoreGive(s->fill_mutex);
+    }
 
-    /* Hand off whatever the producer still holds, before FINALIZE is queued;
-     * the queue is FIFO, so the batch is written first. */
-    producer_commit(s);
-
-    sw_post_job_t job = {
-        .s = s,
-        .end_epoch_ms = end_epoch_ms,
-        .state = state,
-        .allow_ble = allow_ble,
-    };
-    if (xQueueSend(s_post_q, &job, pdMS_TO_TICKS(1000)) != pdTRUE) {
-        /* Post queue full: finalise the files anyway so the raw data is never
-         * left unfinished, and let the day rebuild handle the export. */
-        ESP_LOGE(TAG, "post queue full — finalising files without export");
-        sw_cmd_t fin = {
-            .type = SW_CMD_FINALIZE, .s = s,
-            .end_epoch_ms = end_epoch_ms,
-            .drift_source = "none",
-            .state = state,
-            .free_session = true,   /* nobody downstream owns it now */
-        };
-        /* The stale-session watchdog runs ON the storage worker.  Queueing to
-         * our own queue with portMAX_DELAY would self-deadlock if it were
-         * full, so finalise inline when we are already that task. */
-        if (xTaskGetCurrentTaskHandle() == s_storage_task) {
-            storage_finalize(s, &fin);
-            free(s);
-        } else if (xQueueSend(s_storage_q, &fin, pdMS_TO_TICKS(5000)) != pdTRUE) {
-            ESP_LOGE(TAG, "storage queue full — session %s left unfinalised "
-                     "(recovery will repair it on next boot)", s->session_id);
+    int64_t drift_ms = 0;
+    bool drift_valid = false;
+    const char *drift_source = "none";
+    int64_t drift_at = end_epoch_ms;
+    if (allow_ble && as11_ble_get_clock_drift(&drift_ms) == ESP_OK) {
+        drift_valid = true;
+        drift_source = "measured_prestream";
+    } else {
+        time_drift_snapshot_t snap;
+        if (time_sync_peek_drift_snapshot(&snap) && snap.available) {
+            drift_ms = snap.drift_ms;
+            drift_source = snap.source;
+            drift_at = snap.measured_at_ms;
         }
     }
+
+    sw_cmd_t fin = {
+        .type = SW_CMD_FINALIZE,
+        .s = s,
+        .end_epoch_ms = end_epoch_ms,
+        .clock_drift_ms = drift_ms,
+        .drift_valid = drift_valid,
+        .drift_source = drift_source,
+        .drift_measured_at_ms = drift_at,
+        .state = state,
+        .queue_post = true,
+        .allow_ble = allow_ble,
+    };
+
+    /* Regular BATCH/EVENT admission always preserves this terminal slot.
+     * A STOP therefore never stalls the BLE notification consumer, while the
+     * active mutex still orders this FINALIZE ahead of a later OPEN. */
+    BaseType_t queued = xQueueSend(s_storage_q, &fin, 0);
+
+    if (queued != pdTRUE) {
+        s->finalize_requested = false;
+        s->active = true;
+        s_active = s;
+        xSemaphoreGive(s_active_mutex);
+        ESP_LOGW(TAG, "storage queue busy — deferring finalise of %s",
+                 s->session_id);
+        return;
+    }
+
+    xSemaphoreGive(s_active_mutex);
+    crash_diag_note_activity(state ? state : "finalize");
+    crash_diag_note_session(NULL);
 }
 
 esp_err_t session_writer_stop(session_writer_t *s)
 {
+    s_stream_epoch++;
+    sw_start_intent_end();
     if (!s) return ESP_OK;
     sw_request_finalize(s, "completed", (int64_t)time(NULL) * 1000, true);
     return ESP_OK;
@@ -1804,7 +2181,8 @@ static void queue_event_json(session_writer_t *s, char *json_str)
 {
     if (!s || !json_str) { free(json_str); return; }
     sw_cmd_t cmd = { .type = SW_CMD_EVENT, .s = s, .event_json = json_str };
-    if (xQueueSend(s_storage_q, &cmd, 0) != pdTRUE) {
+    if (uxQueueSpacesAvailable(s_storage_q) <= SW_STORAGE_TERMINAL_RESERVE ||
+        xQueueSend(s_storage_q, &cmd, 0) != pdTRUE) {
         s->event_dropped++;
         free(json_str);
     }
@@ -1980,19 +2358,47 @@ static int match_key(const char *key, int klen)
 
 static int64_t parse_starttime_ms(const char *s, int len)
 {
-    if (len < 24) return -1;
-    if (s[11] < '0' || s[11] > '9') return -1;
+    if (len < 23 || s[13] != ':' || s[16] != ':' || s[19] != '.') return -1;
+    static const uint8_t digits[] = {11,12,14,15,17,18,20,21,22};
+    for (unsigned i = 0; i < sizeof(digits); ++i)
+        if (s[digits[i]] < '0' || s[digits[i]] > '9') return -1;
     int h   = (s[11] - '0') * 10 + (s[12] - '0');
     int m   = (s[14] - '0') * 10 + (s[15] - '0');
     int sec = (s[17] - '0') * 10 + (s[18] - '0');
     int ms  = (s[20] - '0') * 100 + (s[21] - '0') * 10 + (s[22] - '0');
+    if (h >= 24 || m >= 60 || sec >= 60) return -1;
     return (int64_t)h * 3600000 + m * 60000 + sec * 1000 + ms;
 }
 
-void session_writer_on_stream_data_raw(const char *json, int len)
+static void publish_live_stream(const int16_t *flow_vals, int flow_n,
+                                const int16_t *pld_vals, const bool *pld_found)
 {
-    session_writer_t *s = session_writer_get_active();
+    /* PatientFlow is encoded as hundredths of a litre per second.  The
+     * display API uses litres per minute, so convert at this boundary:
+     *
+     *     raw / 100 L/s * 60 s/min = raw * 0.6 L/min
+     *
+     * Keeping the display-side unit explicit matters on the 7-inch UI: it
+     * stores tenths of L/min. Passing L/s made ordinary breathing values
+     * smaller than a single chart pixel and rendered an apparent flat line. */
+    for (int j = 0; j < flow_n; j++) {
+        /* Missingness occupies time on the live trace without becoming a measurement. */
+        bsp_display_push_flow(flow_vals[j] == SNT_MISSING ? NAN : flow_vals[j] * 0.6f);
+    }
 
+    /* Push leak rate to display for info panel mode.
+     * PLD channel 3 = Leak, stored as value*100 in L/s (same raw format
+     * as .snt files).  Convert to L/min: dig * 0.6f, matching
+     * pld_leak_phys() in session_graph.c. */
+    if (pld_found[3] && pld_vals[3] >= 0)
+        bsp_display_push_leak(pld_vals[3] * 0.6f);
+
+}
+
+
+bool session_writer_try_stream_data_raw(const char *json, int len)
+{
+    if (!json || len <= 0) return true;
     static bool s_first_logged = false;
     if (!s_first_logged) {
         s_first_logged = true;
@@ -2072,19 +2478,14 @@ void session_writer_on_stream_data_raw(const char *json, int len)
         }
     }
 
-    /* PatientFlow: push to display, detect active flow */
     bool has_active_flow = false;
     for (int j = 0; j < flow_n; j++) {
-        bsp_display_push_flow(flow_vals[j] / 100.0f);
+        /* null samples are retained as gaps in the recording below, but are
+         * not measurements and must neither move the live trace nor trigger
+         * the mid-therapy recovery heuristic. */
+        if (flow_vals[j] == SNT_MISSING) continue;
         if (abs(flow_vals[j]) > 50) has_active_flow = true;
     }
-
-    /* Push leak rate to display for info panel mode.
-     * PLD channel 3 = Leak, stored as value*100 in L/s (same raw format
-     * as .snt files).  Convert to L/min: dig * 0.6f, matching
-     * pld_leak_phys() in session_graph.c. */
-    if (pld_found[3] && pld_vals[3] >= 0)
-        bsp_display_push_leak(pld_vals[3] * 0.6f);
 
     bool has_therapy_pressure = false;
     for (int j = 0; j < press_n; j++) {
@@ -2095,182 +2496,131 @@ void session_writer_on_stream_data_raw(const char *json, int len)
      * therapy (reboot mid-therapy, or ESP powered on after the AS11).
      * Gated against Mask Fit and Cooldown/Drying mode so non-therapeutic
      * blower air never opens a phantom therapy session (issue #149). */
-    if ((!s || !session_writer_is_active(s)) && !s_therapy_stopped
+    session_writer_t *s = active_session_lock();
+
+    if (!s && !s_therapy_stopped
         && !s_in_mask_fit && !s_in_cooldown
-        && has_active_flow && has_therapy_pressure) {
-        ESP_LOGI(TAG, ">>> THERAPY detected via non-zero flow (reboot mid-therapy?)");
-        bsp_display_set_therapy_active(true);
-        bsp_display_set_therapy_start_time(esp_timer_get_time());
-        s = session_writer_start();
-        if (s) {
-            s_started_from_event = false;
+        && (s_start_intent || (has_active_flow && has_therapy_pressure))) {
+        bool first_attempt = !s_start_intent;
+        if (first_attempt) ESP_LOGI(TAG, ">>> THERAPY detected via non-zero flow (reboot mid-therapy?)");
+        if (!bsp_display_set_therapy_active(true)) {
+            ESP_LOGW(TAG, "therapy recovery ignored: restart already committed");
         } else {
-            ESP_LOGW(TAG, "session_writer_start() failed — "
-                     "graph active but NOT recording to SD");
+            if (first_attempt) bsp_display_set_therapy_start_time(esp_timer_get_time());
+            session_writer_t *started = session_writer_start();
+            if (started) {
+                s_started_from_event = false;
+                s = active_session_lock();
+            } else if (first_attempt) {
+                ESP_LOGW(TAG, "session_writer_start() failed — "
+                         "graph active but NOT recording to SD");
+            }
         }
     }
 
-    if (!s || !session_writer_is_active(s)) return;
+    if (!s && s_start_intent) return false;
+    if (!s) {
+    publish_live_stream(flow_vals, flow_n, pld_vals, pld_found);
+        return true;
+    }
 
     s->last_stream_us = esp_timer_get_time();
-
-    xSemaphoreTake(s->fill_mutex, portMAX_DELAY);
 
     s->stream_notifications++;
     stream_batch_t *b = s->fill;
 
-    /* ── Missing-packet compensation ───────────────────────────────
-     * Short gaps hold the previous value (visually indistinguishable and
-     * matching AS11 conventions).  Long gaps are NOT padded: minutes of
-     * fabricated data would be worse than an honest boundary, so they are
-     * counted and — beyond SW_SPLIT_GAP_MS — the session is split. */
+    /* Source spacing, not task scheduling, determines fixed-rate positions.
+     * Only a real midnight wrap is treated as a wrap; other backward clock
+     * changes start a new span instead of manufacturing nearly 24 hours. */
+    int64_t delta_ms = 200;
     bool want_split = false;
     if (cur_stream_ms >= 0 && s->prev_stream_ms_valid) {
-        int64_t gap = cur_stream_ms - s->prev_stream_ms;
-        if (gap < 0) gap += 86400000;
-        if (gap > 280) {
-            int missing = (int)((gap - 100) / 200);
-            if (missing > 0 && missing < 50) {
-                ESP_LOGW(TAG, "StreamData gap: %lldms (%d missing notifications), "
-                         "inserting compensation", (long long)gap, missing);
-                s->gap_events++;
-                s->gap_missing_total += missing;
-
-                for (int m = 0; m < missing; m++) {
-                    uint32_t base = b->n_brp;
-                    if (base + 5 <= BRP_CAP && s->last_brp_valid) {
-                        for (int j = 0; j < 5; j++) {
-                            b->brp_flow[base + j] = s->last_flow;
-                            b->brp_press[base + j] = s->last_press;
-                        }
-                        b->n_brp = base + 5;
-                    } else if (s->last_brp_valid) {
-                        s->brp_dropped += 5;
-                    }
-                }
-                for (int m = 0; m < missing; m++) {
-                    if (s->sa2_countdown <= 1) {
-                        s->sa2_countdown = 5;
-                        if (b->n_sa2 < SA2_CAP) {
-                            b->sa2_hr[b->n_sa2] = s->last_hr_valid ? s->last_hr : SNT_MISSING;
-                            b->sa2_spo2[b->n_sa2] = s->last_spo2_valid ? s->last_spo2 : SNT_MISSING;
-                            b->n_sa2++;
-                        } else {
-                            s->sa2_dropped++;
-                        }
-                    } else {
-                        s->sa2_countdown--;
-                    }
-                }
-                for (int m = 0; m < missing; m++) {
-                    if (s->pld_countdown <= 1) {
-                        s->pld_countdown = 10;
-                        if (s->last_pld_valid && b->n_pld < PLD_CAP) {
-                            for (int k = 0; k < 12; k++)
-                                b->pld[b->n_pld][k] = s->last_pld[k];
-                            b->n_pld++;
-                        } else if (s->last_pld_valid) {
-                            s->pld_dropped++;
-                        }
-                    } else {
-                        s->pld_countdown--;
-                    }
-                }
-            } else if (missing >= 50) {
-                /* Uncompensated discontinuity — record it honestly. */
-                int64_t offset_ms = s->start_epoch_ms > 0
-                    ? (esp_timer_get_time() - s->start_time_us) / 1000 : 0;
+        delta_ms = cur_stream_ms - s->prev_stream_ms;
+        if (delta_ms < 0 && s->prev_stream_ms >= 23 * 3600000LL &&
+            cur_stream_ms < 3600000LL) delta_ms += 86400000LL;
+        if (delta_ms == 0) { active_session_unlock(s); return true; }
+        /* Ordered intake can still contain an old source packet. Do not
+         * publish it twice or rotate a fresh session for a small regression.
+         * A sustained/large clock reset is handled as a separate span below. */
+        if (delta_ms < 0 && delta_ms > -SW_SPLIT_GAP_MS) {
+            b->timing_uncertain = true;
+            active_session_unlock(s);
+            return true;
+        }
+        want_split = delta_ms < 0 || delta_ms >= SW_SPLIT_GAP_MS;
+        if (delta_ms > 280) {
+            s->gap_events++;
+            s->gap_missing_total += (uint32_t)((delta_ms - 100) / 200);
+            if (delta_ms >= 10200) {
                 s->gap_long_events++;
-                s->gap_long_ms_total += (uint64_t)gap;
-                if (s->gap_long_first_ms == 0) s->gap_long_first_ms = offset_ms;
-                s->gap_long_last_ms = offset_ms;
-                ESP_LOGW(TAG, "long StreamData gap: %lld ms (%d notifications) — "
-                         "not compensated", (long long)gap, missing);
-                if (gap >= SW_SPLIT_GAP_MS) want_split = true;
+                s->gap_long_ms_total += (uint64_t)delta_ms;
+                if (!s->gap_long_first_ms) s->gap_long_first_ms = s->stream_elapsed_ms;
+                s->gap_long_last_ms = s->stream_elapsed_ms + delta_ms;
             }
         }
     }
-
-    if (cur_stream_ms >= 0) {
-        s->prev_stream_ms = cur_stream_ms;
-        s->prev_stream_ms_valid = true;
-    }
-
     if (want_split) {
-        /* Split rather than emit a continuous-looking timeline across a
-         * multi-minute hole.  .snt assumes uniform sampling, so a gap this
-         * large cannot be represented honestly inside one session. */
-        xSemaphoreGive(s->fill_mutex);
-        ESP_LOGW(TAG, "splitting session at long gap");
+        active_session_unlock(s);
         sw_request_finalize(s, "split", (int64_t)time(NULL) * 1000, true);
-        s = session_writer_start();
-        if (!s) return;
-        xSemaphoreTake(s->fill_mutex, portMAX_DELAY);
+        if (!session_writer_start()) return false;
+        s = active_session_lock();
+        if (!s) return false;
         b = s->fill;
-        s->prev_stream_ms = cur_stream_ms;
-        s->prev_stream_ms_valid = true;
     }
-
-    /* BRP: flow + pressure appended in lockstep at the same buffer index. */
-    {
-        uint32_t base = b->n_brp;
-        int n_pairs = flow_n > press_n ? flow_n : press_n;
-        int room = (int)(BRP_CAP - base);
-        int added = n_pairs;
-        if (added > room) {
-            s->brp_dropped += (uint32_t)(added - room);
-            added = room;
-        }
-        for (int j = 0; j < added; j++) {
-            b->brp_flow[base + j]  = (j < flow_n)  ? flow_vals[j]  : SNT_MISSING;
-            b->brp_press[base + j] = (j < press_n) ? press_vals[j] : SNT_MISSING;
-        }
-        b->n_brp = base + (uint32_t)added;
-        if (added > 0) {
-            s->last_flow = b->brp_flow[b->n_brp - 1];
-            s->last_press = b->brp_press[b->n_brp - 1];
-            s->last_brp_valid = true;
-        }
+    if (s->stream_position_valid && delta_ms > 200) {
+        uint32_t missing = (uint32_t)((delta_ms - 200 + 20) / 40);
+        bsp_display_push_flow_gap(missing);
     }
+    publish_live_stream(flow_vals, flow_n, pld_vals, pld_found);
 
-    /* SA2: 1 Hz, decimated from the 5 Hz report. */
-    if (--s->sa2_countdown == 0) {
-        s->sa2_countdown = 5;
+    if (s->stream_position_valid) s->stream_elapsed_ms += (uint64_t)delta_ms;
+    else s->stream_position_valid = true;
+    s->prev_stream_ms = cur_stream_ms;
+    s->prev_stream_ms_valid = cur_stream_ms >= 0;
+    b->timing_uncertain |= cur_stream_ms < 0 || s_transport_uncertain;
+    s_transport_uncertain = false;
+    uint32_t position = (uint32_t)((s->stream_elapsed_ms + 20) / 40);
+
+    uint32_t base = b->n_brp;
+    int n_pairs = flow_n > press_n ? flow_n : press_n;
+    int added = n_pairs;
+    if (added > (int)(BRP_CAP - base)) {
+        added = (int)(BRP_CAP - base);
+        s->brp_dropped += (uint32_t)(n_pairs - added);
+    }
+    for (int j = 0; j < added; j++) {
+        b->brp_position[base + j] = position + (uint32_t)j;
+        b->brp_flow[base + j] = j < flow_n ? flow_vals[j] : SNT_MISSING;
+        b->brp_press[base + j] = j < press_n ? press_vals[j] : SNT_MISSING;
+    }
+    b->n_brp += (uint32_t)added;
+    b->brp_end = position + (uint32_t)(n_pairs > 5 ? n_pairs : 5);
+
+    uint32_t sa2_position = position / 25;
+    if (sa2_position >= s->next_sa2_position) {
+        s->next_sa2_position = sa2_position + 1;
         if (b->n_sa2 < SA2_CAP) {
-            b->sa2_hr[b->n_sa2] = hr_found ? hr_val : SNT_MISSING;
-            b->sa2_spo2[b->n_sa2] = spo2_found ? spo2_val : SNT_MISSING;
-            b->n_sa2++;
-        } else {
-            s->sa2_dropped++;
-        }
-        if (hr_found) { s->last_hr = hr_val; s->last_hr_valid = true; }
-        if (spo2_found) { s->last_spo2 = spo2_val; s->last_spo2_valid = true; }
-    } else if (spo2_found && b->n_sa2 > 0) {
+            uint32_t i = b->n_sa2++;
+            b->sa2_position[i] = sa2_position;
+            b->sa2_hr[i] = hr_found ? hr_val : SNT_MISSING;
+            b->sa2_spo2[i] = spo2_found ? spo2_val : SNT_MISSING;
+        } else s->sa2_dropped++;
+    } else if (spo2_found && b->n_sa2 &&
+               b->sa2_position[b->n_sa2 - 1] == sa2_position) {
         b->sa2_spo2[b->n_sa2 - 1] = spo2_val;
-        s->last_spo2 = spo2_val;
-        s->last_spo2_valid = true;
     }
+    b->sa2_end = sa2_position + 1;
 
-    /* PLD: 12 channels at 0.5 Hz, decimated from the 5 Hz report. */
-    if (--s->pld_countdown == 0) {
-        s->pld_countdown = 10;
-        bool any_found = false;
-        for (int k = 0; k < 12; k++) {
-            if (pld_found[k]) { any_found = true; break; }
-        }
-        if (any_found) {
-            if (b->n_pld < PLD_CAP) {
-                for (int k = 0; k < 12; k++)
-                    b->pld[b->n_pld][k] = pld_found[k] ? pld_vals[k] : SNT_MISSING;
-                b->n_pld++;
-                for (int k = 0; k < 12; k++)
-                    s->last_pld[k] = b->pld[b->n_pld - 1][k];
-                s->last_pld_valid = true;
-            } else {
-                s->pld_dropped++;
-            }
-        }
+    uint32_t pld_position = position / 50;
+    if (pld_position >= s->next_pld_position) {
+        s->next_pld_position = pld_position + 1;
+        if (b->n_pld < PLD_CAP) {
+            uint32_t i = b->n_pld++;
+            b->pld_position[i] = pld_position;
+            for (int k = 0; k < 12; k++) b->pld[i][k] = pld_found[k] ? pld_vals[k] : SNT_MISSING;
+        } else s->pld_dropped++;
     }
+    b->pld_end = pld_position + 1;
 
     /* Hand off to the storage worker before anything can be clipped.  No
      * file I/O happens here — only a pointer swap. */
@@ -2280,7 +2630,25 @@ void session_writer_on_stream_data_raw(const char *json, int len)
         swap_and_enqueue_locked(s);
     }
 
-    xSemaphoreGive(s->fill_mutex);
+    active_session_unlock(s);
+    return true;
+}
+
+void session_writer_on_stream_data_raw(const char *json, int len)
+{
+    (void)session_writer_try_stream_data_raw(json, len);
+}
+
+void session_writer_on_transport_loss(void)
+{
+    s_stream_epoch++;
+    sw_start_intent_end();
+    s_transport_uncertain = true;
+    session_writer_t *s = active_session_lock();
+    if (s) {
+        s->fill->timing_uncertain = true;
+        active_session_unlock(s);
+    }
 }
 
 /* ── Notification dispatch ────────────────────────────────────────── */
@@ -2293,6 +2661,17 @@ void session_writer_on_notification(session_writer_t *s, const cJSON *msg)
     const char *method_str = method ? method->valuestring : NULL;
     if (!method_str) return;
 
+    /* Do not trust a bare pointer captured by the caller.  Reacquire under
+     * the lifecycle lock so the storage worker cannot destroy this session
+     * while the notification is inspecting or queueing data for it. */
+    (void)s;
+    s = active_session_lock();
+    bool session_locked = (s != NULL);
+#define NOTIFY_RETURN() do {                         \
+        if (session_locked) active_session_unlock(s); \
+        return;                                       \
+    } while (0)
+
     ESP_LOGD(TAG, "notification: %s", method_str);
 
     if (strcmp(method_str, "EventNotification") == 0) {
@@ -2300,42 +2679,53 @@ void session_writer_on_notification(session_writer_t *s, const cJSON *msg)
         as11_event_t ev_type = check_event_notification(msg, &report);
 
         if (ev_type == AS11_EV_THERAPY_STOP) {
+            s_stream_epoch++;
             ESP_LOGI(TAG, ">>> THERAPY STOP detected");
             crash_diag_note_activity("therapy_stop");
             s_therapy_stopped = true;
+            sw_start_intent_end();
             s_in_mask_fit = false;
             bsp_display_set_therapy_active(false);
             therapy_alert_on_therapy_stop();
-            if (s && s->active) {
+            if (s) {
                 write_event(s, msg);
+                active_session_unlock(s);
+                session_locked = false;
                 sw_request_finalize(s, "completed",
                                     (int64_t)time(NULL) * 1000, true);
                 s = NULL;
             }
-            return;
+            NOTIFY_RETURN();
         }
         if (ev_type == AS11_EV_THERAPY_START) {
             ESP_LOGI(TAG, ">>> THERAPY START detected");
+            if (!bsp_display_set_therapy_active(true)) {
+                ESP_LOGW(TAG, "TherapyStart ignored: restart already committed");
+                NOTIFY_RETURN();
+            }
             crash_diag_note_activity("therapy_start");
             s_therapy_stopped = false;
             s_in_mask_fit = false;
             s_in_cooldown = false;
             therapy_alert_on_therapy_start();
-            bsp_display_set_therapy_active(true);
             bsp_display_set_therapy_start_time(esp_timer_get_time());
 
             int64_t now_us = esp_timer_get_time();
             bool duplicate = false;
             if (report && report[0] && strcmp(report, s_last_start_report) == 0) {
                 duplicate = true;
-            } else if (s && s->active &&
+            } else if (s &&
                        (now_us - s->start_time_us) / 1000 < SW_START_DEBOUNCE_MS) {
                 duplicate = true;
             }
             if (report && report[0])
                 strlcpy(s_last_start_report, report, sizeof(s_last_start_report));
 
-            if (s && s->active && !duplicate) {
+            if (!duplicate) {
+                s_stream_epoch++;
+                sw_start_intent_end();
+            }
+            if (s && !duplicate) {
                 /* A genuine TherapyStart while a session is still open means
                  * the TherapyStop was missed (BLE dropout across the end of
                  * therapy).  Rotate: without this the sessions glue together,
@@ -2343,15 +2733,20 @@ void session_writer_on_notification(session_writer_t *s, const cJSON *msg)
                  * therapy's StreamData keeps resetting it. */
                 ESP_LOGW(TAG, "TherapyStart while session active — "
                          "missed TherapyStop, rotating session");
+                active_session_unlock(s);
+                session_locked = false;
                 sw_request_finalize(s, "rotated",
                                     (int64_t)time(NULL) * 1000, true);
                 s = NULL;
-            } else if (duplicate && s && s->active) {
+            } else if (duplicate && s) {
                 ESP_LOGI(TAG, "duplicate TherapyStart ignored (echo)");
             }
 
-            if (!s || !s->active) {
-                s = session_writer_start();
+            if (!s) {
+                if (session_writer_start()) {
+                    s = active_session_lock();
+                    session_locked = (s != NULL);
+                }
             }
             if (s) {
                 s_started_from_event = true;
@@ -2360,66 +2755,79 @@ void session_writer_on_notification(session_writer_t *s, const cJSON *msg)
                 ESP_LOGW(TAG, "session_writer_start() failed — "
                          "graph active but NOT recording to SD");
             }
-            return;
+            NOTIFY_RETURN();
         }
         if (ev_type == AS11_EV_MASK_FIT_START) {
+            s_stream_epoch++;
             ESP_LOGI(TAG, ">>> MASK FIT / DIAGNOSTIC START detected (suppressing therapy)");
             s_in_mask_fit = true;
+            sw_start_intent_end();
             bsp_display_set_therapy_active(false);
             /* If a session was started by flow heuristic within the last 15 seconds
              * before the MaskFit event arrived, abort the false session. */
-            if (s && s->active && !s_started_from_event) {
+            if (s && !s_started_from_event) {
                 int64_t dur_ms = (esp_timer_get_time() - s->start_time_us) / 1000;
                 if (dur_ms < 15000) {
                     ESP_LOGW(TAG, "aborting false session opened by Mask Fit airflow (%lld ms)",
                              (long long)dur_ms);
+                    active_session_unlock(s);
+                    session_locked = false;
                     sw_request_finalize(s, "aborted_mask_fit",
                                         (int64_t)time(NULL) * 1000, false);
                     s = NULL;
                 }
             }
-            return;
+            NOTIFY_RETURN();
         }
         if (ev_type == AS11_EV_MASK_FIT_STOP) {
             ESP_LOGI(TAG, ">>> MASK FIT / DIAGNOSTIC STOP detected");
             s_in_mask_fit = false;
-            return;
+            NOTIFY_RETURN();
         }
         if (ev_type == AS11_EV_COOLDOWN_START) {
+            s_stream_epoch++;
             ESP_LOGI(TAG, ">>> COOLDOWN (tube drying) STARTED");
             s_in_cooldown = true;
             s_therapy_stopped = true;
+            sw_start_intent_end();
             bsp_display_set_therapy_active(false);
             therapy_alert_on_therapy_stop();
-            if (s && s->active) {
+            if (s) {
                 ESP_LOGI(TAG, "finalizing therapy session on CooldownStarted");
                 write_event(s, msg);
+                active_session_unlock(s);
+                session_locked = false;
                 sw_request_finalize(s, "completed",
                                     (int64_t)time(NULL) * 1000, true);
                 s = NULL;
             }
-            return;
+            NOTIFY_RETURN();
         }
         if (ev_type == AS11_EV_COOLDOWN_STOP) {
             ESP_LOGI(TAG, ">>> COOLDOWN (tube drying) STOPPED");
             s_in_cooldown = false;
-            return;
+            NOTIFY_RETURN();
         }
         if (ev_type == AS11_EV_STANDBY_START) {
+            s_stream_epoch++;
+            sw_start_intent_end();
+            s_therapy_stopped = true;
             ESP_LOGD(TAG, ">>> STANDBY STARTED");
-            if (s && s->active) {
+            if (s) {
                 ESP_LOGI(TAG, "finalizing therapy session on StandbyStarted");
                 s_therapy_stopped = true;
                 bsp_display_set_therapy_active(false);
                 therapy_alert_on_therapy_stop();
                 write_event(s, msg);
+                active_session_unlock(s);
+                session_locked = false;
                 sw_request_finalize(s, "completed",
                                     (int64_t)time(NULL) * 1000, true);
                 s = NULL;
             }
-            return;
+            NOTIFY_RETURN();
         }
-        if (ev_type != AS11_EV_NONE) return;
+        if (ev_type != AS11_EV_NONE) NOTIFY_RETURN();
 
         cJSON *params = cJSON_GetObjectItem(msg, "params");
         if (params) {
@@ -2439,7 +2847,7 @@ void session_writer_on_notification(session_writer_t *s, const cJSON *msg)
                         }
                     }
                 }
-                return;
+                NOTIFY_RETURN();
             }
             /* _ZLE ValueChange — the AS11 omits reportTime here, so capture
              * the NTP time at receipt and inject it.  The pair (AS11 event +
@@ -2457,7 +2865,7 @@ void session_writer_on_notification(session_writer_t *s, const cJSON *msg)
                             zle_val = (int)val->valuedouble;
                     }
                 }
-                if (s && s->active) {
+                if (s) {
                     cJSON *zle_copy = cJSON_Duplicate(msg, 1);
                     if (zle_copy) {
                         cJSON *zp = cJSON_GetObjectItem(zle_copy, "params");
@@ -2478,15 +2886,17 @@ void session_writer_on_notification(session_writer_t *s, const cJSON *msg)
                 }
                 ESP_LOGI(TAG, ">>> _ZLE ValueChange: %d (%s)",
                          zle_val, zle_val == 1 ? "rising edge" : "falling edge");
-                return;
+                NOTIFY_RETURN();
             }
         }
 
-        if (s && s->active) write_event(s, msg);
-        return;
+        if (s) write_event(s, msg);
+        NOTIFY_RETURN();
     }
 
-    if (s && s->active) write_event(s, msg);
+    if (s) write_event(s, msg);
+    NOTIFY_RETURN();
+#undef NOTIFY_RETURN
 }
 
 /* ════════════════════════════════════════════════════════════════════

--- a/main/session_writer.h
+++ b/main/session_writer.h
@@ -89,8 +89,18 @@ void session_writer_recover(void);
 void session_writer_enable_deferred_export(void);
 
 /* Days still awaiting an automatic export rebuild, as a JSON array of
- * {day, attempts, needs_attention}.  Caller frees. */
+ * {day, attempts, needs_attention, reason}.  Caller frees. */
 esp_err_t session_writer_pending_export_json(char **out_json);
+
+/* Durable rebuilt-day handoff, polled by the upload scheduler. Token is an
+ * opaque marker key plus publication nonce (provide at least 128 bytes). Both calls use
+ * a zero-wait EXPORT transaction. The scheduler must durably invalidate the
+ * day index before acknowledging, and must never wait here holding another
+ * task's EXPORT lease. A failed acknowledgement leaves retryable intent. */
+bool session_writer_next_upload_invalidation(uint32_t *day, char *token, size_t token_len);
+esp_err_t session_writer_ack_upload_invalidation(uint32_t day, const char *token);
+/* Persist before retiring the shared rebuild publication sentinel. */
+esp_err_t session_writer_mark_upload_invalidation(const char *day);
 
 /* Check whether an _SNC ValueChange notification has been received since
  * the last call.  Returns true and stores the new value in *out_value

--- a/main/session_writer.h
+++ b/main/session_writer.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include "esp_err.h"
 #include "cJSON.h"
@@ -36,6 +37,7 @@ typedef struct session_writer session_writer_t;
 esp_err_t session_writer_init(void);
 
 /* Start a new therapy session.
+ * Atomically acquires the SD recording claim before allocating session buffers.
  * Creates noon-day folder under .somnotrace/sessions/streams/YYYYMMDD/ and opens
  * YYYYMMDD_HHMMSS_*.snt files with prefix-based naming.
  * Returns a handle or NULL on failure. */
@@ -56,6 +58,12 @@ void session_writer_on_notification(session_writer_t *s, const cJSON *msg);
 /* Fast-path processor for StreamData notifications using raw JSON.
  * Bypasses cJSON tree building for the high-frequency StreamData path.
  * Handles flow display push, active-flow detection, and sample routing. */
+/* False means admission is pending and the payload was not consumed. The
+ * notification owner retains/replays oldest first and cancels its copies on
+ * STOP/transport loss. Admission uses no filesystem I/O and no retry sleep. */
+bool session_writer_try_stream_data_raw(const char *json, int len);
+void session_writer_on_transport_loss(void);
+uint32_t session_writer_stream_epoch(void);
 void session_writer_on_stream_data_raw(const char *json, int len);
 
 /* Returns true if a session is currently active. */

--- a/main/snt_format.h
+++ b/main/snt_format.h
@@ -42,6 +42,10 @@ extern "C" {
 #define SNT_TIER_RAW       0            /* L0 raw sample stream */
 #define SNT_TIER_MINMAX    1            /* L1 MinMax stream */
 
+/* header.reserved bit: the source contains positioned missing-data gaps.
+ * Continuous EDF export must retain these streams as raw SNT. */
+#define SNT_POSITION_GAP_FLAG 0x0001U
+
 /* Authoritative 28-byte packed SNT header */
 typedef struct __attribute__((packed)) {
     uint32_t magic;            /* 0x534E5442 "SNTB"                  */

--- a/main/somnotrace_lvgl_psram.h
+++ b/main/somnotrace_lvgl_psram.h
@@ -1,0 +1,24 @@
+/* PSRAM-first allocator used only by LVGL on SomnoTrace's 7-inch targets. */
+#pragma once
+
+#include <stddef.h>
+#include "esp_heap_caps.h"
+
+static inline void *somnotrace_lvgl_alloc(size_t size)
+{
+    return heap_caps_malloc_prefer(size, 2,
+                                   MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT,
+                                   MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+}
+
+static inline void *somnotrace_lvgl_realloc(void *ptr, size_t size)
+{
+    return heap_caps_realloc_prefer(ptr, size, 2,
+                                    MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT,
+                                    MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+}
+
+static inline void somnotrace_lvgl_free(void *ptr)
+{
+    heap_caps_free(ptr);
+}

--- a/main/time_sync.c
+++ b/main/time_sync.c
@@ -68,6 +68,40 @@ static int64_t s_drift_ms = 0;       /* last known drift (NTP - AS11) */
 static int64_t s_drift_at_ms = 0;    /* NTP epoch ms when drift was measured */
 static bool s_drift_loaded = false;  /* true once s_drift_ms/at loaded from NVS */
 static const char *s_drift_src = "none";  /* provenance of s_drift_ms */
+static portMUX_TYPE s_drift_lock = portMUX_INITIALIZER_UNLOCKED;
+
+typedef struct {
+    int64_t drift_ms;
+    int64_t measured_at_ms;
+    bool loaded;
+    const char *source;
+} drift_cache_snapshot_t;
+
+/* The drift cache is read by the BLE/session tasks and written by NTP/NVS
+ * recovery paths.  ESP32-S3 cannot atomically load or store int64_t values,
+ * so every field (including provenance) must be published as one snapshot. */
+static drift_cache_snapshot_t drift_cache_load(void)
+{
+    drift_cache_snapshot_t snap;
+    portENTER_CRITICAL(&s_drift_lock);
+    snap.drift_ms = s_drift_ms;
+    snap.measured_at_ms = s_drift_at_ms;
+    snap.loaded = s_drift_loaded;
+    snap.source = s_drift_src;
+    portEXIT_CRITICAL(&s_drift_lock);
+    return snap;
+}
+
+static void drift_cache_store(int64_t drift_ms, int64_t measured_at_ms,
+                              const char *source)
+{
+    portENTER_CRITICAL(&s_drift_lock);
+    s_drift_ms = drift_ms;
+    s_drift_at_ms = measured_at_ms;
+    s_drift_loaded = true;
+    s_drift_src = source ? source : "none";
+    portEXIT_CRITICAL(&s_drift_lock);
+}
 
 static void sntp_sync_cb(struct timeval *tv)
 {
@@ -236,18 +270,35 @@ bool time_is_usable(void)
 
 int64_t time_source_drift_age_ms(void)
 {
-    if (s_drift_at_ms == 0) return -1;
+    drift_cache_snapshot_t snap = drift_cache_load();
+    if (!snap.loaded || snap.measured_at_ms == 0) return -1;
     int64_t now_ms = (int64_t)time(NULL) * 1000;
-    return now_ms - s_drift_at_ms;
+    return now_ms - snap.measured_at_ms;
 }
 
 bool time_sync_has_drift(void)
 {
-    if (s_drift_loaded) return true;
-    return load_drift_from_nvs();
+    if (drift_cache_load().loaded) return true;
+    load_drift_from_nvs();
+    return drift_cache_load().loaded;
 }
 
 static bool load_drift_from_sd(void);
+
+bool time_sync_peek_drift_snapshot(time_drift_snapshot_t *out)
+{
+    if (!out) return false;
+    memset(out, 0, sizeof(*out));
+    out->source = "none";
+    drift_cache_snapshot_t snap = drift_cache_load();
+    if (!snap.loaded) return false;
+
+    out->available = true;
+    out->drift_ms = snap.drift_ms;
+    out->measured_at_ms = snap.measured_at_ms;
+    out->source = snap.source;
+    return true;
+}
 
 bool time_sync_get_drift_snapshot(time_drift_snapshot_t *out)
 {
@@ -255,18 +306,12 @@ bool time_sync_get_drift_snapshot(time_drift_snapshot_t *out)
     memset(out, 0, sizeof(*out));
     out->source = "none";
 
-    if (!s_drift_loaded) {
+    if (!drift_cache_load().loaded) {
         /* NVS first, then the SD upgrade fallback (devices that predate the
          * NVS keys still have drift recorded in session manifests). */
         if (!load_drift_from_nvs()) load_drift_from_sd();
     }
-    if (!s_drift_loaded) return false;
-
-    out->available = true;
-    out->drift_ms = s_drift_ms;
-    out->measured_at_ms = s_drift_at_ms;
-    out->source = s_drift_src;
-    return true;
+    return time_sync_peek_drift_snapshot(out);
 }
 
 /* ── Drift persistence ─────────────────────────────────────────────── */
@@ -293,10 +338,7 @@ static esp_err_t do_save_drift(void *arg)
 
 void time_sync_save_drift(int64_t drift_ms, int64_t measured_at_ms)
 {
-    s_drift_ms = drift_ms;
-    s_drift_at_ms = measured_at_ms;
-    s_drift_loaded = true;
-    s_drift_src = "nvs";
+    drift_cache_store(drift_ms, measured_at_ms, "nvs");
 
     drift_save_args_t args = { .drift_ms = drift_ms, .measured_at_ms = measured_at_ms };
     esp_err_t err = nvs_writer_run(do_save_drift, &args);
@@ -348,10 +390,7 @@ static bool load_drift_from_nvs(void)
     nvs_writer_run(do_load_drift_from_nvs, &args);
 
     if (args.ok) {
-        s_drift_ms = args.drift_ms;
-        s_drift_at_ms = args.measured_at_ms;
-        s_drift_loaded = true;
-        s_drift_src = "nvs";
+        drift_cache_store(args.drift_ms, args.measured_at_ms, "nvs");
         ESP_LOGI(TAG, "drift loaded from NVS: %lld ms (age %lld s)",
                  (long long)args.drift_ms,
                  (long long)((time(NULL) * 1000 - args.measured_at_ms) / 1000));
@@ -434,10 +473,7 @@ static bool load_drift_from_sd(void)
     closedir(streams_dir);
 
     if (found) {
-        s_drift_ms = best_drift;
-        s_drift_at_ms = best_start;
-        s_drift_loaded = true;
-        s_drift_src = "sd";
+        drift_cache_store(best_drift, best_start, "sd");
         ESP_LOGI(TAG, "drift loaded from SD: %lld ms (session start %lld)",
                  (long long)best_drift, (long long)best_start);
     }
@@ -452,11 +488,14 @@ esp_err_t time_sync_recover_from_as11(void)
     }
 
     /* Load drift from NVS, or fall back to SD scan for upgrades. */
-    if (!s_drift_loaded) {
+    drift_cache_snapshot_t drift = drift_cache_load();
+    if (!drift.loaded) {
         if (!load_drift_from_nvs() && !load_drift_from_sd()) {
             ESP_LOGW(TAG, "recover_from_as11: no drift sample available");
             return ESP_ERR_NOT_FOUND;
         }
+        drift = drift_cache_load();
+        if (!drift.loaded) return ESP_ERR_NOT_FOUND;
     }
 
     /* Query AS11 wall clock. */
@@ -469,7 +508,9 @@ esp_err_t time_sync_recover_from_as11(void)
     }
 
     /* Apply: wall = AS11 + drift. */
-    int64_t wall_ms = as11_ms + s_drift_ms;
+    int64_t wall_ms = as11_ms + drift.drift_ms;
+    int64_t drift_age_ms = drift.measured_at_ms > 0
+                         ? wall_ms - drift.measured_at_ms : -1;
     struct timeval tv = { .tv_sec = wall_ms / 1000, .tv_usec = (wall_ms % 1000) * 1000 };
     settimeofday(&tv, NULL);
 
@@ -483,8 +524,8 @@ esp_err_t time_sync_recover_from_as11(void)
              "(AS11=%lld drift=%lld ms, drift age=%lld s)",
              tm_info.tm_year + 1900, tm_info.tm_mon + 1, tm_info.tm_mday,
              tm_info.tm_hour, tm_info.tm_min, tm_info.tm_sec,
-             (long long)as11_ms, (long long)s_drift_ms,
-             (long long)(time_source_drift_age_ms() / 1000));
+             (long long)as11_ms, (long long)drift.drift_ms,
+             (long long)(drift_age_ms / 1000));
 
     return ESP_OK;
 }

--- a/main/time_sync.h
+++ b/main/time_sync.h
@@ -125,3 +125,6 @@ esp_err_t time_sync_recover_from_as11(void);
  * Must be called after time_sync_init(). Subsequent periodic re-syncs do
  * not trigger the failure path. */
 bool time_sync_wait_initial(void);
+
+/* Copy cached drift without NVS or SD access. */
+bool time_sync_peek_drift_snapshot(time_drift_snapshot_t *out);

--- a/main/touch_observation.c
+++ b/main/touch_observation.c
@@ -1,0 +1,78 @@
+#include "touch_observation.h"
+#include <limits.h>
+
+static void withdraw(touch_observation_t *s)
+{
+    if (s->valid || s->pressed) ++s->continuity;
+    s->valid = false;
+    s->pressed = false;
+}
+
+void touch_observation_update(touch_observation_t *s, int64_t now,
+                              int error, bool frame, bool pressed,
+                              uint16_t x, uint16_t y)
+{
+    if (!s) return;
+    if ((s->observed && (now < s->observed_us ||
+                        now - s->observed_us > TOUCH_OBSERVATION_MAX_AGE_US)) ||
+        (s->valid && s->pressed && (now < s->frame_us ||
+                      now - s->frame_us > TOUCH_OBSERVATION_MAX_AGE_US)))
+        withdraw(s);
+    s->observed = true;
+    s->observed_us = now;
+    s->last_error = error;
+    if (error) {
+        withdraw(s);
+        if (s->errors != UINT32_MAX) ++s->errors;
+        if (s->consecutive_errors != UINT8_MAX) ++s->consecutive_errors;
+        return;
+    }
+    s->consecutive_errors = 0;
+    s->recovering = false;
+    s->preventive_recovery = false;
+    if (frame) {
+        s->frame_us = now;
+        s->valid = true;
+        s->pressed = pressed;
+        s->x = x;
+        s->y = y;
+    }
+    /* GT911 need not repeat zero-contact frames while idle. A known release
+     * remains valid through successful status polls; only active points age
+     * out. Bus errors or a missed polling interval still break continuity. */
+}
+
+void touch_observation_recovering(touch_observation_t *s)
+{
+    if (!s) return;
+    withdraw(s);
+    s->recovering = true;
+    s->preventive_recovery = false;
+    if (s->recovery_attempts != UINT32_MAX) ++s->recovery_attempts;
+}
+
+void touch_observation_preventive_recovering(touch_observation_t *s)
+{
+    if (!s) return;
+    withdraw(s);
+    s->recovering = true;
+    s->preventive_recovery = true;
+    if (s->recovery_attempts != UINT32_MAX) ++s->recovery_attempts;
+    if (s->preventive_recovery_attempts != UINT32_MAX)
+        ++s->preventive_recovery_attempts;
+}
+
+bool touch_observation_healthy(const touch_observation_t *s, int64_t now)
+{
+    return s && s->observed && !s->recovering &&
+           s->consecutive_errors < TOUCH_OBSERVATION_FAILURE_LIMIT &&
+           now >= s->observed_us &&
+           now - s->observed_us <= TOUCH_OBSERVATION_MAX_AGE_US;
+}
+
+bool touch_observation_pressed(const touch_observation_t *s, int64_t now)
+{
+    return touch_observation_healthy(s, now) && !s->last_error &&
+           s->valid && s->pressed && now >= s->frame_us &&
+           now - s->frame_us <= TOUCH_OBSERVATION_MAX_AGE_US;
+}

--- a/main/touch_observation.h
+++ b/main/touch_observation.h
@@ -1,0 +1,38 @@
+/* Timestamped touch observations; no RTOS, allocation or hardware ownership. */
+#pragma once
+#include <stdbool.h>
+#include <stdint.h>
+
+#define TOUCH_OBSERVATION_MAX_AGE_US 100000LL
+#define TOUCH_OBSERVATION_FAILURE_LIMIT 3U
+
+typedef struct {
+    uint16_t x, y;
+    bool pressed;
+    bool observed;
+    bool valid;
+    bool recovering;
+    bool preventive_recovery;
+    uint8_t consecutive_errors;
+    uint32_t errors;
+    uint32_t recovery_attempts;
+    uint32_t preventive_recovery_requests;
+    uint32_t preventive_recovery_attempts;
+    uint32_t visibility_requests;
+    int64_t visibility_requested_us; /* Original demand time, retained over retries. */
+    uint32_t continuity;
+    int64_t observed_us;
+    int64_t frame_us;
+    int last_error;
+} touch_observation_t;
+
+/* A successful status read without new data may retain a point only while
+ * observation is continuous. An error, reset or scheduling gap withdraws it
+ * until a new complete controller frame arrives. */
+void touch_observation_update(touch_observation_t *state, int64_t now_us,
+                              int error, bool frame, bool pressed,
+                              uint16_t x, uint16_t y);
+void touch_observation_recovering(touch_observation_t *state);
+void touch_observation_preventive_recovering(touch_observation_t *state);
+bool touch_observation_healthy(const touch_observation_t *state, int64_t now_us);
+bool touch_observation_pressed(const touch_observation_t *state, int64_t now_us);

--- a/scripts/backend_realtime_test.py
+++ b/scripts/backend_realtime_test.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Compile actual production C against deterministic faulting transport/RTOS doubles."""
+from pathlib import Path
+import subprocess, tempfile
+ROOT = Path(__file__).resolve().parents[1]
+
+def function(source, name):
+    # Extraction chooses the production function; none of its logic is modeled.
+    import re
+    m = re.search(r'^(?:static\s+)?[\w\s*]+\b'+re.escape(name)+r'\([^;]*?\)\s*\{', source, re.M)
+    assert m, name
+    start=m.start(); i=m.end(); depth=1
+    while depth:
+        if source[i]=='{': depth+=1
+        elif source[i]=='}': depth-=1
+        i+=1
+    return source[start:i]
+
+def run(name, source, includes=()):
+    with tempfile.TemporaryDirectory(prefix='somno-backend-') as tmp:
+        p=Path(tmp); (p/'test.c').write_text(source)
+        subprocess.run(['cc','-std=c11','-D_DARWIN_C_SOURCE','-Wall','-Wextra','-Werror',
+            '-Wno-unused-function','-Wno-unused-parameter','-pthread',
+            *sum((['-I',str(ROOT/x)] for x in includes),[]),str(p/'test.c'),'-o',str(p/'test')],check=True)
+        subprocess.run([str(p/'test')],check=True,timeout=10)
+    print(name+' passed')
+
+COMMON = '''#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+'''
+
+ble=(ROOT/'main/as11_ble.c').read_text()
+smb=(ROOT/'components/uploader/uploader_smb.c').read_text()
+tls=(ROOT/'components/uploader/uploader_sleephq.c').read_text()
+
+# SMB's *same* wait pump is used for connect, open, mkdir, writes, close,
+# mtime and disconnect. Destroy invokes any pending callback synchronously.
+smba=smb[smb.index('static struct smb2_context *s_smb;'):smb.index('/* Upload a single local')]
+run('SMB idle timeout, cancellation, late callback ownership', COMMON+r'''
+#include <time.h>
+#include <sys/time.h>
+#include <sys/poll.h>
+#include "smb2.h"
+#include "libsmb2.h"
+#include "libsmb2-raw.h"
+#define ESP_LOGW(...) ((void)0)
+static int64_t clock_us, cancel_at;
+static int destroyed, serviced, completed_at, submitted_status, write_slice, write_seen;
+static smb2_command_cb cb;
+static void *cb_arg;
+static struct smb2_context *ctx_value=(struct smb2_context *)(uintptr_t)1;
+static struct smb2fh *fh_value=(struct smb2fh *)(uintptr_t)2;
+static bool uploader_should_cancel(void) { return cancel_at >= 0 && clock_us >= cancel_at; }
+static int64_t esp_timer_get_time(void) { return clock_us; }
+int poll(struct pollfd *fd, nfds_t n, int ms) { assert(ms<=20); clock_us+=ms*1000; fd->revents=0; return 0; }
+void smb2_destroy_context(struct smb2_context *ctx) { assert(ctx==ctx_value); ++destroyed; if(cb) { smb2_command_cb f=cb; cb=NULL; f(ctx,-ECANCELED,NULL,cb_arg); } }
+const char *smb2_get_error(struct smb2_context *ctx) { assert(!destroyed); return "fake"; }
+int smb2_get_fd(struct smb2_context *ctx) { assert(!destroyed); return 7; }
+int smb2_which_events(struct smb2_context *ctx) { return POLLIN; }
+int smb2_service(struct smb2_context *ctx, int events) { ++serviced; if(completed_at && clock_us>=completed_at && cb) { smb2_command_cb f=cb; cb=NULL; f(ctx,submitted_status,fh_value,cb_arg); } return 0; }
+static int submit(smb2_command_cb f, void *arg) { cb=f; cb_arg=arg; submitted_status=0; return 0; }
+int smb2_connect_share_async(struct smb2_context *c,const char *h,const char *s,const char *u,smb2_command_cb f,void *a) { return submit(f,a); }
+int smb2_mkdir_async(struct smb2_context *c,const char *p,smb2_command_cb f,void *a) { return submit(f,a); }
+int smb2_open_async(struct smb2_context *c,const char *p,int flags,smb2_command_cb f,void *a) { return submit(f,a); }
+int smb2_pwrite_async(struct smb2_context *c,struct smb2fh *h,const uint8_t *b,uint32_t n,uint64_t off,smb2_command_cb f,void *a) { submit(f,a); if(write_slice) { assert(off==(uint64_t)write_seen && b[0]=='A'+write_seen); submitted_status=n<(uint32_t)write_slice?(int)n:write_slice; write_seen+=submitted_status; } return 0; }
+int smb2_close_async(struct smb2_context *c,struct smb2fh *h,smb2_command_cb f,void *a) { return submit(f,a); }
+int smb2_disconnect_share_async(struct smb2_context *c,smb2_command_cb f,void *a) { return submit(f,a); }
+smb2_file_id *smb2_get_file_id(struct smb2fh *fh) { static smb2_file_id id; return &id; }
+struct smb2_pdu *smb2_cmd_set_info_async(struct smb2_context *c,struct smb2_set_info_request *r,smb2_command_cb f,void *a) { submit(f,a); return (struct smb2_pdu *)3; }
+void smb2_queue_pdu(struct smb2_context *c,struct smb2_pdu *p) { }
+'''+smba+r'''
+static void reset(void) { clock_us=0; cancel_at=-1; destroyed=serviced=completed_at=submitted_status=write_slice=write_seen=0; cb=NULL; s_smb=ctx_value; }
+int main(void) {
+ for(int op=0;op<7;++op) {
+  reset(); cancel_at=41000;
+  switch(op) {
+   case 0: assert(smb_connect(s_smb,"1.2.3.4","share","user")<0); break;
+   case 1: assert(smb_mkdir(s_smb,"path")<0); break;
+   case 2: assert(!smb_open(s_smb,"path",0)); break;
+   case 3: { uint8_t *buf=malloc(32); assert(smb_write(s_smb,fh_value,buf,32,0)<0); assert(destroyed==1); free(buf); break; }
+   case 4: assert(smb_close(s_smb,fh_value)<0); break;
+   case 5: assert(smb_set_mtime(s_smb,fh_value,99)<0); break;
+   case 6: assert(smb_disconnect(s_smb)<0); break;
+  }
+  assert(clock_us<=61000 && destroyed==1 && !s_smb && !cb);
+  assert(smb_close(ctx_value,fh_value)<0); assert(destroyed==1);
+ }
+ reset(); assert(smb_set_mtime(s_smb,fh_value,0)<0);
+ assert(clock_us==5000000 && serviced==250 && destroyed==1);
+ reset(); completed_at=40000; assert(smb_open(s_smb,"path",0)==fh_value); assert(!destroyed);
+ smb_abort(); assert(destroyed==1);
+ reset(); completed_at=20000; write_slice=2;
+ assert(smb_write_all(s_smb,fh_value,(const uint8_t *)"ABCDE",5,0)==5 && write_seen==5);
+ smb_abort(); assert(destroyed==1);
+}
+''', ('third_party/libsmb2/include/smb2','third_party/libsmb2/include'))
+
+# Bound every TLS request even when peer trickles data forever.
+a=tls.index('static int64_t s_request_deadline;');b=tls.index('/* Read a complete',a)
+run('TLS WANT_READ/WANT_WRITE, trickle deadline and cancellation',COMMON+r'''
+#include <sys/types.h>
+typedef int esp_tls_t;
+#define ESP_TLS_ERR_SSL_WANT_READ -2
+#define ESP_TLS_ERR_SSL_WANT_WRITE -3
+#define pdMS_TO_TICKS(x) (x)
+static int64_t now, cancel_at; static int mode, calls;
+static bool uploader_should_cancel(void) { return cancel_at>=0 && now>=cancel_at; }
+static int64_t esp_timer_get_time(void) { return now; }
+static void vTaskDelay(int ms) { assert(ms<=20); now+=ms*1000; }
+static ssize_t esp_tls_conn_read(esp_tls_t *tls,void *buf,size_t n) { ++calls; return ESP_TLS_ERR_SSL_WANT_READ; }
+static ssize_t esp_tls_conn_write(esp_tls_t *tls,const void *buf,size_t n) { ++calls; if(mode) { now+=10000; return 1; } return ESP_TLS_ERR_SSL_WANT_WRITE; }
+'''+tls[a:b]+r'''
+int main(void) {
+ char buf[1000]={0}; s_request_deadline=100000; cancel_at=-1;
+ assert(shq_tls_read(NULL,buf,1)==-1 && now==100000 && calls==5);
+ now=calls=0; cancel_at=21000;
+ assert(shq_tls_write_all(NULL,buf,10)==-1 && now==40000 && calls==2);
+ now=calls=0; cancel_at=-1; mode=1;
+ assert(shq_tls_write_all(NULL,buf,1000)==-1 && now==100000 && calls==10);
+ now=calls=0; assert(shq_tls_write_all(NULL,buf,3)==3 && calls==3);
+}
+''')
+
+# Decoded bytes retained exactly; admission does not duplicate or reorder them.
+a=ble.index('#define PENDING_STREAM_COUNT');b=ble.index('static void notif_proc_task',a)
+run('Pending stream bounded retention, replay and STOP fence',COMMON+r'''
+#define MALLOC_CAP_SPIRAM 1
+static bool admitted; static int accepted, loss, allocs;
+static char seen[256];
+static bool session_writer_try_stream_data_raw(const char *s,int n) { if(!admitted) return false; memcpy(seen+accepted,s,n); accepted+=n; return true; }
+static void *heap_caps_malloc(size_t n,int caps) { ++allocs; return malloc(n); }
+static void notif_mark_loss(void) { ++loss; }
+'''+ble[a:b]+r'''
+int main(void) {
+ pending_stream_submit("A",1); pending_stream_submit("B",1); pending_stream_replay();
+ assert(s_pending_count==2 && accepted==0);
+ admitted=true; pending_stream_replay(); assert(s_pending_count==0 && accepted==2 && !memcmp(seen,"AB",2));
+ pending_stream_replay(); assert(accepted==2);
+ admitted=false; pending_stream_submit("old",3); pending_stream_clear(); // decoded STOP fence
+ admitted=true; pending_stream_replay(); pending_stream_submit("new",3);
+ assert(accepted==5 && !memcmp(seen,"ABnew",5));
+ admitted=false; for(int i=0;i<PENDING_STREAM_COUNT+1;++i) pending_stream_submit("x",1);
+ assert(loss==1 && s_pending_count==0 && s_pending_bytes==0);
+ pending_stream_submit("z",1); pending_stream_clear(); assert(!s_pending_count);
+}
+''')
+
+# Timeout cleanup cannot free a semaphore/collector while decoder holds its mutex.
+run('Spool withdrawal joins decoder before reclamation', COMMON+r'''
+#include <pthread.h>
+#include <stdatomic.h>
+#define portMAX_DELAY 0
+#define BLE_HS_CONN_HANDLE_NONE -1
+#define BLE_ERR_REM_USER_CONN_TERM 0
+static pthread_mutex_t lock=PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t gate=PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t cond=PTHREAD_COND_INITIALIZER;
+static pthread_mutex_t *s_spool_mtx=&lock;
+static bool s_spool_tainted; static int s_conn_handle=-1, freed, entered;
+static atomic_int decoder_live;
+typedef struct { struct { void *data; } frags[32]; int frag_count; void *sem; } spool_collector_t;
+static spool_collector_t *s_spool_collector;
+static void xSemaphoreTake(pthread_mutex_t *m,int timeout) { pthread_mutex_lock(&gate); entered=1; pthread_cond_broadcast(&cond); pthread_mutex_unlock(&gate); pthread_mutex_lock(m); }
+static void xSemaphoreGive(pthread_mutex_t *m) { pthread_mutex_unlock(m); }
+static void vSemaphoreDelete(void *sem) { assert(!atomic_load(&decoder_live)); assert(!s_spool_collector); ++freed; free(sem); }
+static void ble_gap_terminate(int a,int b) { }
+'''+function(ble,'spool_withdraw')+r'''
+static void *withdraw(void *p) { spool_withdraw(p,true); return NULL; }
+int main(void) {
+ spool_collector_t coll={0}; coll.sem=malloc(8); s_spool_collector=&coll;
+ pthread_mutex_lock(&lock); atomic_store(&decoder_live,1);
+ pthread_t thread; pthread_create(&thread,NULL,withdraw,&coll);
+ pthread_mutex_lock(&gate); while(!entered) pthread_cond_wait(&cond,&gate); pthread_mutex_unlock(&gate);
+ assert(!freed && s_spool_collector==&coll);
+ coll.frags[coll.frag_count++].data=malloc(12); // decoder was already in flight
+ atomic_store(&decoder_live,0); pthread_mutex_unlock(&lock);
+ pthread_join(thread,NULL);
+ assert(freed==1 && !coll.sem && !coll.frag_count && !s_spool_collector && s_spool_tainted);
+ pthread_mutex_lock(&lock); assert(!s_spool_collector); pthread_mutex_unlock(&lock); // late decoder
+}
+''')
+
+# Reply ownership and exact ID matching, using production accept/clear/wait.
+run('RPC late/mismatched/duplicate response fencing',COMMON+r'''
+#define portENTER_CRITICAL(p) ((void)(p))
+#define portEXIT_CRITICAL(p) ((void)(p))
+#define pdTRUE 1
+#define pdMS_TO_TICKS(x) (x)
+static int s_response_lock, sem_count, deleted;
+static void *s_resp_sem;
+static int64_t now;
+typedef struct cJSON { double valuedouble; bool number; struct cJSON *id; } cJSON;
+static cJSON *s_resp_json, *s_response_original_id;
+static uint32_t s_expected_response_id;
+static cJSON *cJSON_GetObjectItemCaseSensitive(cJSON *p,const char *key) { return p->id; }
+static bool cJSON_IsNumber(cJSON *p) { return p && p->number; }
+static void cJSON_Delete(cJSON *p) { if(p) { cJSON_Delete(p->id); ++deleted; free(p); } }
+static bool cJSON_ReplaceItemInObjectCaseSensitive(cJSON *p,const char *key,cJSON *id) { cJSON_Delete(p->id); p->id=id; return true; }
+static int xSemaphoreGive(void *s) { ++sem_count; return 1; }
+static int xSemaphoreTake(void *s,int ticks) { if(sem_count) { --sem_count; return 1; } now+=(int64_t)ticks*1000; return 0; }
+static int64_t esp_timer_get_time(void) { return now; }
+'''+function(ble,'rpc_accept_response')+function(ble,'clear_response')+function(ble,'wait_response')+r'''
+static cJSON *reply(int id) { cJSON *p=calloc(1,sizeof(*p)); p->id=calloc(1,sizeof(*p)); p->id->number=true; p->id->valuedouble=id; return p; }
+int main(void) {
+ s_expected_response_id=101; rpc_accept_response(reply(100)); assert(!s_resp_json && !sem_count);
+ rpc_accept_response(reply(101)); cJSON *first=s_resp_json;
+ rpc_accept_response(reply(101)); assert(s_resp_json==first && sem_count==1);
+ cJSON *r=wait_response(50); assert(r==first && !s_expected_response_id); cJSON_Delete(r);
+ clear_response(); s_expected_response_id=102; sem_count=3;
+ assert(!wait_response(50) && now==50000 && !s_expected_response_id);
+ rpc_accept_response(reply(102)); assert(!s_resp_json);
+ s_expected_response_id=103; rpc_accept_response(reply(102)); assert(!s_resp_json);
+ rpc_accept_response(reply(103)); r=wait_response(50); assert(r && r->id->valuedouble==103); cJSON_Delete(r);
+ clear_response(); assert(!sem_count && deleted==12);
+}
+''')
+
+# The actual scheduler transaction: preparation outside lease; interruption
+# leaves groups pending and no transport finalization claims success.
+sched=(ROOT/'components/uploader/upload_sched.c').read_text()
+run('Scheduler recording handoff and uncommitted-day rollback',COMMON+r'''
+#include "uploader.h"
+#define ESP_LOGI(...) ((void)0)
+#define ESP_LOGW(...) ((void)0)
+#define MALLOC_CAP_SPIRAM 1
+#define LEASE_WAIT_MS 5000
+#define FAILS_BEFORE_SWITCH 2
+#define portMAX_DELAY 0
+#define SB_IDLE 0
+#define SB_UPLOADING 1
+#define SB_COOLDOWN 2
+static int s_lock, held, prepares, ended, finalizes, put_count, cancelled, mode, commits;
+typedef struct { const upload_backend_t *be; int slot,state,n_units,cur_unit; uint32_t last_ok_s; char cur_day[12],err[80]; } backend_rt_t;
+static upload_day_t day={.day=20260906,.n_groups=2};
+static void *heap_caps_malloc(size_t n,int cap) { return malloc(n); }
+static void *heap_caps_calloc(size_t n,size_t sz,int cap) { return calloc(n,sz); }
+static int xSemaphoreTake(int lock,int timeout) { return 1; }
+static void xSemaphoreGive(int lock) {}
+static void set_be_state(backend_rt_t *r,int state) { r->state=state; }
+static void set_be_error(backend_rt_t *r,const char *s) {}
+static void cooldown_enter(backend_rt_t *r,const char *s,bool permanent) { r->state=SB_COOLDOWN; }
+static void cooldown_reset(backend_rt_t *r) {}
+static uint32_t now_s(void) { return 100; }
+bool uploader_should_cancel(void) { return cancelled; }
+bool uploader_lease_take(uint32_t timeout) { assert(!held); if(cancelled)return false; held=1; return true; }
+void uploader_lease_give(void) { assert(held); held=0; }
+int upload_index_day_count(void) { return 1; }
+upload_day_t *upload_index_day_at(int n) { return &day; }
+upload_day_t *upload_index_day(uint32_t d,bool create) { return &day; }
+upload_group_t *upload_index_group(upload_day_t *d,uint32_t p,bool create) { return &d->groups[0]; }
+uint64_t upload_index_bundle_ok_fp(int slot) { return 0; }
+esp_err_t upload_index_set_bundle_ok(int slot,uint64_t fp) { assert(held); ++commits; return ESP_OK; }
+esp_err_t upload_index_save_day(upload_day_t *d) { assert(held); return ESP_OK; }
+bool upload_scan_bundle(upload_bundle_ref_t *out) { assert(held); memset(out,0,sizeof(*out)); out->fp=5; if(mode==1)cancelled=1; return true; }
+int upload_scan_day_groups(const char *s,upload_group_ref_t *out,int max) { assert(held); memset(out,0,sizeof(*out)); out->n_files=1; return 1; }
+int upload_ox_reconcile(upload_ox_ref_t *out,int n,int days) { assert(held); return cancelled?-1:0; }
+int upload_ox_pending(const upload_ox_ref_t *r,int n,int slot) { return 0; }
+int upload_ox_status(const upload_ox_ref_t *r,int slot) { return UG_PENDING; }
+void upload_ox_mark(const upload_ox_ref_t *r,int slot,upload_unit_status_t st,const char *remote) { assert(held); }
+static upload_result_t prepare(void) { assert(!held); ++prepares; if(mode==2)cancelled=1; return UPLOAD_OK; }
+static upload_result_t session_begin(void) { assert(!held); return UPLOAD_OK; }
+static upload_result_t begin_day(const char *d) { assert(held); return UPLOAD_OK; }
+static upload_result_t put(const char *d,const upload_group_ref_t *g) { assert(held); ++put_count; if(mode==3)cancelled=1; return UPLOAD_OK; }
+static upload_result_t bundle(const char *d,const upload_bundle_ref_t *b,bool changed) { assert(held); return UPLOAD_OK; }
+static upload_result_t finalize(const char *d,bool any) { assert(!held && !cancelled); ++finalizes; return UPLOAD_OK; }
+static void end(void) { assert(!held); ++ended; }
+'''+function(sched,'ox_mark_day_failed')+function(sched,'run_backend')+r'''
+int main(void) {
+ upload_backend_t be={.id="test",.bundle_only_ok=true,.prepare=prepare,.session_begin=session_begin,.day_begin=begin_day,.put_group=put,.put_bundle=bundle,.day_end=finalize,.session_end=end};
+ backend_rt_t r={.be=&be};
+ for(mode=0;mode<4;++mode) {
+  held=prepares=ended=finalizes=put_count=cancelled=commits=0; day.groups[0].be[0].status=UG_PENDING; day.groups[1].be[0].status=UG_OK;
+  run_backend(&r,30); assert(!held && prepares==1 && ended==1);
+  assert(day.groups[1].be[0].status==UG_OK); // never duplicate an already committed group
+  if(mode==0) { assert(day.groups[0].be[0].status==UG_OK && finalizes==1 && commits==1); }
+  else { assert(day.groups[0].be[0].status==UG_PENDING && !finalizes && !commits); }
+ }
+}
+''',('components/uploader','scripts/test_include'))

--- a/scripts/backend_recording_test.py
+++ b/scripts/backend_recording_test.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Compile actual production C against deterministic faulting transport/RTOS doubles."""
+from pathlib import Path
+import subprocess, tempfile
+ROOT = Path(__file__).resolve().parents[1]
+def function(source, name):
+    # Extraction chooses the production function; none of its logic is modeled.
+    import re
+    m = re.search(r'^(?:static\s+)?[\w\s*]+\b'+re.escape(name)+r'\([^;]*?\)\s*\{', source, re.M)
+    assert m, name
+    start=m.start(); i=m.end(); depth=1
+    while depth:
+        if source[i]=='{': depth+=1
+        elif source[i]=='}': depth-=1
+        i+=1
+    return source[start:i]
+
+def run(name, source, includes=()):
+    with tempfile.TemporaryDirectory(prefix='somno-backend-') as tmp:
+        p=Path(tmp); (p/'test.c').write_text(source)
+        subprocess.run(['cc','-std=c11','-D_DARWIN_C_SOURCE','-Wall','-Wextra','-Werror',
+            '-Wno-unused-function','-Wno-unused-parameter','-pthread',
+            *sum((['-I',str(ROOT/x)] for x in includes),[]),str(p/'test.c'),'-o',str(p/'test')],check=True)
+        subprocess.run([str(p/'test')],check=True,timeout=10)
+    print(name+' passed')
+
+COMMON = '''#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+'''
+
+ble=(ROOT/'main/as11_ble.c').read_text()
+# Decoded bytes retained exactly; admission does not duplicate or reorder them.
+a=ble.index('#define PENDING_STREAM_COUNT');b=ble.index('static void notif_proc_task',a)
+run('Pending stream bounded retention, replay and STOP fence',COMMON+r'''
+#define MALLOC_CAP_SPIRAM 1
+static bool admitted; static int accepted, loss, allocs;
+static char seen[256];
+static bool session_writer_try_stream_data_raw(const char *s,int n) { if(!admitted) return false; memcpy(seen+accepted,s,n); accepted+=n; return true; }
+static void *heap_caps_malloc(size_t n,int caps) { ++allocs; return malloc(n); }
+static void notif_mark_loss(void) { ++loss; }
+'''+ble[a:b]+r'''
+int main(void) {
+ pending_stream_submit("A",1); pending_stream_submit("B",1); pending_stream_replay();
+ assert(s_pending_count==2 && accepted==0);
+ admitted=true; pending_stream_replay(); assert(s_pending_count==0 && accepted==2 && !memcmp(seen,"AB",2));
+ pending_stream_replay(); assert(accepted==2);
+ admitted=false; pending_stream_submit("old",3); pending_stream_clear(); // decoded STOP fence
+ admitted=true; pending_stream_replay(); pending_stream_submit("new",3);
+ assert(accepted==5 && !memcmp(seen,"ABnew",5));
+ admitted=false; for(int i=0;i<PENDING_STREAM_COUNT+1;++i) pending_stream_submit("x",1);
+ assert(loss==1 && s_pending_count==0 && s_pending_bytes==0);
+ pending_stream_submit("z",1); pending_stream_clear(); assert(!s_pending_count);
+}
+''')

--- a/scripts/backend_runtime_test.py
+++ b/scripts/backend_runtime_test.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Compile actual production C against deterministic faulting transport/RTOS doubles."""
+from pathlib import Path
+import subprocess, tempfile
+ROOT = Path(__file__).resolve().parents[1]
+
+def function(source, name):
+    # Extraction chooses the production function; none of its logic is modeled.
+    import re
+    m = re.search(r'^(?:static\s+)?[\w\s*]+\b'+re.escape(name)+r'\([^;]*?\)\s*\{', source, re.M)
+    assert m, name
+    start=m.start(); i=m.end(); depth=1
+    while depth:
+        if source[i]=='{': depth+=1
+        elif source[i]=='}': depth-=1
+        i+=1
+    return source[start:i]
+
+def run(name, source, includes=()):
+    with tempfile.TemporaryDirectory(prefix='somno-backend-') as tmp:
+        p=Path(tmp); (p/'test.c').write_text(source)
+        subprocess.run(['cc','-std=c11','-D_DARWIN_C_SOURCE','-Wall','-Wextra','-Werror',
+            '-Wno-unused-function','-Wno-unused-parameter','-pthread',
+            *sum((['-I',str(ROOT/x)] for x in includes),[]),str(p/'test.c'),'-o',str(p/'test')],check=True)
+        subprocess.run([str(p/'test')],check=True,timeout=10)
+    print(name+' passed')
+
+COMMON = '''#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+'''
+
+ble=(ROOT/'main/as11_ble.c').read_text()
+# Timeout cleanup cannot free a semaphore/collector while decoder holds its mutex.
+run('Spool withdrawal joins decoder before reclamation', COMMON+r'''
+#include <pthread.h>
+#include <stdatomic.h>
+#define portMAX_DELAY 0
+#define BLE_HS_CONN_HANDLE_NONE -1
+#define BLE_ERR_REM_USER_CONN_TERM 0
+static pthread_mutex_t lock=PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t gate=PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t cond=PTHREAD_COND_INITIALIZER;
+static pthread_mutex_t *s_spool_mtx=&lock;
+static bool s_spool_tainted; static int s_conn_handle=-1, freed, entered;
+static atomic_int decoder_live;
+typedef struct { struct { void *data; } frags[32]; int frag_count; void *sem; } spool_collector_t;
+static spool_collector_t *s_spool_collector;
+static void xSemaphoreTake(pthread_mutex_t *m,int timeout) { pthread_mutex_lock(&gate); entered=1; pthread_cond_broadcast(&cond); pthread_mutex_unlock(&gate); pthread_mutex_lock(m); }
+static void xSemaphoreGive(pthread_mutex_t *m) { pthread_mutex_unlock(m); }
+static void vSemaphoreDelete(void *sem) { assert(!atomic_load(&decoder_live)); assert(!s_spool_collector); ++freed; free(sem); }
+static void ble_gap_terminate(int a,int b) { }
+'''+function(ble,'spool_withdraw')+r'''
+static void *withdraw(void *p) { spool_withdraw(p,true); return NULL; }
+int main(void) {
+ spool_collector_t coll={0}; coll.sem=malloc(8); s_spool_collector=&coll;
+ pthread_mutex_lock(&lock); atomic_store(&decoder_live,1);
+ pthread_t thread; pthread_create(&thread,NULL,withdraw,&coll);
+ pthread_mutex_lock(&gate); while(!entered) pthread_cond_wait(&cond,&gate); pthread_mutex_unlock(&gate);
+ assert(!freed && s_spool_collector==&coll);
+ coll.frags[coll.frag_count++].data=malloc(12); // decoder was already in flight
+ atomic_store(&decoder_live,0); pthread_mutex_unlock(&lock);
+ pthread_join(thread,NULL);
+ assert(freed==1 && !coll.sem && !coll.frag_count && !s_spool_collector && s_spool_tainted);
+ pthread_mutex_lock(&lock); assert(!s_spool_collector); pthread_mutex_unlock(&lock); // late decoder
+}
+''')
+
+# Reply ownership and exact ID matching, using production accept/clear/wait.
+run('RPC late/mismatched/duplicate response fencing',COMMON+r'''
+#define portENTER_CRITICAL(p) ((void)(p))
+#define portEXIT_CRITICAL(p) ((void)(p))
+#define pdTRUE 1
+#define pdMS_TO_TICKS(x) (x)
+static int s_response_lock, sem_count, deleted;
+static void *s_resp_sem;
+static int64_t now;
+typedef struct cJSON { double valuedouble; bool number; struct cJSON *id; } cJSON;
+static cJSON *s_resp_json, *s_response_original_id;
+static uint32_t s_expected_response_id;
+static cJSON *cJSON_GetObjectItemCaseSensitive(cJSON *p,const char *key) { return p->id; }
+static bool cJSON_IsNumber(cJSON *p) { return p && p->number; }
+static void cJSON_Delete(cJSON *p) { if(p) { cJSON_Delete(p->id); ++deleted; free(p); } }
+static bool cJSON_ReplaceItemInObjectCaseSensitive(cJSON *p,const char *key,cJSON *id) { cJSON_Delete(p->id); p->id=id; return true; }
+static int xSemaphoreGive(void *s) { ++sem_count; return 1; }
+static int xSemaphoreTake(void *s,int ticks) { if(sem_count) { --sem_count; return 1; } now+=(int64_t)ticks*1000; return 0; }
+static int64_t esp_timer_get_time(void) { return now; }
+'''+function(ble,'rpc_accept_response')+function(ble,'clear_response')+function(ble,'wait_response')+r'''
+static cJSON *reply(int id) { cJSON *p=calloc(1,sizeof(*p)); p->id=calloc(1,sizeof(*p)); p->id->number=true; p->id->valuedouble=id; return p; }
+int main(void) {
+ s_expected_response_id=101; rpc_accept_response(reply(100)); assert(!s_resp_json && !sem_count);
+ rpc_accept_response(reply(101)); cJSON *first=s_resp_json;
+ rpc_accept_response(reply(101)); assert(s_resp_json==first && sem_count==1);
+ cJSON *r=wait_response(50); assert(r==first && !s_expected_response_id); cJSON_Delete(r);
+ clear_response(); s_expected_response_id=102; sem_count=3;
+ assert(!wait_response(50) && now==50000 && !s_expected_response_id);
+ rpc_accept_response(reply(102)); assert(!s_resp_json);
+ s_expected_response_id=103; rpc_accept_response(reply(102)); assert(!s_resp_json);
+ rpc_accept_response(reply(103)); r=wait_response(50); assert(r && r->id->valuedouble==103); cJSON_Delete(r);
+ clear_response(); assert(!sem_count && deleted==12);
+}
+''')
+
+
+# Extraction boundary: all present public command owners release their bus.
+for name in ("as11_ble_get_values", "as11_ble_get_datetime", "as11_ble_spool_pull",
+             "as11_ble_start_therapy", "as11_ble_stop_therapy"):
+    body = function(ble, name)
+    assert "xSemaphoreTake(s_cmd_mtx" in body, name
+    assert "xSemaphoreGive(s_cmd_mtx)" in body, name
+    assert "clear_response()" in body, name
+assert "do_setup_encrypted_session(" in function(ble, "reconnect_task")
+print("Runtime extraction command ownership and reusable encrypted handshake passed")

--- a/scripts/backend_runtime_test.py
+++ b/scripts/backend_runtime_test.py
@@ -108,7 +108,7 @@ int main(void) {
 
 # Extraction boundary: all present public command owners release their bus.
 for name in ("as11_ble_get_values", "as11_ble_get_datetime", "as11_ble_spool_pull",
-             "as11_ble_start_therapy", "as11_ble_stop_therapy"):
+             "therapy_command"):
     body = function(ble, name)
     assert "xSemaphoreTake(s_cmd_mtx" in body, name
     assert "xSemaphoreGive(s_cmd_mtx)" in body, name

--- a/scripts/build-7b.sh
+++ b/scripts/build-7b.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Build a merged, offset-0 image for Waveshare ESP32-S3-Touch-LCD-7B.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+BUILD_DIR="build-7b"
+SDKCONFIG="sdkconfig.7b"
+DEFAULTS="sdkconfig.defaults;sdkconfig.7b.defaults"
+OUTPUT="somnotrace-waveshare-7b-test-full.bin"
+
+if [ "${1:-}" = "--clean" ]; then
+    "${SCRIPT_DIR}/idf.sh" -B "${BUILD_DIR}" -D "SDKCONFIG=${SDKCONFIG}" fullclean || true
+elif [ "$#" -ne 0 ]; then
+    echo "Usage: $0 [--clean]" >&2
+    exit 2
+fi
+
+# Refresh git-derived PROJECT_VER even when the source tree is otherwise unchanged.
+"${SCRIPT_DIR}/idf.sh" -B "${BUILD_DIR}" \
+    -D "SDKCONFIG=${SDKCONFIG}" \
+    -D "SDKCONFIG_DEFAULTS=${DEFAULTS}" reconfigure
+"${SCRIPT_DIR}/idf.sh" -B "${BUILD_DIR}" \
+    -D "SDKCONFIG=${SDKCONFIG}" \
+    -D "SDKCONFIG_DEFAULTS=${DEFAULTS}" build
+"${SCRIPT_DIR}/idf.sh" -B "${BUILD_DIR}" \
+    -D "SDKCONFIG=${SDKCONFIG}" merge-bin -o "${OUTPUT}"
+
+mkdir -p "${PROJECT_DIR}/dist"
+cp "${PROJECT_DIR}/${BUILD_DIR}/${OUTPUT}" "${PROJECT_DIR}/dist/${OUTPUT}"
+cp "${PROJECT_DIR}/${BUILD_DIR}/somnotrace.bin" \
+   "${PROJECT_DIR}/dist/somnotrace-waveshare-7b-test-ota.bin"
+
+echo
+echo "7B firmware ready:"
+echo "  ${PROJECT_DIR}/dist/${OUTPUT}"
+echo "Flash the full image at address 0x0."

--- a/scripts/capacity_snapshot_behavior_test.py
+++ b/scripts/capacity_snapshot_behavior_test.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Compile the public capacity API with its production implementation."""
+from pathlib import Path
+import re, subprocess, tempfile
+ROOT=Path(__file__).resolve().parents[1]
+source=(ROOT/'main/sd_storage.c').read_text()
+name='sd_storage_get_cached_free'
+m=re.search(r'^bool '+name+r'\([^;]*?\)\s*\{',source,re.M)
+assert m
+cursor=m.end();depth=1
+while depth:
+    depth += (source[cursor]=='{')-(source[cursor]=='}');cursor+=1
+body=source[m.start():cursor]
+fixture='''#include <assert.h>
+#include <stddef.h>
+#include "sd_storage.h"
+#define portENTER_CRITICAL(p) ((void)(p))
+#define portEXIT_CRITICAL(p) ((void)(p))
+static int s_capacity_lock;
+static bool s_capacity_cache_valid;
+static uint64_t s_cached_free_bytes, s_cached_total_bytes;
+'''+body+'''
+int main(void) {
+    uint64_t free_bytes=9, total_bytes=8;
+    assert(!sd_storage_get_cached_free(&free_bytes, &total_bytes));
+    s_capacity_cache_valid=true;
+    s_cached_free_bytes=0x123456789ULL; s_cached_total_bytes=0xabcdef987ULL;
+    assert(sd_storage_get_cached_free(&free_bytes, &total_bytes));
+    assert(free_bytes==0x123456789ULL && total_bytes==0xabcdef987ULL);
+    assert(sd_storage_get_cached_free(NULL, NULL));
+}
+'''
+with tempfile.TemporaryDirectory() as tmp:
+    p=Path(tmp);(p/'test.c').write_text(fixture)
+    subprocess.run(['cc','-std=c11','-Wall','-Wextra','-Werror','-I',str(ROOT/'scripts/test_include'),'-I',str(ROOT/'main'),str(p/'test.c'),'-o',str(p/'test')],check=True)
+    subprocess.run([str(p/'test')],check=True)
+net=(ROOT/'main/net_provision.c').read_text()
+a=net.index('static void status_cache_refresh_sd(');b=net.index('\n}',a)
+assert 'sd_storage_get_cached_free(' in net[a:b]
+assert '== ESP_OK' not in net[a:b], 'bool capacity success must not be inverted'
+print('Production capacity public API and bool success/failure convention passed')

--- a/scripts/clock_snapshot_contract_test.py
+++ b/scripts/clock_snapshot_contract_test.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Contracts for atomic drift/captured-clock snapshots and provenance."""
+
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TIME_SYNC = (ROOT / "main/time_sync.c").read_text(encoding="utf-8")
+AS11 = (ROOT / "main/as11_ble.c").read_text(encoding="utf-8")
+HOST_TEST = (ROOT / "scripts/test-host.sh").read_text(encoding="utf-8")
+
+
+def function_span(source: str, name: str) -> tuple[int, int]:
+    match = re.search(
+        rf"^[\w][\w\s*]*\b{name}\s*\([^;{{}}]*\)\s*\{{",
+        source,
+        re.MULTILINE,
+    )
+    if not match:
+        raise AssertionError(f"missing function: {name}")
+    depth = 1
+    cursor = match.end()
+    while cursor < len(source) and depth:
+        if source[cursor] == "{":
+            depth += 1
+        elif source[cursor] == "}":
+            depth -= 1
+        cursor += 1
+    if depth:
+        raise AssertionError(f"unterminated function: {name}")
+    return match.start(), cursor
+
+
+def function_body(source: str, name: str) -> str:
+    start, end = function_span(source, name)
+    return source[start:end]
+
+
+def assert_symbol_confined(
+    source: str, symbol: str, allowed_functions: tuple[str, ...]
+) -> None:
+    spans = [function_span(source, name) for name in allowed_functions]
+    declaration = re.search(rf"^static\b[^;]*\b{symbol}\b[^;]*;", source, re.MULTILINE)
+    comments = [
+        match.span()
+        for match in re.finditer(r"//[^\n]*|/\*.*?\*/", source, re.DOTALL)
+    ]
+    allowed = spans + comments + ([declaration.span()] if declaration else [])
+    for match in re.finditer(rf"\b{symbol}\b", source):
+        if not any(start <= match.start() < end for start, end in allowed):
+            line = source.count("\n", 0, match.start()) + 1
+            raise AssertionError(f"unguarded {symbol} access at line {line}")
+
+
+# Persisted drift is a four-field snapshot.  In particular, its int64_t
+# values cannot be torn on the 32-bit S3 and provenance cannot lag a value.
+assert "portMUX_TYPE s_drift_lock = portMUX_INITIALIZER_UNLOCKED" in TIME_SYNC
+drift_load = function_body(TIME_SYNC, "drift_cache_load")
+drift_store = function_body(TIME_SYNC, "drift_cache_store")
+for body in (drift_load, drift_store):
+    assert "portENTER_CRITICAL(&s_drift_lock)" in body
+    assert "portEXIT_CRITICAL(&s_drift_lock)" in body
+for symbol in ("s_drift_ms", "s_drift_at_ms", "s_drift_loaded", "s_drift_src"):
+    assert symbol in drift_load and symbol in drift_store
+    assert_symbol_confined(TIME_SYNC, symbol, ("drift_cache_load", "drift_cache_store"))
+
+for reader in (
+    "time_source_drift_age_ms",
+    "time_sync_has_drift",
+    "time_sync_peek_drift_snapshot",
+    "time_sync_get_drift_snapshot",
+    "time_sync_recover_from_as11",
+):
+    assert "drift_cache_load()" in function_body(TIME_SYNC, reader)
+for writer in ("time_sync_save_drift", "load_drift_from_nvs", "load_drift_from_sd"):
+    assert "drift_cache_store(" in function_body(TIME_SYNC, writer)
+
+
+# The pre-stream AS11 clock and the corresponding wall clock/source are also
+# published together.  A stale connection must never donate a measurement.
+assert "portMUX_TYPE s_as11_clock_lock = portMUX_INITIALIZER_UNLOCKED" in AS11
+capture_invalidate = function_body(AS11, "as11_clock_capture_invalidate")
+capture_store = function_body(AS11, "as11_clock_capture_store")
+capture_load = function_body(AS11, "as11_clock_capture_load")
+for body in (capture_invalidate, capture_store, capture_load):
+    assert "portENTER_CRITICAL(&s_as11_clock_lock)" in body
+    assert "portEXIT_CRITICAL(&s_as11_clock_lock)" in body
+assert_symbol_confined(
+    AS11,
+    "s_as11_clock_capture",
+    (
+        "as11_clock_capture_invalidate",
+        "as11_clock_capture_store",
+        "as11_clock_capture_load",
+    ),
+)
+assert_symbol_confined(
+    AS11,
+    "s_as11_clock_generation",
+    ("as11_clock_capture_invalidate", "as11_clock_capture_store"),
+)
+assert "++s_as11_clock_generation" in capture_invalidate
+assert "generation == s_as11_clock_generation" in capture_store
+assert "s_as11_clock_ms" not in AS11
+assert "s_as11_clock_capture_ntp_ms" not in AS11
+
+gap_disconnect = re.search(
+    r"case BLE_GAP_EVENT_DISCONNECT:.*?case BLE_GAP_EVENT_ENC_CHANGE:",
+    AS11,
+    re.DOTALL,
+)
+assert gap_disconnect and "as11_clock_capture_invalidate();" in gap_disconnect.group()
+assert "as11_clock_capture_invalidate();" in function_body(AS11, "as11_ble_forget")
+assert "as11_clock_capture_invalidate();" in function_body(AS11, "as11_ble_disconnect")
+
+reconnect = function_body(AS11, "reconnect_task")
+recapture_at = reconnect.find("as11_clock_capture_invalidate()")
+query_at = reconnect.find("as11_ble_get_datetime(&as11_ms)")
+source_at = reconnect.find("time_source_get()", query_at)
+wall_at = reconnect.find("time(NULL)", source_at)
+store_at = reconnect.find("as11_clock_capture_store(", wall_at)
+assert -1 not in (recapture_at, query_at, source_at, wall_at, store_at)
+assert recapture_at < query_at < source_at < wall_at < store_at
+assert "capture_generation = as11_clock_capture_invalidate()" in reconnect
+assert "as11_clock_capture_store(capture_generation" in reconnect
+
+get_drift = function_body(AS11, "as11_ble_get_clock_drift")
+provenance_at = get_drift.find("capture.wall_source != TIME_SRC_NTP")
+calculate_at = get_drift.find("capture.wall_ms - capture.as11_ms")
+assert -1 not in (provenance_at, calculate_at) and provenance_at < calculate_at
+
+# Pairing's intentional link teardown is another manual disconnect route.
+assert re.search(
+    r"as11_clock_capture_invalidate\(\);\s*"
+    r"s_manual_disconnect = true;\s*"
+    r"if \(s_conn_handle != BLE_HS_CONN_HANDLE_NONE\)",
+    AS11,
+)
+
+assert "clock_snapshot_contract_test.py" in HOST_TEST
+
+print("clock snapshot contract passed")

--- a/scripts/compact_display_init_test.py
+++ b/scripts/compact_display_init_test.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Fault-inject the real compact init/cleanup and required-strip flush paths."""
+from pathlib import Path
+import subprocess
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = (ROOT / "main/bsp_display.c").read_text()
+
+
+def function(signature):
+    start = SOURCE.index(signature + "\n{")
+    opening = SOURCE.index("{", start)
+    depth = 1
+    end = opening + 1
+    while depth:
+        depth += (SOURCE[end] == "{") - (SOURCE[end] == "}")
+        end += 1
+    return SOURCE[start:end]
+
+
+PRELUDE = r'''
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#define ESP_OK 0
+#define ESP_ERR_NO_MEM 0x101
+#define ESP_LOGE(...) ((void)0)
+#define ESP_LOGI(...) ((void)0)
+#define ESP_LOGW(...) ((void)0)
+#define ESP_LOG_WARN 2
+#define ESP_ERROR_CHECK(call) assert((call) == ESP_OK)
+#define LCD_H_RES 240
+#define LCD_V_RES 240
+#define FLOW_BUF_SIZE 240
+#define LCD_STRIP_BUFS 2
+#define LCD_STRIP_ROWS 40
+#define LCD_PIN_SCLK 38
+#define LCD_PIN_MOSI 39
+#define LCD_PIN_DC 45
+#define LCD_PIN_CS 21
+#define LCD_PIN_RST 40
+#define LCD_PIN_BL 46
+#define LCD_PIXEL_CLOCK_HZ 26666667
+#define LCD_SPI_HOST 2
+#define LCD_CMD_BITS 8
+#define LCD_PARAM_BITS 8
+#define LCD_INVERT_COLOR true
+#define BL_LEDC_RESOLUTION 10
+#define BL_LEDC_TIMER 0
+#define BL_LEDC_FREQ_HZ 5000
+#define BL_LEDC_CHANNEL 0
+#define LEDC_LOW_SPEED_MODE 0
+#define LEDC_AUTO_CLK 0
+#define LEDC_INTR_DISABLE 0
+#define SPI_DMA_CH_AUTO 0
+#define LCD_RGB_ELEMENT_ORDER_RGB 0
+#define DISPLAY_TASK_STACK 4096
+#define MALLOC_CAP_SPIRAM 1
+#define MALLOC_CAP_DMA 2
+#define tskNO_AFFINITY -1
+#define pdTRUE 1
+#define portMAX_DELAY 0
+#define pdMS_TO_TICKS(ms) (ms)
+typedef int esp_err_t;
+typedef void *esp_lcd_panel_handle_t;
+typedef void *esp_lcd_panel_io_handle_t;
+typedef intptr_t esp_lcd_spi_bus_handle_t;
+typedef void *SemaphoreHandle_t;
+typedef void *TaskHandle_t;
+typedef void *esp_timer_handle_t;
+typedef struct { void (*callback)(void *); const char *name; } esp_timer_create_args_t;
+typedef struct { int speed_mode, duty_resolution, timer_num, freq_hz, clk_cfg; } ledc_timer_config_t;
+typedef struct { int gpio_num, speed_mode, channel, intr_type, timer_sel, duty, hpoint; } ledc_channel_config_t;
+typedef struct { int sclk_io_num, mosi_io_num, miso_io_num, quadwp_io_num, quadhd_io_num, max_transfer_sz; } spi_bus_config_t;
+typedef struct { int dc_gpio_num, cs_gpio_num, pclk_hz, lcd_cmd_bits, lcd_param_bits, spi_mode, trans_queue_depth;
+    void (*on_color_trans_done)(void); void *user_ctx; } esp_lcd_panel_io_spi_config_t;
+typedef struct { int reset_gpio_num, rgb_ele_order, bits_per_pixel; } esp_lcd_panel_dev_config_t;
+static uint16_t *s_fb, *s_strip[2], s_rotation;
+static float *s_flow_buf, *s_flow_local, *s_flow_yf;
+static SemaphoreHandle_t s_state_mutex, s_flush_done;
+static TaskHandle_t s_display_task;
+static esp_timer_handle_t s_display_supervisor_timer;
+static esp_lcd_panel_handle_t s_panel;
+static esp_lcd_panel_io_handle_t s_io;
+static bool s_backlight_on = true, s_flush_stuck;
+static uint8_t s_brightness;
+static int allocation, fail_at, live, hardware_calls, panel_live, io_live, bus_live;
+static int bitmap_calls, task_calls;
+static bool fail_framebuffer, fail_task;
+
+static void *allocate(size_t bytes) {
+    ++allocation;
+    if (allocation == fail_at || (fail_framebuffer && bytes == 240 * 240 * 2)) return NULL;
+    void *result = calloc(1, bytes);
+    assert(result);
+    ++live;
+    return result;
+}
+static void *heap_caps_malloc(size_t bytes, int caps) { (void)caps; return allocate(bytes); }
+static void *heap_caps_calloc(size_t n, size_t bytes, int caps) { return heap_caps_malloc(n * bytes, caps); }
+static void heap_caps_free(void *p) { if (p) { --live; free(p); } }
+static void *xSemaphoreCreateCounting(int count, int initial) { (void)count; (void)initial; return allocate(1); }
+static void *xSemaphoreCreateMutex(void) { return allocate(1); }
+static void vSemaphoreDelete(void *p) { heap_caps_free(p); }
+static int xSemaphoreTake(void *p, int timeout) { (void)timeout; assert(p); return pdTRUE; }
+static int xSemaphoreGive(void *p) { assert(p); return pdTRUE; }
+static int hardware(void) { ++hardware_calls; return ESP_OK; }
+#define esp_log_level_set(...) ((void)0)
+#define ledc_timer_config(...) hardware()
+#define ledc_channel_config(...) hardware()
+#define ledc_stop(...) hardware()
+#define esp_lcd_panel_reset(...) hardware()
+#define esp_lcd_panel_init(...) hardware()
+#define esp_lcd_panel_invert_color(...) hardware()
+#define esp_lcd_panel_set_gap(...) hardware()
+#define esp_lcd_panel_disp_on_off(...) hardware()
+static int spi_bus_initialize(int host, const spi_bus_config_t *cfg, int dma) {
+    (void)host; (void)cfg; (void)dma; ++bus_live; return hardware();
+}
+static int spi_bus_free(int host) { (void)host; --bus_live; return hardware(); }
+static int esp_lcd_new_panel_io_spi(esp_lcd_spi_bus_handle_t bus, const esp_lcd_panel_io_spi_config_t *cfg, void **io) {
+    (void)bus; (void)cfg; ++io_live; *io = (void *)2; return hardware();
+}
+static int esp_lcd_panel_io_del(void *io) { assert(io); --io_live; return hardware(); }
+static int esp_lcd_new_panel_st7789(void *io, const esp_lcd_panel_dev_config_t *cfg, void **panel) {
+    (void)io; (void)cfg; ++panel_live; *panel = (void *)3; return hardware();
+}
+static int esp_lcd_panel_del(void *panel) { assert(panel); --panel_live; return ESP_OK; }
+static int board_qemu_154_init(void **panel) { ++panel_live; *panel = (void *)3; return ESP_OK; }
+static int board_qemu_154_flush(void *panel, const uint16_t *fb, uint16_t rotation, bool backlight) {
+    (void)rotation; (void)backlight; assert(panel && fb); ++bitmap_calls; return ESP_OK;
+}
+static int esp_lcd_panel_draw_bitmap(void *panel, int x0, int y0, int x1, int y1, void *fb) {
+    assert(panel && fb && fb != s_fb);
+    assert(x0 == 0 && x1 == 240 && y1 - y0 <= 40);
+    ++bitmap_calls; return ESP_OK;
+}
+static void lcd_color_done_cb(void) {}
+static void display_task(void *arg) { (void)arg; }
+static void display_supervisor_cb(void *arg) { (void)arg; }
+static int esp_timer_create(const esp_timer_create_args_t *args, esp_timer_handle_t *timer) {
+    assert(args && args->callback && timer); *timer = (void *)5; return ESP_OK;
+}
+static int esp_timer_start_periodic(esp_timer_handle_t timer, uint64_t period) {
+    assert(timer && period == 3000000); return ESP_OK;
+}
+static void *psram_task_create(void (*fn)(void *), const char *name, int stack, void *arg,
+                               int priority, int core, void *out_stack, void *out_tcb) {
+    (void)fn; (void)name; (void)stack; (void)arg; (void)priority; (void)core; (void)out_stack; (void)out_tcb;
+    ++task_calls;
+    assert(s_fb && s_flow_buf && s_flow_local && s_flow_yf && s_state_mutex && s_panel);
+#if !CONFIG_SOMNOTRACE_QEMU_DISPLAY_154
+    assert(s_strip[0] && s_strip[1] && s_flush_done && s_io);
+#endif
+    return fail_task ? NULL : (void *)4;
+}
+'''
+
+TEST = r'''
+static void clean_success(void) {
+    esp_lcd_panel_del(s_panel); s_panel = NULL;
+#if !CONFIG_SOMNOTRACE_QEMU_DISPLAY_154
+    esp_lcd_panel_io_del(s_io); s_io = NULL;
+    spi_bus_free(LCD_SPI_HOST);
+#endif
+    s_display_task = NULL;
+    display_buffers_free();
+}
+static void assert_clean(void) {
+    assert(!s_fb && !s_flow_buf && !s_flow_local && !s_flow_yf && !s_state_mutex);
+    assert(!s_panel && !s_io && !s_display_task && !s_flush_done && !s_strip[0] && !s_strip[1]);
+    assert(live == 0 && panel_live == 0 && io_live == 0 && bus_live == 0);
+}
+int main(void) {
+    assert(bsp_display_init() == ESP_OK);
+    int allocations = allocation;
+    lcd_flush();
+#if CONFIG_SOMNOTRACE_QEMU_DISPLAY_154
+    assert(bitmap_calls == 1 && hardware_calls == 0);
+#else
+    assert(bitmap_calls == 6);
+    void *second = s_strip[1]; s_strip[1] = NULL;
+    lcd_flush(); assert(bitmap_calls == 6); s_strip[1] = second;
+#endif
+    clean_success(); assert_clean();
+
+    /* Every required allocation fails in turn, including the second strip.
+     * The first framebuffer attempt has one intentional allocation fallback. */
+    for (int failure = 1; failure <= allocations; ++failure) {
+        allocation = 0; fail_at = failure; task_calls = 0; hardware_calls = 0;
+        int result = bsp_display_init();
+        if (failure == 1) {
+            assert(result == ESP_OK && task_calls == 1);
+            clean_success();
+        } else {
+            assert(result == ESP_ERR_NO_MEM && task_calls == 0 && hardware_calls == 0);
+        }
+        assert_clean();
+    }
+    allocation = 0; fail_at = 0; fail_framebuffer = true; task_calls = 0; hardware_calls = 0;
+    assert(bsp_display_init() == ESP_ERR_NO_MEM);
+    assert(task_calls == 0 && hardware_calls == 0); assert_clean();
+    fail_framebuffer = false; fail_task = true; allocation = 0; task_calls = 0;
+    assert(bsp_display_init() == ESP_ERR_NO_MEM && task_calls == 1); assert_clean();
+    fail_task = false; allocation = 0;
+    assert(bsp_display_init() == ESP_OK); clean_success(); assert_clean();
+    printf("PASS compact init allocation failures, task failure, retry, required strips (qemu=%d)\n",
+           CONFIG_SOMNOTRACE_QEMU_DISPLAY_154);
+}
+'''
+
+with tempfile.TemporaryDirectory(prefix="somno-compact-init-") as directory:
+    path = Path(directory)
+    production = "\n".join(function(signature) for signature in [
+        "static void display_buffers_free(void)",
+        "static esp_err_t display_buffers_init(void)",
+        "esp_err_t bsp_display_init(void)",
+        "static void lcd_flush(void)",
+    ])
+    fixture = path / "test.c"
+    fixture.write_text(PRELUDE + production + TEST)
+    for compact in (0,):
+        binary = path / f"test-{compact}"
+        subprocess.run(["cc", "-std=c11", "-Wall", "-Wextra", "-Werror",
+                        "-Wno-unused-function", "-Wno-unused-variable",
+                        "-fsanitize=address,undefined", "-fno-omit-frame-pointer",
+                        f"-DCONFIG_SOMNOTRACE_QEMU_DISPLAY_154={compact}",
+                        str(fixture), "-o", str(binary)], check=True)
+        subprocess.run([str(binary)], check=True)

--- a/scripts/controller_diagnostics_test.c
+++ b/scripts/controller_diagnostics_test.c
@@ -1,0 +1,77 @@
+#include "controller_diagnostics.h"
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+static int64_t s_now;
+int64_t esp_timer_get_time(void) { return s_now; }
+
+static void record(controller_operation_t operation, esp_err_t result)
+{
+    s_now += 1000;
+    controller_diagnostics_record(operation, result);
+}
+
+int main(void)
+{
+    controller_diagnostics_snapshot_t before, snap;
+    controller_diagnostics_get_snapshot(&snap);
+    assert(!snap.initialized && !snap.operations[CONTROLLER_TOUCH_READ].observed);
+    record(CONTROLLER_TOUCH_READ, ESP_FAIL);
+    controller_diagnostics_get_snapshot(&snap);
+    assert(!snap.initialized && snap.history_count == 0);
+
+    controller_diagnostics_init(false);
+    record(CONTROLLER_TOUCH_INIT, ESP_OK);
+    record(CONTROLLER_TOUCH_READ, ESP_FAIL);
+    record(CONTROLLER_PANEL_SUBMIT, ESP_ERR_INVALID_STATE);
+    record(CONTROLLER_TOUCH_READ, ESP_FAIL);
+    controller_diagnostics_get_snapshot(&snap);
+    assert(snap.initialized && !snap.simulated && snap.history_count == 2);
+    assert(!snap.operations[CONTROLLER_PANEL_HANDOFF].observed);
+    assert(snap.history[0].operation == CONTROLLER_TOUCH_READ);
+    assert(snap.history[0].occurrences == 2);
+    assert(snap.history[0].last_us - snap.history[0].first_us == 2000);
+    assert(snap.operations[CONTROLLER_TOUCH_READ].error_count == 2);
+
+    /* Recovery updates current health without erasing dated failure evidence. */
+    before = snap;
+    record(CONTROLLER_TOUCH_READ, ESP_OK);
+    controller_diagnostics_get_snapshot(&snap);
+    assert(snap.operations[CONTROLLER_TOUCH_READ].last_result == ESP_OK);
+    assert(snap.operations[CONTROLLER_TOUCH_READ].error_count == 2);
+    assert(memcmp(snap.history, before.history, sizeof(snap.history)) == 0);
+    record(CONTROLLER_TOUCH_READ, ESP_FAIL);
+    controller_diagnostics_get_snapshot(&snap);
+    assert(snap.history_count == 3 && snap.history[0].occurrences == 1);
+    assert(snap.history[1].operation == CONTROLLER_TOUCH_READ);
+    assert(snap.history[1].occurrences == 2);
+
+    /* More episodes evict only old evidence and preserve lifetime counts. */
+    for (unsigned i = 0; i < 20; ++i) {
+        record(CONTROLLER_TOUCH_READ, ESP_OK);
+        record(CONTROLLER_TOUCH_READ, ESP_FAIL);
+    }
+    controller_diagnostics_get_snapshot(&snap);
+    assert(snap.history_count == CONTROLLER_DIAGNOSTICS_HISTORY_MAX);
+    assert(snap.operations[CONTROLLER_TOUCH_READ].error_count == 23);
+    for (size_t i = 1; i < snap.history_count; ++i)
+        assert(snap.history[i - 1].last_us > snap.history[i].last_us);
+
+    before = snap;
+    record((controller_operation_t)-1, ESP_FAIL);
+    record(CONTROLLER_OPERATION_COUNT, ESP_FAIL);
+    controller_diagnostics_get_snapshot(&snap);
+    assert(memcmp(&before, &snap, sizeof(snap)) == 0);
+    controller_diagnostics_get_snapshot(NULL);
+    assert(strcmp(controller_diagnostics_operation_name(CONTROLLER_TOUCH_READ),
+                  "Touch read") == 0);
+
+    /* Simulated observations never masquerade as physical-board readings. */
+    controller_diagnostics_init(true);
+    controller_diagnostics_get_snapshot(&snap);
+    assert(snap.simulated && snap.history_count == 0);
+    assert(!snap.operations[CONTROLLER_TOUCH_INIT].observed);
+    puts("Controller diagnostics recovery and retention tests passed");
+    return 0;
+}

--- a/scripts/edf_rebuild_behavior_test.py
+++ b/scripts/edf_rebuild_behavior_test.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Exercise production day transaction with failing session/shared converters."""
+from pathlib import Path
+from session_storage_behavior_test import COMMON, EDF, function, run
+
+EDF_HEADER = (Path(__file__).resolve().parents[1]/'main/edf_header.c').read_text()
+
+code = COMMON + r'''
+#include <dirent.h>
+#define SD_LEASE_EXPORT 1
+#define REBUILD_MAX_SESSIONS 64
+#define EDF_GEN_PER_SESSION 1
+#define EDF_GEN_SHARED 2
+static char SD_STREAMS_DIR[300],SD_SDCARD_DIR[300],SD_SDCARD_DATALOG[300];
+static char REBUILD_STAGING_DIR[300],REBUILD_SENTINEL[300];
+static int lease_depth, failure_mode, generated;
+static esp_err_t session_writer_mark_upload_invalidation(const char *day) {
+    assert(!strcmp(day,"20260906"));assert(lease_depth>0);
+    if(failure_mode==5)return ESP_FAIL;
+    return ESP_OK;
+}
+static bool sd_storage_is_ready(void) { return true; }
+static bool sd_storage_lease_acquire(int a,int b) {(void)a;(void)b;lease_depth++;return true;}
+static void sd_storage_lease_release(int a) {(void)a;lease_depth--;assert(lease_depth>=0);}
+static const char *esp_err_to_name(int e) {(void)e;return "failure";}
+typedef struct {char session_id[40];int64_t start_epoch_ms,end_epoch_ms,clock_drift_ms;bool interrupted;} rebuild_session_t;
+static esp_err_t rebuild_read_manifest(const char *p,const char *f,rebuild_session_t *out) {
+    (void)p;snprintf(out->session_id,sizeof out->session_id,"%.*s",(int)strlen(f)-13,f);
+    out->start_epoch_ms=1700000000000LL+(f[0]=='a'?0:100000);out->interrupted=true;return ESP_OK;
+}
+static void file(const char *p,const char *v) {FILE *f=fopen(p,"wb");assert(f);fputs(v,f);fclose(f);}
+static void expect(const char *p,const char *v) {
+    char b[40]={0};FILE *f=fopen(p,"rb");assert(f);fread(b,1,sizeof b-1,f);fclose(f);assert(!strcmp(b,v));
+}
+static esp_err_t edf_gen_generate_ex(const char *root,const char *dir,const char *id,
+    int64_t a,int64_t b,int64_t c,uint32_t flags) {
+    (void)dir;(void)a;(void)b;(void)c;generated++;
+    char p[700];mkdir(root,0700);snprintf(p,sizeof p,"%s/DATALOG",root);mkdir(p,0700);
+    snprintf(p,sizeof p,"%s/DATALOG/20260906",root);mkdir(p,0700);
+    snprintf(p,sizeof p,"%s/SETTINGS",root);mkdir(p,0700);
+    if(flags==EDF_GEN_PER_SESSION) {
+        snprintf(p,sizeof p,"%s/DATALOG/20260906/%s.edf",root,id);file(p,"NEW");
+        if(id[0]=='b' && failure_mode==1) return ESP_ERR_NO_MEM;
+        if(id[0]=='b' && failure_mode==2) return ESP_FAIL;
+        if(id[0]=='b' && failure_mode==3) return EDF_GEN_ERR_POSITION_GAPS;
+    } else {
+        snprintf(p,sizeof p,"%s/STR.edf",root);file(p,"SHARED");
+        if(failure_mode==4) return ESP_ERR_NO_MEM;
+    }
+    return ESP_OK;
+}
+'''
+code += ''.join(function(EDF_HEADER,n) for n in [
+    'edf_open_atomic_file','edf_publish_atomic_path',
+    'edf_finalize_atomic_file','edf_discard_atomic_file'])
+code += ''.join(function(EDF,n) for n in [
+    'rebuild_rmtree','rebuild_move_dir','edf_gen_rebuild_day',
+    'edf_gen_take_interrupted_rebuild'])
+code += r'''
+int main(void) {
+    char base[]="/tmp/somno-rebuild-XXXXXX";assert(mkdtemp(base));
+    snprintf(SD_STREAMS_DIR,sizeof SD_STREAMS_DIR,"%s/raw",base);mkdir(SD_STREAMS_DIR,0700);
+    snprintf(SD_SDCARD_DIR,sizeof SD_SDCARD_DIR,"%s/out",base);mkdir(SD_SDCARD_DIR,0700);
+    snprintf(SD_SDCARD_DATALOG,sizeof SD_SDCARD_DATALOG,"%s/DATALOG",SD_SDCARD_DIR);mkdir(SD_SDCARD_DATALOG,0700);
+    snprintf(REBUILD_STAGING_DIR,sizeof REBUILD_STAGING_DIR,"%s/.rebuild",SD_SDCARD_DIR);
+    snprintf(REBUILD_SENTINEL,sizeof REBUILD_SENTINEL,"%s/.rebuilding",SD_SDCARD_DIR);
+    char p[700],good[700],shared[700];
+    snprintf(p,sizeof p,"%s/20260906",SD_STREAMS_DIR);mkdir(p,0700);
+    snprintf(p,sizeof p,"%s/20260906/a_session.json",SD_STREAMS_DIR);file(p,"{}");
+    snprintf(p,sizeof p,"%s/20260906/b_session.json",SD_STREAMS_DIR);file(p,"{}");
+    snprintf(p,sizeof p,"%s/20260906",SD_SDCARD_DATALOG);mkdir(p,0700);
+    snprintf(good,sizeof good,"%s/20260906/good.edf",SD_SDCARD_DATALOG);file(good,"GOOD");
+    snprintf(shared,sizeof shared,"%s/STR.edf",SD_SDCARD_DIR);file(shared,"OLD-SHARED");
+    for(failure_mode=1;failure_mode<=4;failure_mode++) {
+        generated=0;int ret=edf_gen_rebuild_day("20260906");assert(ret!=ESP_OK);
+        assert(lease_depth==0);assert(generated==(failure_mode==4?3:2));
+        expect(good,"GOOD");expect(shared,"OLD-SHARED");
+        assert(access(REBUILD_STAGING_DIR,F_OK)!=0);assert(access(REBUILD_SENTINEL,F_OK)!=0);
+    }
+    failure_mode=5;assert(edf_gen_rebuild_day("20260906")==ESP_FAIL);
+    assert(access(REBUILD_SENTINEL,F_OK)==0 && lease_depth==0);
+    // A reboot check must not consume the only durable retry intent.
+    file(REBUILD_SENTINEL,"20260906\n");char day[16];
+    assert(edf_gen_take_interrupted_rebuild(day,sizeof day));assert(!strcmp(day,"20260906"));
+    assert(edf_gen_take_interrupted_rebuild(day,sizeof day));
+    failure_mode=0;assert(edf_gen_rebuild_day("20260906")==ESP_OK);assert(lease_depth==0);
+    assert(access(REBUILD_SENTINEL,F_OK)!=0);expect(shared,"SHARED");
+    snprintf(p,sizeof p,"%s/20260906/a.edf",SD_SDCARD_DATALOG);expect(p,"NEW");
+    snprintf(p,sizeof p,"%s/20260906/b.edf",SD_SDCARD_DATALOG);expect(p,"NEW");
+    rebuild_rmtree(base);
+    puts("production rebuild transaction: OOM/I/O/gap failures abort whole staged day; shared failure preserves live output; reboot intent retained");
+}
+'''
+if __name__ == '__main__':
+    run('rebuild',code)

--- a/scripts/fork_backend_reconciliation_test.py
+++ b/scripts/fork_backend_reconciliation_test.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Production newest-day selection and pressure encoder reconciliation checks."""
+from pathlib import Path
+import datetime, subprocess, tempfile
+from session_storage_behavior_test import COMMON, function
+ROOT=Path(__file__).resolve().parents[1]
+ox=(ROOT/'components/uploader/upload_ox.c').read_text()
+edf=(ROOT/'main/edf_summary.c').read_text()
+days=[(datetime.date(2026,1,1)+datetime.timedelta(days=i)).strftime('%Y%m%d') for i in range(500)]
+order=[days[(i*137)%500] for i in range(500)]
+code=COMMON+r'''
+#include <dirent.h>
+#include "upload_ox.h"
+#define MALLOC_CAP_SPIRAM 1
+#define OX_RECORDINGS_DIR "recordings"
+static int root_reads, child_reads, close_count, allocations, fail_alloc, fail_child;
+static int cancel_root_at, cancel_child_at;
+static bool cancelled;
+static const char *names[] = {'''+','.join('"'+d+'"' for d in order)+r'''};
+static DIR *test_open(const char *path) { assert(!strcmp(path,OX_RECORDINGS_DIR)); return (DIR*)1; }
+static struct dirent *test_read(DIR *d) {
+    static struct dirent entry;
+    assert(d==(DIR*)1);
+    if(root_reads==500) return NULL;
+    strcpy(entry.d_name,names[root_reads++]);
+    return &entry;
+}
+static int test_close(DIR *d) { assert(d==(DIR*)1); ++close_count; return 0; }
+static void *heap_caps_calloc(size_t n,size_t size,int caps) {
+    if(fail_alloc) return NULL;
+    void *p=calloc(n,size); assert(p); ++allocations; return p;
+}
+static void test_free(void *p) { assert(p && allocations==1); --allocations; free(p); }
+static bool uploader_should_cancel(void) {
+    return cancelled || (cancel_root_at>=0 && root_reads>=cancel_root_at);
+}
+esp_err_t upload_ox_init(void) { return ESP_OK; }
+static int scan_day(const char *day,upload_ox_ref_t *out,int max_out) {
+    assert(close_count==1 && max_out>0);
+    ++child_reads;
+    if(fail_child==child_reads) return -1;
+    if(cancel_child_at==child_reads) cancelled=true;
+    strcpy(out->day,day); return 1;
+}
+#define opendir test_open
+#define readdir test_read
+#define closedir test_close
+#define free test_free
+'''+function(ox,'valid_day')+function(ox,'upload_ox_scan')+r'''
+#undef free
+static void reset(void) {
+    assert(!allocations);
+    root_reads=child_reads=close_count=fail_alloc=fail_child=cancel_child_at=0;
+    cancel_root_at=-1; cancelled=false;
+}
+'''+function(edf,'settings_x50').replace('static inline','static')+r'''
+int main(void) {
+    upload_ox_ref_t *out=calloc(64,sizeof(*out)); assert(out);
+    reset(); assert(upload_ox_scan(out,64)==64 && close_count==1 && !allocations);
+'''+''.join(f'    assert(!strcmp(out[{i}].day,"{d}"));\n' for i,d in enumerate(reversed(days[-64:])))+r'''
+    reset(); cancel_root_at=13;
+    assert(upload_ox_scan(out,64)==-1 && root_reads==13 && !child_reads && close_count==1 && !allocations);
+    reset(); fail_child=3;
+    assert(upload_ox_scan(out,64)==-1 && child_reads==3 && close_count==1 && !allocations);
+    reset(); cancel_child_at=2;
+    assert(upload_ox_scan(out,64)==-1 && child_reads==2 && close_count==1 && !allocations);
+    reset(); fail_alloc=1;
+    assert(upload_ox_scan(out,64)==0 && close_count==1 && !allocations);
+    assert(settings_x50(4.6)==230);
+    assert(settings_x50(4.2)==210 && settings_x50(0.6)==30);
+    free(out);
+}
+'''
+with tempfile.TemporaryDirectory() as tmp:
+    p=Path(tmp);(p/'test.c').write_text(code)
+    subprocess.run(['cc','-std=c11','-D_DARWIN_C_SOURCE','-Wall','-Wextra','-Werror','-Wno-unused-parameter','-Wno-unused-function','-fsanitize=address,undefined','-I',str(ROOT/'scripts/test_include'),'-I',str(ROOT/'components/uploader'),str(p/'test.c'),'-lm','-o',str(p/'test')],check=True)
+    subprocess.run([str(p/'test')],check=True,timeout=5)
+print('Production O2 newest 64/500 unsorted days, root/child cancellation, negative scan and OOM cleanup; STR encoder rounding passed')

--- a/scripts/idf-command.sh
+++ b/scripts/idf-command.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Executed by the ESP-IDF Docker entrypoint, after IDF_PATH is established.
+set -euo pipefail
+python3 /project/scripts/idf-sdk-patches.py
+exec "$@"

--- a/scripts/idf-sdk-patches.py
+++ b/scripts/idf-sdk-patches.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Apply the checked SDK async-request unwind fix inside the build container."""
+from pathlib import Path
+import os
+
+ROOT = Path(__file__).resolve().parents[1]
+REFERENCE = ROOT / "third_party/esp-idf-patches/httpd_async_v5_5_1.c"
+OLD = """    if (async_aux->resp_hdrs == NULL) {
+        free(async_aux);"""
+NEW = """    if (async_aux->resp_hdrs == NULL) {
+        free(async_aux->scratch);
+        free(async_aux);"""
+
+
+def functions(source):
+    start = source.index("esp_err_t httpd_req_async_handler_begin(")
+    complete = source.index("esp_err_t httpd_req_async_handler_complete(", start)
+    end = source.index("\n}", complete) + 2
+    return source[start:end]
+
+
+def apply(path):
+    source = path.read_text()
+    expected = functions(REFERENCE.read_text())
+    fixed = expected.replace(OLD, NEW)
+    assert fixed != expected and expected.count(OLD) == 1
+    actual = functions(source)
+    if actual == fixed:
+        return False
+    if actual != expected:
+        raise RuntimeError("ESP-IDF HTTP async implementation changed; review the SDK patch and fault test")
+    path.write_text(source.replace(actual, fixed, 1))
+    return True
+
+
+if __name__ == "__main__":
+    target = Path(os.environ["IDF_PATH"]) / "components/esp_http_server/src/httpd_txrx.c"
+    if apply(target):
+        print("Applied checked ESP-IDF HTTP async allocation cleanup")

--- a/scripts/idf.sh
+++ b/scripts/idf.sh
@@ -72,4 +72,4 @@ exec docker run --rm \
     -v "${PROJECT_DIR}:/project" \
     -w /project \
     "$IMAGE" \
-    "$@"
+    /bin/bash /project/scripts/idf-command.sh "$@"

--- a/scripts/idf_async_allocation_test.py
+++ b/scripts/idf_async_allocation_test.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Fault every allocation in the checked ESP-IDF async begin/complete functions."""
+import importlib.util
+from pathlib import Path
+import subprocess
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[1]
+spec = importlib.util.spec_from_file_location("sdk_patches", ROOT / "scripts/idf-sdk-patches.py")
+patch = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(patch)
+fixture = r'''
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+typedef int esp_err_t;
+#define ESP_OK 0
+#define ESP_ERR_INVALID_ARG 1
+#define ESP_ERR_NO_MEM 2
+struct sock_db {bool for_async_req;};
+struct resp_hdr {const char *field,*value;};
+struct httpd_req_aux {
+    void *scratch;size_t scratch_cur_size,scratch_size_limit,remaining_len;
+    struct resp_hdr *resp_hdrs;struct sock_db *sd;
+};
+struct httpd_data {struct {size_t max_resp_headers;} config;};
+typedef struct {void *handle,*aux;} httpd_req_t;
+static unsigned calls,fail_at,retained;
+static void *fault_malloc(size_t bytes) {
+    if(++calls==fail_at)return NULL;
+    void *p=malloc(bytes);assert(p);++retained;return p;
+}
+static void *fault_calloc(size_t n,size_t bytes) {
+    void *p=fault_malloc(n*bytes);if(p)memset(p,0,n*bytes);return p;
+}
+static void fault_free(void *p) {if(p){assert(retained);--retained;}free(p);}
+#define malloc fault_malloc
+#define calloc fault_calloc
+#define free fault_free
+'''
+cases = r'''
+int main(void) {
+    char scratch[128]="request headers";
+    struct resp_hdr headers[8]={{"Content-Type","application/octet-stream"}};
+    struct httpd_data server={.config.max_resp_headers=8};
+    for(unsigned has_scratch=0;has_scratch<2;++has_scratch) {
+        for(unsigned failure=0;failure<=3+has_scratch;++failure) {
+            struct sock_db socket={0};
+            struct httpd_req_aux aux={.scratch=has_scratch?scratch:NULL,
+                .scratch_cur_size=128,.remaining_len=99,.resp_hdrs=headers,.sd=&socket};
+            httpd_req_t request={.handle=&server,.aux=&aux},*async=NULL;
+            calls=0;fail_at=failure;retained=0;
+            int result=httpd_req_async_handler_begin(&request,&async);
+            if(failure) {
+                assert(result==ESP_ERR_NO_MEM && !async && !retained);
+                assert(!socket.for_async_req && aux.remaining_len==99);
+            } else {
+                assert(result==ESP_OK && async && retained==3+has_scratch);
+                assert(socket.for_async_req && !aux.remaining_len);
+                struct httpd_req_aux *copy=async->aux;
+                assert(copy!=&aux && copy->resp_hdrs!=headers);
+                if(has_scratch)assert(copy->scratch!=scratch && !memcmp(copy->scratch,scratch,128));
+                assert(httpd_req_async_handler_complete(async)==ESP_OK);
+                assert(!retained && !socket.for_async_req);
+            }
+        }
+    }
+    puts("checked SDK async request: every allocation failure unwinds with no retained bytes or ownership");
+}
+'''
+with tempfile.TemporaryDirectory(prefix="somno-sdk-async-") as temp:
+    directory = Path(temp)
+    source = directory / "httpd_txrx.c"
+    source.write_text(patch.REFERENCE.read_text())
+    assert patch.apply(source)
+    assert not patch.apply(source), "patch must be idempotent"
+    patched = patch.functions(source.read_text())
+    source.write_text(fixture + patched + cases)
+    binary = directory / "test"
+    subprocess.run(["cc", "-std=c11", "-Wall", "-Wextra", "-Werror",
+                    "-fsanitize=address,undefined", str(source), "-o", str(binary)], check=True)
+    subprocess.run([str(binary)], check=True)
+    source.write_text(patch.REFERENCE.read_text().replace("r_aux->remaining_len = 0;", "r_aux->remaining_len = 1;"))
+    try:
+        patch.apply(source)
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("unknown SDK implementation was accepted")

--- a/scripts/oximetry_forget_tombstone_contract_test.py
+++ b/scripts/oximetry_forget_tombstone_contract_test.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Structural contracts preventing stale paired.json resurrection."""
+
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TOP = (ROOT / "main/oximeter.c").read_text(encoding="utf-8")
+OXYII = (ROOT / "main/oximeter_oxyii.c").read_text(encoding="utf-8")
+LEGACY = (ROOT / "main/oximeter_legacy.c").read_text(encoding="utf-8")
+INTERNAL = (ROOT / "main/oximeter_internal.h").read_text(encoding="utf-8")
+NETPROV = (ROOT / "main/net_provision.c").read_text(encoding="utf-8")
+
+
+def function_body(name: str, source: str) -> str:
+    match = re.search(
+        rf"^[\w][\w\s*]*\b{name}\s*\([^;{{}}]*\)\s*\{{",
+        source,
+        re.MULTILINE,
+    )
+    if not match:
+        raise AssertionError(f"missing function: {name}")
+    depth = 1
+    cursor = match.end()
+    while cursor < len(source) and depth:
+        if source[cursor] == "{":
+            depth += 1
+        elif source[cursor] == "}":
+            depth -= 1
+        cursor += 1
+    if depth:
+        raise AssertionError(f"unterminated function: {name}")
+    return source[match.end(): cursor - 1]
+
+
+for source, driver in (
+    (OXYII, "OX_DRIVER_OXYII"),
+    (LEGACY, "OX_DRIVER_LEGACY"),
+):
+    save = function_body("do_save_nvs", source)
+    driver_write = f'nvs_set_u8(h, "driver", (uint8_t){driver})'
+    assert save.index(driver_write) < save.index('nvs_set_u8(h, "forgotten", 0)') \
+           < save.index("nvs_commit(h)")
+    assert 'if (e == ESP_OK) e = nvs_set_u8(h, "forgotten", 0);' in save
+
+    pair = function_body("pair_task", source)
+    persist = pair.index("nvs_writer_run(do_save_nvs, &nvs_arg)")
+    persist_guard = pair.index("if (persisted != ESP_OK)", persist)
+    sd_mirror = pair.index("ox_store_save_paired(", persist_guard)
+    ram_publish = pair.index("s_paired = true", sd_mirror)
+    assert persist < persist_guard < sd_mirror < ram_publish
+    failure = pair[persist_guard:sd_mirror]
+    assert "set_error(" in failure
+    assert "do_disconnect()" in failure
+    assert "psram_task_delete(NULL)" in failure
+    assert "return;" in failure
+
+    erase = function_body("do_erase_nvs", source)
+    assert 'nvs_erase_key(h, "forgotten")' not in erase
+    assert erase.index('erase_nvs_key_if_present(h, "driver")') \
+           < erase.index('nvs_set_u8(h, "forgotten", 1)') \
+           < erase.index("nvs_commit(h)")
+    assert 'if (e == ESP_OK) e = nvs_set_u8(h, "forgotten", 1);' in erase
+    assert 'if (e == ESP_OK) e = nvs_commit(h);' in erase
+
+    erase_helper = function_body("erase_nvs_key_if_present", source)
+    assert "nvs_erase_key(h, key)" in erase_helper
+    assert "e == ESP_ERR_NVS_NOT_FOUND ? ESP_OK : e" in erase_helper
+    for key in (
+        "firmware",
+        "name_prefix",
+        "ble_name",
+        "last_addr",
+        "driver",
+        "probe_mode",
+    ):
+        assert f'if (e == ESP_OK) e = erase_nvs_key_if_present(h, "{key}");' in erase
+
+    load = function_body("load_paired_from_nvs", source)
+    tombstone_read = load.index('nvs_get_u8(h, "forgotten", &forgotten_value)')
+    sd_fallback = load.index("ox_store_load_paired(")
+    assert tombstone_read < sd_fallback
+    assert "if (!s_paired && !forgotten)" in load[:sd_fallback]
+    # Missing keys remain backward-compatible: only an explicitly persisted 1
+    # suppresses the paired.json fallback.
+    assert re.search(r'== ESP_OK\s*&&\s*forgotten_value == 1', load)
+    assert "nvs_writer_unlock(); return;" not in load[:sd_fallback]
+
+    forget_name = "oxyii_forget" if driver == "OX_DRIVER_OXYII" else "legacy_forget"
+    forget = function_body(forget_name, source)
+    persist = forget.index("nvs_writer_run(do_erase_nvs, NULL)")
+    persist_guard = forget.index("if (persisted != ESP_OK)", persist)
+    sd_mirror = forget.index("ox_store_delete_paired()", persist_guard)
+    ram_clear = forget.index("s_paired = false", sd_mirror)
+    assert persist < persist_guard < sd_mirror < ram_clear
+    failure = forget[persist_guard:sd_mirror]
+    assert "set_error(" in failure
+    assert "return persisted;" in failure
+    assert "return ESP_OK;" in forget[ram_clear:]
+
+
+selection = function_body("load_driver_type", TOP)
+assert selection.index('nvs_get_u8(h, "forgotten", &forgotten_value)') \
+       < selection.index("ox_store_load_paired(")
+assert "if (!forgotten && s_driver_type == OX_DRIVER_OXYII)" in selection
+assert 'forgotten_value == 1' in selection
+
+assert "esp_err_t (*forget)(void);" in INTERNAL
+dispatcher = function_body("oximeter_forget", TOP)
+assert "return s_active->forget();" in dispatcher
+forget_http = function_body("ox_forget_handler", NETPROV)
+assert forget_http.index("esp_err_t e = oximeter_forget()") \
+       < forget_http.index("if (e != ESP_OK)") \
+       < forget_http.index('httpd_resp_sendstr(req, "{\\"ok\\":true}")')
+
+print("Oximetry Forget tombstone contract passed")

--- a/scripts/oximetry_sd_lease_contract_test.py
+++ b/scripts/oximetry_sd_lease_contract_test.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Structural contracts for O2 Ring FATFS arbitration."""
+
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve().parents[1]
+STORE = (ROOT / "main/oximeter_store.c").read_text(encoding="utf-8")
+OXYII = (ROOT / "main/oximeter_oxyii.c").read_text(encoding="utf-8")
+LEGACY = (ROOT / "main/oximeter_legacy.c").read_text(encoding="utf-8")
+HTTP = (ROOT / "main/oximetry_http.c").read_text(encoding="utf-8")
+HEADER = (ROOT / "main/oximeter_store.h").read_text(encoding="utf-8")
+
+
+def function_body(name: str, source: str) -> str:
+    match = re.search(
+        rf"^[\w][\w\s*]*\b{name}\s*\([^;{{}}]*\)\s*\{{",
+        source,
+        re.MULTILINE,
+    )
+    if not match:
+        raise AssertionError(f"missing function: {name}")
+    depth = 1
+    cursor = match.end()
+    while cursor < len(source) and depth:
+        if source[cursor] == "{":
+            depth += 1
+        elif source[cursor] == "}":
+            depth -= 1
+        cursor += 1
+    if depth:
+        raise AssertionError(f"unterminated function: {name}")
+    return source[match.end(): cursor - 1]
+
+
+# A transaction is admitted only on a mounted card and uses EXPORT: this
+# excludes destructive format/unmount while still allowing therapy recording.
+assert "bool ox_store_begin_io(uint32_t timeout_ms);" in HEADER
+assert "void ox_store_end_io(void);" in HEADER
+begin = function_body("ox_store_begin_io", STORE)
+assert begin.index("sd_storage_is_ready()") < begin.index(
+    "sd_storage_lease_acquire(SD_LEASE_EXPORT, timeout_ms)"
+)
+assert begin.count("sd_storage_is_ready()") == 2
+assert "sd_storage_lease_release(SD_LEASE_EXPORT)" in begin
+assert "sd_storage_lease_release(SD_LEASE_EXPORT)" in function_body(
+    "ox_store_end_io", STORE
+)
+
+# Short standalone metadata/diagnostic operations own leases themselves. This
+# covers boot fallback, pairing, forget and the diagnostics endpoint.
+for name in (
+    "ox_store_ensure_dirs",
+    "ox_store_load_paired",
+    "ox_store_save_paired",
+    "ox_store_delete_paired",
+    "ox_store_conversion_diagnostics_json",
+):
+    body = function_body(name, STORE)
+    assert body.index("ox_store_begin_io(0)") < body.index("ox_store_end_io()"), name
+
+# A complete pull owns one lease from before its first store/index operation
+# through conversion/finalisation. BLE discovery and file-list exchange happen
+# first, so passive scanning never pins the card gate.
+for source, list_call in (
+    (OXYII, "oxyii_get_file_list(names, 32)"),
+    (LEGACY, "parse_file_list(file_list, names, 32)"),
+):
+    pull = function_body("do_pull_and_mark", source)
+    acquire = pull.index("ox_store_begin_io(0)")
+    release = pull.rindex("ox_store_end_io()")
+    assert pull.index(list_call) < acquire < pull.index("ox_store_index_check", acquire)
+    assert release < pull.rindex("return pull_ok;")
+    assert "do_scan(" not in pull[acquire:release]
+
+for source in (OXYII, LEGACY):
+    scan = function_body("do_scan", source)
+    assert "ox_store_begin_io" not in scan
+    assert "sd_storage_lease_acquire" not in scan
+
+# Boot reconciliation and legacy conversion run under one transaction, rather
+# than relying on a stale pre-I/O mounted check.
+migration = function_body("canonical_migration_task", OXYII)
+assert migration.index("ox_store_begin_io(5000)") \
+       < migration.index("oximetry_canonical_reconcile()") \
+       < migration.index("oximetry_canonical_migrate_all_legacy()") \
+       < migration.index("ox_store_end_io()")
+
+# Canonical HTTP enumeration and downloads retain the lease until all FATFS
+# objects are closed. Every return after the file handler acquires must release.
+for name in (
+    "oximetry_recordings_handler",
+    "oximetry_recording_handler",
+    "oximetry_uploads_handler",
+):
+    body = function_body(name, HTTP)
+    assert body.index("ox_store_begin_io(0)") < body.index("ox_store_end_io()")
+
+file_handler = function_body("oximetry_file_handler", HTTP)
+held = file_handler[file_handler.index("ox_store_begin_io(0)"):]
+for index, return_match in enumerate(re.finditer(r"\breturn\b", held)):
+    prefix = held[:return_match.start()]
+    # The first return is the acquire-failed branch; every later return must
+    # have released the transaction since the last acquire.
+    if index == 0:
+        continue
+    assert prefix.rfind("ox_store_end_io()") > prefix.rfind("ox_store_begin_io(0)"), \
+        "file handler return can strand O2 SD lease"
+
+print("Oximetry SD lease contract passed")

--- a/scripts/pending_export_behavior_test.py
+++ b/scripts/pending_export_behavior_test.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Production durable-intent journal/finalize tests with a small JSON test double.
+
+The cJSON double supplies known scalar fixture fields. The production journal
+reader selects complete records and the production writer performs real FILE I/O.
+"""
+from session_storage_behavior_test import COMMON, DEFS, SW, function, run
+
+code=COMMON+r'''
+#include <dirent.h>
+typedef void *SemaphoreHandle_t;
+typedef void *QueueHandle_t;
+typedef struct session_writer session_writer_t;
+'''+DEFS+r'''
+#define SD_APP_DIR "."
+#define SD_PENDING_EXPORT_DIR "./pending_export"
+#define SD_LEASE_EXPORT 1
+static int sync_fail,unlink_fail,closed,lease_depth,manifests;
+static bool allow_lease=true;
+static unsigned nonce_counter;
+static void esp_fill_random(void *p,size_t len) {uint32_t *v=p;for(size_t i=0;i<len/4;i++)v[i]=++nonce_counter;}
+
+static int fake_sync(int fd) {(void)fd;if(sync_fail){errno=EIO;return -1;}return 0;}
+static int fake_unlink(const char *path) {if(unlink_fail){errno=EIO;return -1;}return unlink(path);}
+static int count_close(FILE *f) {closed++;return fclose(f);}
+#define fsync fake_sync
+#define unlink fake_unlink
+#define fclose count_close
+static bool sd_storage_is_ready(void) {return true;}
+static bool sd_storage_lease_acquire(int a,int b) {(void)a;(void)b;if(!allow_lease)return false;lease_depth++;return true;}
+static void sd_storage_lease_release(int a) {(void)a;assert(lease_depth>0);lease_depth--;}
+static void sd_storage_lease_release_unchanged(int a) {sd_storage_lease_release(a);}
+static const char *esp_err_to_name(int e) {(void)e;return "ESP_FAIL";}
+// Scalar cJSON test double; malformed or unfinished fixtures have no object.
+typedef struct cJSON {int type;double valuedouble;char *valuestring;struct cJSON *children;} cJSON;
+static cJSON *cJSON_Parse(const char *line) {
+    const char *d=strstr(line,"\"day\":\"");if(!d || !strchr(d,'}'))return NULL;
+    cJSON *r=calloc(1,sizeof *r);r->children=calloc(6,sizeof *r);
+    cJSON *v=r->children;v[0].type=1;v[0].valuestring=calloc(16,1);
+    if(sscanf(d,"\"day\":\"%15[^\"]",v[0].valuestring)!=1){free(v[0].valuestring);free(v);free(r);return NULL;}
+    d=strstr(line,"\"attempts\":");v[1].type=2;v[1].valuedouble=d?strtol(d+11,NULL,10):0;
+    d=strstr(line,"\"stalled\":true");v[2].type=d?3:0;
+    d=strstr(line,"\"last_error\":\"");if(d){v[3].type=1;v[3].valuestring=calloc(96,1);sscanf(d,"\"last_error\":\"%95[^\"]",v[3].valuestring);}
+    d=strstr(line,"\"phase\":\"");if(d){v[4].type=1;v[4].valuestring=calloc(32,1);sscanf(d,"\"phase\":\"%31[^\"]",v[4].valuestring);}
+    d=strstr(line,"\"generation\":\"");if(d){v[5].type=1;v[5].valuestring=calloc(40,1);sscanf(d,"\"generation\":\"%39[^\"]",v[5].valuestring);}
+    return r;
+}
+static cJSON *cJSON_GetObjectItem(const cJSON *r,const char *name) {
+    if(!r)return NULL;int i=!strcmp(name,"day")?0:!strcmp(name,"attempts")?1:!strcmp(name,"stalled")?2:!strcmp(name,"phase")?4:!strcmp(name,"generation")?5:3;
+    return r->children+i;
+}
+static bool cJSON_IsString(const cJSON *v){return v && v->type==1;}
+static bool cJSON_IsNumber(const cJSON *v){return v && v->type==2;}
+static bool cJSON_IsTrue(const cJSON *v){return v && v->type==3;}
+static void cJSON_Delete(cJSON *r){if(r){free(r->children[0].valuestring);free(r->children[3].valuestring);free(r->children[4].valuestring);free(r->children[5].valuestring);free(r->children);free(r);}}
+'''
+code+=''.join(function(SW,n) for n in ['pending_path','pending_export_mark_session',
+    'pending_export_ack_session','pending_read','pending_upload_ready','pending_mark_upload_ready',
+    'session_writer_mark_upload_invalidation','pending_key_valid',
+    'session_writer_next_upload_invalidation','session_writer_ack_upload_invalidation',
+    'pending_reason','pending_update','pending_error_is_permanent'])
+code+=r'''
+static int64_t esp_timer_get_time(void){return 1000000;}
+static void storage_write_batch(session_writer_t *s,stream_batch_t *b){(void)s;(void)b;}
+static void batch_reset(stream_batch_t *b){(void)b;}
+static void storage_commit(session_writer_t *s){(void)s;}
+static void io_fail(session_writer_t *s,const char *v){(void)v;s->storage_failed=true;}
+static void noon_day_folder_local(time_t t,char *out,size_t n){(void)t;snprintf(out,n,"20260906");}
+static void as11_time_noon_day(int64_t t,char *out,size_t n){(void)t;snprintf(out,n,"20260906");}
+static void write_manifest(session_writer_t *s,const char *st){
+    (void)st;assert(!s->files_open);assert(!s->flow.f_l0 && !s->f_events && !s->f_ckpt);
+    char p[160];pending_path(s->session_id,p,sizeof p);assert(access(p,F_OK)==0);manifests++;
+}
+static void sd_storage_recording_end(void){}
+static void lat_report(void){}
+static void batch_pool_destroy(session_writer_t *s){(void)s;}
+static void vSemaphoreDelete(void *p){(void)p;}
+'''
+code+=function(SW,'close_session_file')+function(SW,'storage_finalize')
+code+=r'''
+static void check(const char *id,int want,bool needs) {
+    char p[160],day[16];pending_path(id,p,sizeof p);int attempts;bool stalled;
+    pending_read(p,&attempts,&stalled,day);assert(!strcmp(day,"20260906"));
+    assert(attempts==want && stalled==needs);
+}
+int main(void) {
+    // Finalization closes raw data, then durable intent, then terminal manifest.
+    session_writer_t s={.files_open=true};snprintf(s.session_id,sizeof s.session_id,"first");
+    s.flow.f_l0=tmpfile();s.f_events=tmpfile();s.f_ckpt=tmpfile();
+    sw_cmd_t cmd={.state="completed"};storage_finalize(&s,&cmd);
+    assert(manifests==1);check("first",0,false);
+    // Failed marker sync prevents terminal publication; recovery retains its work.
+    memset(&s,0,sizeof s);snprintf(s.session_id,sizeof s.session_id,"failed");
+    sync_fail=1;closed=0;storage_finalize(&s,&cmd);
+    assert(s.storage_failed && manifests==1 && closed==1);
+    assert(access("./pending_export/failed.json",F_OK)!=0);sync_fail=0;
+    assert(pending_export_mark_session("second","20260906"));
+    char p[160];pending_path("first",p,sizeof p);
+    pending_update(p,"20260906",1,false,ESP_FAIL);check("first",1,false);
+    // Simulate reset halfway through appending a new record; prior line wins.
+    FILE *f=fopen(p,"a");fputs("{\"day\":\"20260906\",\"attempts\":9",f);fclose(f);
+    check("first",1,false);
+    pending_update(p,"20260906",2,true,EDF_GEN_ERR_POSITION_GAPS);check("first",2,true);
+    char reason[96];pending_reason(p,reason,sizeof reason);
+    assert(!strcmp(reason,"positioned_gaps_require_discontinuous_export"));
+    assert(pending_error_is_permanent(EDF_GEN_ERR_POSITION_GAPS));
+    // Idempotent marker creation does not erase retry metadata after reboot.
+    assert(pending_export_mark_session("first","20260906"));check("first",2,true);
+    allow_lease=false;pending_export_ack_session("first");check("first",2,true);
+    allow_lease=true;pending_export_ack_session("first");assert(access(p,F_OK)!=0);
+    check("second",0,false);assert(lease_depth==0);
+    assert(session_writer_mark_upload_invalidation("20260906")==ESP_OK);
+    char token[128],again[128];uint32_t day;
+    assert(session_writer_next_upload_invalidation(&day,token,sizeof token) && day==20260906);
+    // No RAM callback/queue state is needed to rediscover the same generation.
+    assert(session_writer_next_upload_invalidation(&day,again,sizeof again));assert(!strcmp(token,again));
+    allow_lease=false;assert(session_writer_ack_upload_invalidation(day,token)==ESP_ERR_TIMEOUT);
+    allow_lease=true;assert(session_writer_next_upload_invalidation(&day,again,sizeof again));
+    // A new publication between next and ack cannot be erased by the old token.
+    assert(session_writer_mark_upload_invalidation("20260906")==ESP_OK);
+    assert(session_writer_ack_upload_invalidation(day,token)==ESP_ERR_INVALID_STATE);
+    assert(session_writer_next_upload_invalidation(&day,again,sizeof again));assert(strcmp(token,again));
+    assert(session_writer_ack_upload_invalidation(20260905,again)==ESP_ERR_INVALID_STATE);
+    // An interrupted newer append preserves the last complete handoff token.
+    char handoff[160];pending_path("rebuild_20260906",handoff,sizeof handoff);
+    f=fopen(handoff,"a");fputs("{\"day\":\"20260906\",\"phase\":\"upload_pending\"",f);fclose(f);
+    assert(session_writer_next_upload_invalidation(&day,token,sizeof token));assert(!strcmp(token,again));
+    // A failed durable acknowledgement never consumes the work, even when
+    // the uploader has already deleted its old index and will repeat safely.
+    unlink_fail=1;assert(session_writer_ack_upload_invalidation(day,again)==ESP_FAIL);
+    unlink_fail=0;assert(session_writer_next_upload_invalidation(&day,token,sizeof token));assert(!strcmp(token,again));
+    assert(session_writer_ack_upload_invalidation(day,again)==ESP_OK);
+    assert(!session_writer_next_upload_invalidation(&day,again,sizeof again));
+    assert(lease_depth==0);
+    unlink("./pending_export/second.json");rmdir("./pending_export");
+    puts("production durable export intent: finalization, failed sync/unlink, torn journals, reboot and generation-fenced acknowledgement passed");
+}
+'''
+if __name__=='__main__':
+    run('pending_intent_test',code)

--- a/scripts/pending_export_service_test.py
+++ b/scripts/pending_export_service_test.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Production retry selection and persistent scheduler handoff interleavings."""
+from pending_export_behavior_test import code as pending_code
+from session_storage_behavior_test import SW, function, run
+
+code = pending_code.split('int main(void) {')[0] + r'''
+#define SD_STREAMS_DIR "./raw"
+#define PENDING_MAX_ATTEMPTS 12
+#define PENDING_MIN_FREE_HEAP (12 * 1024)
+#define MALLOC_CAP_INTERNAL 1
+static bool s_deferred_export_enabled=true;
+static session_writer_t *s_active;
+static int generated, rejected_nudges, dir_index, missing_fault;
+static char last_rebuilt[16];
+static bool sd_storage_recording_active(void){return false;}
+static bool sd_storage_recording_pending(void){return false;}
+static size_t heap_caps_get_free_size(int cap){(void)cap;return 100000;}
+static void crash_diag_note_activity(const char *s){(void)s;}
+static esp_err_t edf_gen_rebuild_day(const char *day){
+    generated++;snprintf(last_rebuilt,sizeof last_rebuilt,"%s",day);
+    // This durable hook is also executed by the actual shared rebuild path;
+    // edf_rebuild_behavior_test checks its success/failure sentinel ordering.
+    return session_writer_mark_upload_invalidation(day);
+}
+static void uploader_request_scan(void){rejected_nudges++; /* saturated scheduler queue */}
+static DIR *ordered_open(const char *path){(void)path;dir_index=0;return (DIR*)1;}
+static struct dirent *ordered_read(DIR *dir){
+    (void)dir;static struct dirent e;
+    const char *names[]={"missing-key.json","rebuild_20260906.json","healthy-key.json","newer-key.json"};
+    if(dir_index==4)return NULL;
+    memset(&e,0,sizeof e);strcpy(e.d_name,names[dir_index++]);return &e;
+}
+static int ordered_close(DIR *dir){(void)dir;return 0;}
+static int source_stat(const char *path,struct stat *out){
+    if(missing_fault && !strcmp(path,"./raw/20260905")){errno=EIO;return -1;}
+    return stat(path,out);
+}
+static time_t fixed_time(time_t *out){time_t now=1800000000;if(out)*out=now;return now;}
+#define opendir ordered_open
+#define readdir ordered_read
+#define closedir ordered_close
+#define stat(...) source_stat(__VA_ARGS__)
+#define time fixed_time
+'''
+code += function(SW,'pending_export_service_unlocked')+function(SW,'pending_export_service')
+code += r'''
+#undef opendir
+#undef readdir
+#undef closedir
+#undef stat
+#undef time
+int main(void){
+    mkdir(SD_STREAMS_DIR,0700);mkdir(SD_STREAMS_DIR "/20260906",0700);
+    assert(pending_export_mark_session("missing-key","20260905"));
+    assert(pending_export_mark_session("healthy-key","20260906"));
+    pending_export_service();
+    assert(generated==1 && !strcmp(last_rebuilt,"20260906") && rejected_nudges==1);
+    assert(access("./pending_export/healthy-key.json",F_OK)!=0);
+    assert(access("./pending_export/missing-key.json",F_OK)==0);
+    uint32_t day;char token[128],token_after_restart[128];
+    assert(session_writer_next_upload_invalidation(&day,token,sizeof token) && day==20260906);
+    // Queue delivery was rejected, but the last authoritative work survived.
+    assert(access("./pending_export/rebuild_20260906.json",F_OK)==0);
+    struct stat before,after;assert(stat("./pending_export/missing-key.json",&before)==0);
+    for(int i=0;i<100;i++)pending_export_service();
+    assert(generated==1);assert(stat("./pending_export/missing-key.json",&after)==0);
+    assert(before.st_size==after.st_size); // repeated absence cannot grow the journal forever
+    assert(session_writer_next_upload_invalidation(&day,token_after_restart,sizeof token_after_restart));
+    assert(!strcmp(token,token_after_restart)); // filesystem-only rediscovery; no queued state
+    int attempts;bool stalled;char day_text[16];
+    pending_read("./pending_export/missing-key.json",&attempts,&stalled,day_text);
+    assert(attempts==0 && !stalled && !strcmp(day_text,"20260905"));
+    // Neither missing source nor unacknowledged upload_pending monopolizes work.
+    mkdir(SD_STREAMS_DIR "/20260907",0700);
+    assert(pending_export_mark_session("newer-key","20260907"));
+    missing_fault=1;pending_export_service();
+    assert(generated==2 && !strcmp(last_rebuilt,"20260907"));
+    assert(access("./pending_export/missing-key.json",F_OK)==0);
+    // Returning source becomes eligible without resetting or deleting its intent.
+    missing_fault=0;mkdir(SD_STREAMS_DIR "/20260905",0700);pending_export_service();
+    assert(generated==3 && !strcmp(last_rebuilt,"20260905"));
+    assert(access("./pending_export/missing-key.json",F_OK)!=0);
+    assert(access("./pending_export/rebuild_20260905.json",F_OK)==0);
+    assert(lease_depth==0);
+    puts("production retry service: missing-first/EIO fairness, restored-source retry, saturated wakeup and reboot-safe handoff passed");
+}
+'''
+if __name__ == '__main__':
+    run('pending_service',code)

--- a/scripts/prepare_host_lvgl.py
+++ b/scripts/prepare_host_lvgl.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Resolve the exact LVGL 8.4.0 input source used by the release-cancellation test."""
+import hashlib
+from pathlib import Path
+from urllib.request import urlopen
+
+ROOT = Path(__file__).resolve().parents[1]
+EXPECTED_SHA256 = "ce2d4915b4e478c02a6f86474e4a241056128f674c60edfd1d40ad5e7fd1b599"
+URL = "https://raw.githubusercontent.com/lvgl/lvgl/v8.4.0/src/core/lv_indev.c"
+
+
+def prepare_lvgl():
+    managed = ROOT / "managed_components/lvgl__lvgl/src/core/lv_indev.c"
+    cached = ROOT / ".host-deps/lvgl-8.4.0/lv_indev.c"
+    path = managed if managed.exists() else cached
+    if not path.exists():
+        with urlopen(URL, timeout=30) as response:
+            content = response.read()
+        if hashlib.sha256(content).hexdigest() != EXPECTED_SHA256:
+            raise RuntimeError("LVGL 8.4.0 source digest mismatch")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content)
+    if hashlib.sha256(path.read_bytes()).hexdigest() != EXPECTED_SHA256:
+        raise RuntimeError(f"LVGL 8.4.0 source digest mismatch: {path}")
+    return path
+
+
+if __name__ == "__main__":
+    print(prepare_lvgl())

--- a/scripts/psram_task_lifecycle_contract_test.py
+++ b/scripts/psram_task_lifecycle_contract_test.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Contracts for reclaiming PSRAM-backed task stacks and internal TCBs."""
+
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MAIN = ROOT / "main"
+HELPER_C = (MAIN / "psram_task.c").read_text(encoding="utf-8")
+HELPER_H = (MAIN / "psram_task.h").read_text(encoding="utf-8")
+HOST_TEST = (ROOT / "scripts/test-host.sh").read_text(encoding="utf-8")
+
+
+def function_body(source: str, name: str) -> str:
+    match = re.search(
+        rf"^[\w][\w\s*]*\b{name}\s*\([^;{{}}]*\)\s*\{{",
+        source,
+        re.MULTILINE,
+    )
+    if not match:
+        raise AssertionError(f"missing function: {name}")
+    depth = 1
+    cursor = match.end()
+    while cursor < len(source) and depth:
+        if source[cursor] == "{":
+            depth += 1
+        elif source[cursor] == "}":
+            depth -= 1
+        cursor += 1
+    if depth:
+        raise AssertionError(f"unterminated function: {name}")
+    return source[match.end(): cursor - 1]
+
+
+# The ESP-IDF WithCaps API owns both buffers and has the matching deletion API.
+# Plain xTaskCreateStaticPinnedToCore leaves caller-provided buffers allocated
+# forever after vTaskDelete(), which was the original leak. ESP-IDF's NULL
+# deletion path creates a temporary internal-stack task and aborts on OOM, so a
+# retained static reaper must always invoke the non-self deletion path.
+create = function_body(HELPER_C, "psram_task_create")
+delete = function_body(HELPER_C, "psram_task_delete")
+init = function_body(HELPER_C, "psram_task_init")
+reaper = function_body(HELPER_C, "psram_task_reaper")
+assert "xTaskCreatePinnedToCoreWithCaps" in create
+assert "MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT" in create
+assert "heap_caps_malloc(stack_size" not in create
+assert "vTaskDeleteWithCaps(task)" in delete
+assert "vTaskDeleteWithCaps(victim)" in reaper
+assert "xTaskCreateStaticPinnedToCore" in init
+assert "xQueueCreateStatic" in init
+assert "vTaskDeleteWithCaps(NULL)" not in HELPER_C
+assert "xQueueSend(s_reaper_queue, &current, portMAX_DELAY)" in delete
+assert "vTaskSuspend(NULL)" in delete
+assert "psram_task_init" in (MAIN / "main.c").read_text(encoding="utf-8")
+assert "psram_task_delete(TaskHandle_t task)" in HELPER_H
+
+# Audit every concrete helper call. A WithCaps task must not use plain
+# vTaskDelete(), because that unlinks the task without reclaiming its PSRAM
+# stack or internal TCB. The 7B storage worker is a deliberate dual-mode
+# exception: persistent WithCaps on hardware, ordinary xTaskCreate/vTaskDelete
+# under QEMU.
+created = set()
+sources = {}
+for path in sorted(MAIN.glob("*.c")):
+    source = path.read_text(encoding="utf-8")
+    sources[path.name] = source
+    for match in re.finditer(
+        r"\bpsram_task_create\s*\(\s*([A-Za-z_]\w*)\s*,", source
+    ):
+        created.add((path.name, match.group(1)))
+
+assert created, "no psram_task_create callers found"
+raw_delete_exception = {("bsp_display_7b.c", "storage_status_task")}
+for filename, task_name in sorted(created):
+    body = function_body(sources[filename], task_name)
+    if (filename, task_name) not in raw_delete_exception:
+        assert "vTaskDelete(" not in body, (
+            f"{filename}:{task_name} deletes a WithCaps task without reclaiming it"
+        )
+
+# These tasks have finite/error exits today and therefore must exercise the
+# reclaiming path. Persistent workers intentionally have no deletion call.
+self_deleting = {
+    ("as11_ble.c", "pair_task"),
+    ("as11_ble.c", "confirm_task"),
+    ("as11_ble.c", "reconnect_task"),
+    ("as11_ble.c", "auto_reconnect_task"),
+    ("bsp_power.c", "battery_monitor_task"),
+    ("log_stream.c", "ws_forwarder_task"),
+    ("net_provision.c", "wifi_scan_task"),
+    ("net_provision.c", "rebuild_day_task"),
+    ("net_provision.c", "format_sd_task"),
+    ("net_provision.c", "netprov_dns_task"),
+    ("oximeter.c", "auto_pair_task"),
+    ("oximeter_legacy.c", "pair_task"),
+    ("oximeter_legacy.c", "pull_task"),
+    ("oximeter_oxyii.c", "pair_task"),
+    ("oximeter_oxyii.c", "canonical_migration_task"),
+    ("oximeter_oxyii.c", "pull_task"),
+}
+assert self_deleting <= created, "self-deleting task missing from helper audit"
+for filename, task_name in sorted(self_deleting):
+    body = function_body(sources[filename], task_name)
+    assert "psram_task_delete(NULL)" in body, (
+        f"{filename}:{task_name} has no reclaiming self-delete path"
+    )
+
+# OTA URL uses ordinary xTaskCreate and therefore self-deletes normally.  The
+# streamed flash worker is deliberately parent-joined: after publishing its
+# result it parks, and the owning HTTP task deletes it before freeing the
+# shared event group and buffers.
+ota_url = function_body(sources["net_provision.c"], "ota_url_task")
+assert "vTaskDelete(NULL)" in ota_url
+assert "psram_task_delete" not in ota_url
+
+assert "psram_task_lifecycle_contract_test.py" in HOST_TEST
+
+print(f"PSRAM task lifecycle contract passed ({len(created)} callers audited)")

--- a/scripts/rapid_session_lifecycle_contract_test.py
+++ b/scripts/rapid_session_lifecycle_contract_test.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Contracts for repeated therapy START/STOP without FD or writer retention."""
+
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WRITER = (ROOT / "main/session_writer.c").read_text(encoding="utf-8")
+HOST_TEST = (ROOT / "scripts/test-host.sh").read_text(encoding="utf-8")
+
+
+def function_body(source: str, name: str) -> str:
+    match = re.search(rf"\b{name}\s*\([^;]*?\)\s*\{{", source, re.DOTALL)
+    if not match:
+        raise AssertionError(f"missing function: {name}")
+    depth = 1
+    cursor = match.end()
+    while cursor < len(source) and depth:
+        if source[cursor] == "{":
+            depth += 1
+        elif source[cursor] == "}":
+            depth -= 1
+        cursor += 1
+    if depth:
+        raise AssertionError(f"unterminated function: {name}")
+    return source[match.end(): cursor - 1]
+
+
+request = function_body(WRITER, "sw_request_finalize")
+start = function_body(WRITER, "session_writer_start")
+send_open = function_body(WRITER, "storage_queue_send_open")
+finish = function_body(WRITER, "storage_finish_and_dispatch")
+post = function_body(WRITER, "sw_post_task")
+worker = function_body(WRITER, "sw_storage_task")
+stream = function_body(WRITER, "session_writer_try_stream_data_raw")
+notify = function_body(WRITER, "session_writer_on_notification")
+
+# A stop is terminal storage work, never a slow post-pipeline job.  Regular
+# work preserves one queue slot so the sole BLE consumer never waits at STOP.
+assert "SW_CMD_FINALIZE" in request
+assert "SW_STORAGE_TERMINAL_RESERVE 1" in WRITER
+assert "xQueueSend(s_storage_q, &fin, 0)" in request
+assert "xQueueSend(s_storage_q, &fin, portMAX_DELAY)" not in request
+assert "xQueueSend(s_post_q" not in request
+assert "storage_finalize(" not in request
+assert "free(s)" not in request
+assert "s->end_time_us = esp_timer_get_time()" in request
+assert request.find("s_active != s") < request.find("s->finalize_requested"), (
+    "an obsolete borrowed pointer is dereferenced before active-owner validation"
+)
+
+# The lifecycle gate orders old FINALIZE before new OPEN, and OPEN is visible
+# to the worker before any producer can discover the new pointer.
+assert request.find("xSemaphoreTake(s_active_mutex") < request.find(
+    "xQueueSend(s_storage_q, &fin"
+)
+assert start.find("xSemaphoreTake(s_active_mutex") < start.find(
+    "storage_queue_send_open(&cmd"
+)
+assert start.find("storage_queue_send_open(&cmd") < start.find("s_active = s")
+assert "uxQueueSpacesAvailable(s_storage_q)" in send_open
+assert ">\n                SW_STORAGE_TERMINAL_RESERVE" in send_open
+assert "xQueueSend(s_storage_q, cmd, 0)" in send_open
+
+# Post work owns only copied values.  It cannot retain seven FILE handles,
+# request a second FINALIZE, or free a writer object.
+post_job = re.search(
+    r"/\* ── Post-stop pipeline job.*?typedef struct \{(?P<body>.*?)"
+    r"\}\s*sw_post_job_t;",
+    WRITER,
+    re.DOTALL,
+)
+assert post_job, "missing post-job definition"
+post_fields = post_job.group("body")
+assert "session_writer_t" not in post_fields
+assert "session_dir" in post_fields and "session_id" in post_fields
+assert "SW_CMD_FINALIZE" not in post
+assert "free(s)" not in post
+assert "post_wait_for_storage_quiet()" in post
+
+# Storage closes/finalises first, copies metadata second, and frees the sole
+# live writer owner last.  Queue overflow degrades to a durable day rebuild.
+assert finish.find("storage_finalize(s, cmd)") < finish.find(
+    "xQueueSend(s_post_q"
+) < finish.rfind("free(s)")
+finalize = function_body(WRITER, "storage_finalize")
+assert "storage_finish_and_dispatch(finished, &cmd)" in worker
+
+# Producer/event paths pin active->fill, preventing a BATCH/EVENT from landing
+# behind FINALIZE and dereferencing a freed session.
+assert "active_session_lock()" in stream
+assert "session_writer_get_active()" not in stream
+assert "active_session_lock()" in notify
+assert "session_writer_get_active()" not in notify
+assert "active_session_try_lock(&lifecycle_sampled)" in worker
+assert "if (!lifecycle_sampled) continue" in worker
+try_lock = function_body(WRITER, "active_session_try_lock")
+assert "xSemaphoreTake(s_active_mutex, 0)" in try_lock
+assert "xSemaphoreTake(s_active->fill_mutex, 0)" in try_lock
+assert "portMAX_DELAY" not in try_lock
+assert "producer_commit(" not in worker
+
+# Both real therapy-start publishers must win the display lifecycle gate before
+# starting recording or alert state. If OTA has already committed its restart,
+# the event/heuristic is abandoned instead of reopening the race window.
+gate_call = "if (!bsp_display_set_therapy_active(true))"
+assert gate_call in stream
+assert stream.index(gate_call) < stream.index("session_writer_start()")
+assert "therapy recovery ignored: restart already committed" in stream
+assert gate_call in notify
+therapy_start = notify[notify.index("if (ev_type == AS11_EV_THERAPY_START)"):]
+assert therapy_start.index(gate_call) < therapy_start.index(
+    'crash_diag_note_activity("therapy_start")'
+) < therapy_start.index("therapy_alert_on_therapy_start()") \
+  < therapy_start.index("session_writer_start()")
+assert "TherapyStart ignored: restart already committed" in therapy_start
+
+# The worker refuses to operate on a command whose writer does not own the
+# open descriptors.  OPEN is rejected even when it repeats the same pointer.
+assert "if (file_owner != NULL)" in worker
+for command in ("BATCH", "EVENT", "FINALIZE"):
+    assert f"lifecycle violation: {command} owner mismatch" in worker
+
+# A failed regular enqueue leaves the periodic commit due so it retries after
+# the worker has drained capacity.
+assert "SW_CMD_COMMIT" in worker and "s->commit_queued = true" in worker
+barrier = worker[worker.index("case SW_CMD_COMMIT:"):worker.index("case SW_CMD_FINALIZE:")]
+assert barrier.index("storage_commit(cmd.s)") < barrier.index("last_commit_us = esp_timer_get_time()")
+assert "xQueuePeek" not in worker
+# Actual EVENT -> EVENT -> COMMIT queue execution lives in session_checkpoint_barrier_test.py.
+
+# Exhaust the compact admission model, including the former 23-queued-items
+# counterexample.  Whenever a session is published active, one terminal slot
+# must remain available regardless of regular sends, drains and restarts.
+QUEUE_LEN = 24
+RESERVE = 1
+states = {(0, False)}  # (queued commands, active session published)
+for _ in range(100):
+    next_states = set(states)
+    for queued, active in states:
+        if queued:
+            next_states.add((queued - 1, active))
+        if active and QUEUE_LEN - queued > RESERVE:
+            next_states.add((queued + 1, active))       # BATCH/EVENT
+        if active:
+            assert queued < QUEUE_LEN, "active session lost its FINALIZE slot"
+            next_states.add((queued + 1, False))       # FINALIZE
+        elif QUEUE_LEN - queued > RESERVE:
+            next_states.add((queued + 1, True))        # OPEN + publish
+    states = next_states
+    for queued, active in states:
+        assert 0 <= queued <= QUEUE_LEN
+        assert not active or queued < QUEUE_LEN
+
+# Full-after-STOP must drain twice before OPEN can consume a slot; the new
+# session can then STOP immediately without blocking or dropping FINALIZE.
+queued, active = 23, True
+queued, active = queued + 1, False
+queued -= 1
+assert QUEUE_LEN - queued == RESERVE and not active
+queued -= 1
+assert QUEUE_LEN - queued > RESERVE
+queued, active = queued + 1, True
+assert queued < QUEUE_LEN
+queued, active = queued + 1, False
+assert queued == QUEUE_LEN and not active
+
+assert "rapid_session_lifecycle_contract_test.py" in HOST_TEST
+
+print("rapid session lifecycle contract passed")

--- a/scripts/rapid_session_lifecycle_contract_test.py
+++ b/scripts/rapid_session_lifecycle_contract_test.py
@@ -85,6 +85,8 @@ assert finish.find("storage_finalize(s, cmd)") < finish.find(
     "xQueueSend(s_post_q"
 ) < finish.rfind("free(s)")
 finalize = function_body(WRITER, "storage_finalize")
+assert finalize.index("pending_export_mark_session(s->session_id, export_day)") < finalize.index("write_manifest(s, state)")
+assert "pending_export_ack_session(job.session_id)" in post
 assert "storage_finish_and_dispatch(finished, &cmd)" in worker
 
 # Producer/event paths pin active->fill, preventing a BATCH/EVENT from landing

--- a/scripts/rgb_frame_handoff_test.py
+++ b/scripts/rgb_frame_handoff_test.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Exercise the production flush path against an independently timed scanout."""
+from pathlib import Path
+import re
+import subprocess
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[1]
+source = (ROOT / "main/bsp_display_7b.c").read_text()
+
+
+def function(name):
+    match = re.search(rf"static void {name}\([^;]*?\)\s*\{{", source)
+    assert match, name
+    depth, end = 1, match.end()
+    while depth:
+        depth += (source[end] == "{") - (source[end] == "}")
+        end += 1
+    return source[match.start():end]
+
+
+fixture = r'''
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#define CONFIG_SOMNOTRACE_BOARD_QEMU 0
+#define ESP_OK 0
+#define ESP_ERR_TIMEOUT 1
+#define CONTROLLER_PANEL_SUBMIT 0
+#define CONTROLLER_PANEL_HANDOFF 1
+#define WAVESHARE_7B_H_RES 1024
+#define WAVESHARE_7B_V_RES 600
+#define pdTRUE 1
+#define pdMS_TO_TICKS(n) (n)
+#define ESP_LOGE(...) ((void)0)
+#define ESP_LOGW(...) ((void)0)
+typedef int esp_err_t;
+typedef void *esp_lcd_panel_handle_t;
+typedef uint16_t lv_color_t;
+typedef struct {void *user_data;} lv_disp_drv_t;
+typedef struct {int unused;} lv_area_t;
+static uint32_t s_flush_count, s_flush_timeouts;
+static unsigned notifications, timeouts_left, restarts, retries, ready;
+static unsigned selected, scanned, submit_calls, handoff_errors;
+static bool inject_before_selection, inject_after_selection, last_area;
+static void boundary(void) {scanned = selected; ++notifications;}
+static void controller_diagnostics_record(int operation, int result) {
+    if (operation == CONTROLLER_PANEL_HANDOFF && result != ESP_OK) ++handoff_errors;
+}
+static int esp_lcd_panel_draw_bitmap(void *panel, int x, int y, int w, int h, const void *pixels) {
+    (void)panel; (void)x; (void)y; (void)pixels;
+    assert(w == 1024 && h == 600); ++submit_calls;
+    if (retries) {--retries; return 2;}
+    if (inject_before_selection) boundary();
+    selected = 1;
+    if (inject_after_selection) boundary();
+    return ESP_OK;
+}
+static unsigned ulTaskNotifyTake(int clear, unsigned wait) {
+    assert(clear == pdTRUE);
+    if (notifications) {unsigned n = notifications; notifications = 0; return n;}
+    if (!wait) return 0;
+    assert(!ready);
+    if (timeouts_left) {--timeouts_left; return 0;}
+    boundary(); notifications = 0; return 1;
+}
+static int esp_lcd_rgb_panel_restart(void *panel) {
+    (void)panel; assert(!ready); ++restarts; return ESP_OK;
+}
+static void vTaskDelay(unsigned ticks) {assert(ticks == 100 && !ready);}
+static bool lv_disp_flush_is_last(lv_disp_drv_t *drv) {(void)drv; return last_area;}
+static void lv_disp_flush_ready(lv_disp_drv_t *drv) {
+    (void)drv;
+    if (last_area) assert(selected == 1 && scanned == 1);
+    ++ready;
+}
+'''
+fixture += function("submit_rgb_frame") + "\n" + function("flush_cb")
+fixture += r'''
+int main(void) {
+    lv_disp_drv_t drv = {0}; lv_area_t area = {0}; lv_color_t pixels = 0;
+    for (unsigned before = 0; before < 2; ++before)
+    for (unsigned after = 0; after < 2; ++after)
+    for (unsigned stale = 0; stale < 2; ++stale)
+    for (unsigned missed = 0; missed < 4; ++missed)
+    for (unsigned fail = 0; fail < 2; ++fail) {
+        selected = scanned = ready = restarts = submit_calls = handoff_errors = 0;
+        s_flush_count = s_flush_timeouts = 0;
+        inject_before_selection = before; inject_after_selection = after;
+        notifications = stale; timeouts_left = missed; retries = fail; last_area = true;
+        flush_cb(&drv, &area, &pixels);
+        assert(ready == 1 && submit_calls == 1 + fail && s_flush_count == 1);
+        assert(restarts == missed && handoff_errors == missed);
+        assert(s_flush_timeouts == missed + fail);
+    }
+    last_area = false; ready = submit_calls = 0; selected = scanned = 0;
+    flush_cb(&drv, &area, &pixels);
+    assert(ready == 1 && submit_calls == 0);
+    puts("RGB handoff: stale IRQs, submit races, missed frames and retries passed");
+}
+'''
+with tempfile.TemporaryDirectory(prefix="somno-rgb-handoff-") as temporary:
+    path = Path(temporary)
+    (path / "test.c").write_text(fixture)
+    subprocess.run(["cc", "-std=c11", "-Wall", "-Wextra", "-Werror",
+                    str(path / "test.c"), "-o", str(path / "test")], check=True)
+    subprocess.run([str(path / "test")], check=True)
+    # The same independent scanout model must reject the previous ordering.
+    raced = fixture.replace("    ulTaskNotifyTake(pdTRUE, 0);", "", 1)
+    raced = raced.replace("    for (;;) {", "    ulTaskNotifyTake(pdTRUE, 0);\n    for (;;) {", 1)
+    (path / "race.c").write_text(raced)
+    subprocess.run(["cc", "-std=c11", "-Wall", "-Wextra", "-Werror",
+                    str(path / "race.c"), "-o", str(path / "race")], check=True)
+    previous = subprocess.run([str(path / "race")], cwd=path, capture_output=True)
+    assert previous.returncode != 0, "test failed to detect the old handoff race"
+    print("Previous clear-before-submit ordering correctly rejected")

--- a/scripts/sd_mount_fallback_contract_test.py
+++ b/scripts/sd_mount_fallback_contract_test.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Contract for resilient SDMMC width and clock fallback."""
+
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = (ROOT / "main/sd_storage.c").read_text(encoding="utf-8")
+
+
+def function(name: str) -> str:
+    match = re.search(
+        rf"^[\w][\w\s*]*\b{name}\s*\([^;{{}}]*\)\s*\{{",
+        SOURCE,
+        re.MULTILINE,
+    )
+    if not match:
+        raise AssertionError(f"missing function {name}")
+    depth = 1
+    cursor = match.end()
+    while cursor < len(SOURCE) and depth:
+        if SOURCE[cursor] == "{":
+            depth += 1
+        elif SOURCE[cursor] == "}":
+            depth -= 1
+        cursor += 1
+    if depth:
+        raise AssertionError(f"unterminated function {name}")
+    return SOURCE[match.end():cursor - 1]
+
+
+mount = function("sdmmc_mount_with_fallback")
+assert mount.count("esp_vfs_fat_sdmmc_mount") == 3
+assert "slot->width = 1" in mount
+assert "host->max_freq_khz = SDMMC_FREQ_DEFAULT" in mount
+assert mount.index("slot->width = 1") < mount.index(
+    "host->max_freq_khz = SDMMC_FREQ_DEFAULT"
+)
+
+init = function("sd_storage_init")
+format_card = function("sd_storage_format")
+assert "sdmmc_mount_with_fallback" in init
+assert "sdmmc_mount_with_fallback" in format_card
+
+print("SDMMC mount fallback contract passed")

--- a/scripts/sd_recording_arbitration_contract_test.py
+++ b/scripts/sd_recording_arbitration_contract_test.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Contracts for atomic raw-recording versus card-reader ownership."""
+
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve().parents[1]
+STORAGE = (ROOT / "main/sd_storage.c").read_text(encoding="utf-8")
+HEADER = (ROOT / "main/sd_storage.h").read_text(encoding="utf-8")
+WRITER = (ROOT / "main/session_writer.c").read_text(encoding="utf-8")
+
+
+def function_body(source: str, name: str) -> str:
+    match = re.search(rf"\b{name}\s*\([^;]*?\)\s*\{{", source, re.DOTALL)
+    if not match:
+        raise AssertionError(f"missing function: {name}")
+    depth = 1
+    cursor = match.end()
+    while cursor < len(source) and depth:
+        if source[cursor] == "{":
+            depth += 1
+        elif source[cursor] == "}":
+            depth -= 1
+        cursor += 1
+    if depth:
+        raise AssertionError(f"unterminated function: {name}")
+    return source[match.end() : cursor - 1]
+
+
+begin = function_body(STORAGE, "sd_storage_recording_begin")
+acquire = function_body(STORAGE, "sd_storage_lease_acquire")
+release = function_body(STORAGE, "sd_storage_lease_release_unchanged")
+mutation_release = function_body(STORAGE, "sd_storage_lease_release")
+assert mutation_release.index("sd_storage_content_changed()") < mutation_release.index(
+    "sd_storage_lease_release_unchanged(role)")
+start = function_body(WRITER, "session_writer_start")
+discard = function_body(WRITER, "session_start_discard")
+
+assert "bool sd_storage_recording_begin(void);" in HEADER
+assert "s_destructive" in STORAGE
+
+# Recording publishes waiter priority, waits only for a bounded reader handoff,
+# and publishes its claim while holding the one arbitration mutex.
+lock_at = begin.find("xSemaphoreTake(s_lease_mutex")
+waiter_at = begin.find("__atomic_add_fetch(&s_recording_waiters, 1, __ATOMIC_RELEASE)")
+destructive_check_at = begin.find("while (s_destructive == 0)")
+reader_check_at = begin.find("if (s_uploading == 0)")
+claim_at = begin.find("__atomic_add_fetch(&s_recording, 1, __ATOMIC_RELEASE)")
+unlock_at = begin.rfind("xSemaphoreGive(s_lease_mutex")
+assert -1 not in (
+    lock_at, waiter_at, destructive_check_at, reader_check_at, claim_at,
+    unlock_at,
+)
+assert lock_at < waiter_at < destructive_check_at < reader_check_at \
+       < claim_at < unlock_at
+assert "SD_RECORDING_PRIORITY_WAIT_MS" in begin
+assert "__atomic_sub_fetch(&s_recording_waiters, 1, __ATOMIC_RELEASE)" in begin
+assert "return claimed" in begin
+
+# UPLOAD and DESTRUCTIVE publish their mutually-exclusive claim beneath that
+# same mutex after acquiring the file-operation gate. A recording claim that
+# wins first is observed before either role starts card I/O.
+upload = acquire[acquire.find("case SD_LEASE_UPLOAD:") :]
+upload_sem = upload.find("xSemaphoreTakeRecursive(s_export_sem")
+upload_lock = upload.find("xSemaphoreTake(s_lease_mutex")
+upload_check = upload.find("s_recording > 0 || sd_storage_recording_pending()")
+upload_claim = upload.find("s_uploading++")
+assert -1 not in (upload_sem, upload_lock, upload_check, upload_claim)
+assert upload_sem < upload_lock < upload_check < upload_claim
+
+destructive = acquire[
+    acquire.find("case SD_LEASE_DESTRUCTIVE:") :
+    acquire.find("case SD_LEASE_EXPORT:")
+]
+destructive_sem = destructive.find("xSemaphoreTakeRecursive(s_export_sem")
+destructive_lock = destructive.find("xSemaphoreTake(s_lease_mutex")
+destructive_check = destructive.find("s_recording > 0 || sd_storage_recording_pending() ||")
+destructive_claim = destructive.find("s_destructive++")
+assert -1 not in (
+    destructive_sem, destructive_lock, destructive_check, destructive_claim
+)
+assert destructive_sem < destructive_lock < destructive_check < destructive_claim
+assert "s_destructive--" in release
+assert "s_uploading--" in release
+
+# A writer is never allocated, published or queued without a successful raw-
+# recording claim. Refusal therefore has no large session object to unwind;
+# every later failure uses the centralized claim-aware discard helper.
+claim_at = start.find("sd_storage_recording_try_begin()")
+alloc_at = start.find("heap_caps_calloc(1, sizeof(session_writer_t)")
+open_at = start.find("storage_queue_send_open(&cmd")
+publish_at = start.find("s_active = s")
+assert -1 not in (claim_at, alloc_at, open_at, publish_at)
+assert claim_at < alloc_at < open_at < publish_at
+refused_claim = start[claim_at:alloc_at]
+assert "return NULL" in refused_claim
+assert "batch_pool_create" not in refused_claim
+assert start.count("session_start_discard(s)") == 4
+for cleanup in (
+    "batch_pool_destroy(s)",
+    "vSemaphoreDelete(s->fill_mutex)",
+    "sd_storage_recording_end()",
+    "free(s)",
+):
+    assert cleanup in discard, f"start discard misses {cleanup}"
+
+# Compact interleaving model: because all three claim transitions execute
+# under the same mutex, no possible winner can overlap recording with either
+# a reader or destructive owner.
+states = {(0, 0, 0)}  # recording, uploading, destructive
+for _ in range(12):
+    next_states = set(states)
+    for recording, uploading, destructive_count in states:
+        if not uploading and not destructive_count:
+            next_states.add((recording + 1, uploading, destructive_count))
+        if not recording and not destructive_count:
+            next_states.add((recording, uploading + 1, destructive_count))
+        if not recording and not uploading and not destructive_count:
+            next_states.add((recording, uploading, destructive_count + 1))
+        if recording:
+            next_states.add((recording - 1, uploading, destructive_count))
+        if uploading:
+            next_states.add((recording, uploading - 1, destructive_count))
+        if destructive_count:
+            next_states.add((recording, uploading, destructive_count - 1))
+    states = next_states
+    for recording, uploading, destructive_count in states:
+        assert not (recording and uploading)
+        assert not (recording and destructive_count)
+        assert not (uploading and destructive_count)
+
+print("SD recording arbitration contract passed")
+
+# Exercise the production state transitions and deadline, not just a model of
+# them: an old reader outlives one attempt, intent prevents reacquisition, then
+# the retained start claims the card when that reader actually releases it.
+import subprocess
+import tempfile
+
+
+def production_function(name: str) -> str:
+    match = re.search(r"^(?:static )?[\w\s*]+\b" + name + r"\([^;]*?\)\s*\{", STORAGE, re.M)
+    assert match, name
+    depth, end = 1, match.end()
+    while depth:
+        depth += (STORAGE[end] == "{") - (STORAGE[end] == "}")
+        end += 1
+    return STORAGE[match.start():end] + "\n"
+
+
+fixture = r'''
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include "sd_storage.h"
+#define pdTRUE 1
+#define portMAX_DELAY 0
+#define pdMS_TO_TICKS(ms) (ms)
+#define SD_RECORDING_PRIORITY_WAIT_MS 500U
+#define SD_RECORDING_PRIORITY_POLL_MS 5U
+#define ESP_LOGW(...) ((void)0)
+typedef uint32_t TickType_t;
+static int s_export_sem=2,s_lease_mutex=1;
+static int s_recording,s_recording_waiters,s_uploading,s_destructive;
+static uint32_t s_recording_intents,s_content_generation=7;
+static int mutex_depth,export_depth;
+static bool mutex_busy,s_mounted=true,cache_valid;
+static uint64_t cached_free;
+bool sd_storage_get_cached_free(uint64_t *out,uint64_t *total)
+{ (void)total; *out=cached_free; return cache_valid; }
+static int64_t now_us,release_at;
+static void lease_init_once(void) {}
+static int xSemaphoreTake(int sem, TickType_t ticks)
+{ if(mutex_busy){assert(ticks==0);return 0;}assert(sem==1 && !mutex_depth);++mutex_depth;return pdTRUE; }
+static void xSemaphoreGive(int sem)
+{ assert(sem==1 && mutex_depth==1);--mutex_depth; }
+static int xSemaphoreTakeRecursive(int sem,TickType_t ticks)
+{ (void)ticks;assert(sem==2);++export_depth;return pdTRUE; }
+static void xSemaphoreGiveRecursive(int sem)
+{ assert(sem==2 && export_depth>0);--export_depth; }
+static int64_t esp_timer_get_time(void) { return now_us; }
+static void vTaskDelay(TickType_t ticks)
+{
+    assert(!mutex_depth && sd_storage_recording_pending());
+    now_us+=(int64_t)ticks*1000;
+    if(release_at && now_us>=release_at) {
+        release_at=0;sd_storage_lease_release(SD_LEASE_UPLOAD);
+    }
+}
+'''
+fixture += re.search(r"^#define SD_FLOOR_BYTES[^\n]*", STORAGE, re.M).group(0) + "\n"
+fixture += "".join(production_function(name) for name in (
+    "sd_storage_content_generation", "sd_storage_content_changed",
+    "sd_storage_recording_intent_begin", "sd_storage_recording_intent_end",
+    "sd_storage_recording_pending", "sd_storage_recording_active",
+    "sd_storage_recording_begin", "sd_storage_recording_end",
+    "sd_storage_recording_try_begin", "sd_storage_reserve_for_recording_cached",
+    "sd_storage_lease_acquire", "sd_storage_lease_release_unchanged",
+    "sd_storage_lease_release"))
+fixture += r'''
+int main(void) {
+    assert(sd_storage_lease_acquire(SD_LEASE_UPLOAD,0));
+    sd_storage_recording_intent_begin();assert(sd_storage_recording_pending());
+    assert(!sd_storage_recording_begin());
+    assert(now_us==500000 && !s_recording_waiters && s_uploading==1);
+    assert(sd_storage_recording_pending()); /* no gap between retries */
+    assert(!sd_storage_lease_acquire(SD_LEASE_UPLOAD,0));
+    assert(!sd_storage_lease_acquire(SD_LEASE_DESTRUCTIVE,0));
+    assert(export_depth==1 && !mutex_depth && !sd_storage_recording_active());
+    /* No force-release: old reader must close before recording may claim. */
+    now_us=650000;sd_storage_lease_release(SD_LEASE_UPLOAD);
+    assert(sd_storage_recording_begin() && now_us==650000);
+    assert(sd_storage_recording_pending() && sd_storage_recording_active());
+    sd_storage_recording_intent_end();assert(!sd_storage_recording_pending());
+    assert(!sd_storage_lease_acquire(SD_LEASE_UPLOAD,0));
+    sd_storage_recording_end();assert(!sd_storage_recording_active());
+    assert(sd_storage_content_generation()==8 && !export_depth && !mutex_depth);
+    /* Multiple pending owners and cancellation remain paired and saturate. */
+    sd_storage_recording_intent_begin();sd_storage_recording_intent_begin();
+    sd_storage_recording_intent_end();assert(sd_storage_recording_pending());
+    sd_storage_recording_intent_end();sd_storage_recording_intent_end();
+    assert(!sd_storage_recording_pending() && !s_recording_intents);
+    assert(sd_storage_lease_acquire(SD_LEASE_DESTRUCTIVE,0));
+    sd_storage_recording_intent_begin();
+    assert(!sd_storage_recording_begin()); /* destructive lease is not revoked */
+    sd_storage_lease_release_unchanged(SD_LEASE_DESTRUCTIVE);
+    sd_storage_recording_intent_end();
+    assert(sd_storage_lease_acquire(SD_LEASE_UPLOAD,0));
+    int64_t start=now_us;release_at=now_us+300000;
+    assert(sd_storage_recording_begin());
+    assert(now_us-start==300000 && !sd_storage_recording_pending());
+    sd_storage_recording_end();
+    assert(sd_storage_lease_acquire(SD_LEASE_UPLOAD,0));
+    start=now_us;assert(!sd_storage_recording_begin());
+    assert(now_us-start==500000 && !sd_storage_recording_pending());
+    sd_storage_lease_release(SD_LEASE_UPLOAD);
+    assert(!s_recording && !s_uploading && !s_destructive && !export_depth && !mutex_depth);
+    start=now_us;mutex_busy=true;
+    assert(!sd_storage_recording_try_begin() && !s_recording);mutex_busy=false;
+    s_lease_mutex=0;assert(!sd_storage_recording_try_begin());s_lease_mutex=1;
+    s_export_sem=0;assert(!sd_storage_recording_try_begin());s_export_sem=2;
+    assert(sd_storage_lease_acquire(SD_LEASE_UPLOAD,0));
+    sd_storage_recording_intent_begin();
+    assert(!sd_storage_recording_try_begin() && sd_storage_recording_pending());
+    sd_storage_lease_release(SD_LEASE_UPLOAD);
+    assert(sd_storage_recording_try_begin() && sd_storage_recording_pending());
+    sd_storage_recording_intent_end();sd_storage_recording_end();
+    assert(now_us==start && !mutex_depth && !export_depth);
+    assert(sd_storage_reserve_for_recording_cached());
+    cache_valid=true;cached_free=SD_FLOOR_BYTES-1;
+    assert(!sd_storage_reserve_for_recording_cached());
+    cached_free=SD_FLOOR_BYTES;assert(sd_storage_reserve_for_recording_cached());
+    s_mounted=false;assert(!sd_storage_reserve_for_recording_cached());
+    puts("Production SD arbitration: retained intent spans 500ms retry, excludes new readers/maintenance, waits for real release, balances stop/success and owner references");
+}
+'''
+with tempfile.TemporaryDirectory(prefix="somno-recording-admission-") as temp:
+    path = Path(temp)
+    (path / "test.c").write_text(fixture)
+    subprocess.run(["cc", "-std=c11", "-Wall", "-Wextra", "-Werror",
+                    "-I" + str(ROOT / "main"), "-I" + str(ROOT / "scripts/test_include"),
+                    str(path / "test.c"), "-o", str(path / "test")], check=True)
+    subprocess.run([str(path / "test")], check=True)

--- a/scripts/session_checkpoint_barrier_test.py
+++ b/scripts/session_checkpoint_barrier_test.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Run the actual storage queue loop with ordered event and commit commands."""
+from session_storage_behavior_test import COMMON, DEFS, SW, function, run
+
+code=COMMON+r'''
+#include <setjmp.h>
+typedef void *SemaphoreHandle_t;
+typedef void *QueueHandle_t;
+typedef struct session_writer session_writer_t;
+typedef int BaseType_t;
+#define pdTRUE 1
+#define pdMS_TO_TICKS(x) (x)
+'''+DEFS+r'''
+static session_writer_t state;
+static sw_cmd_t q[32];static int head,tail,commits;static int64_t now;
+static void *s_storage_q=(void*)1;static jmp_buf complete;
+static int64_t esp_timer_get_time(void){return now;}
+static int xPortGetCoreID(void){return 0;}
+static void vTaskSuspend(void *p){(void)p;}
+static void io_fail(session_writer_t *s,const char *p){(void)p;s->storage_failed=true;}
+static int xQueueReceive(void *queue,void *out,int timeout) {
+    (void)queue;(void)timeout;
+    if(head==tail)longjmp(complete,1);
+    sw_cmd_t cmd=q[head++];memcpy(out,&cmd,sizeof cmd);
+    now=head==1?1000:31000000;
+    return pdTRUE;
+}
+static int xQueueSend(void *queue,const void *p,int timeout){
+    (void)queue;(void)timeout;assert(tail<32);q[tail++]=*(const sw_cmd_t*)p;return pdTRUE;
+}
+static unsigned uxQueueSpacesAvailable(void *p){(void)p;return 24-(tail-head);}
+static session_writer_t *active_session_try_lock(bool *sampled){*sampled=true;return &state;}
+static void active_session_unlock(session_writer_t *s){(void)s;}
+static bool swap_and_enqueue_locked(session_writer_t *s){(void)s;return true;}
+static void storage_open(session_writer_t *s){s->files_open=true;}
+static void storage_write_batch(session_writer_t *s,stream_batch_t *b){(void)s;(void)b;}
+static void storage_finish_and_dispatch(session_writer_t *s,const sw_cmd_t *cmd){(void)s;(void)cmd;assert(0);}
+static void sw_request_finalize(session_writer_t *s,const char *a,int64_t b,bool c){(void)s;(void)a;(void)b;(void)c;assert(0);}
+static void storage_commit(session_writer_t *s){
+    assert(s->have_uncommitted);fflush(s->f_events);long end=ftell(s->f_events);
+    rewind(s->f_events);char b[32]={0};fread(b,1,sizeof b-1,s->f_events);
+    assert(!strcmp(b,"older-event\nnewer-event\n"));fseek(s->f_events,end,SEEK_SET);
+    commits++;s->have_uncommitted=false;
+}
+'''+function(SW,'sw_storage_task')+r'''
+int main(void){
+    state.f_events=tmpfile();assert(state.f_events);state.last_stream_us=1000;
+    q[tail++]=(sw_cmd_t){.type=SW_CMD_OPEN,.s=&state};
+    q[tail++]=(sw_cmd_t){.type=SW_CMD_EVENT,.s=&state,.event_json=strdup("older-event")};
+    q[tail++]=(sw_cmd_t){.type=SW_CMD_EVENT,.s=&state,.event_json=strdup("newer-event")};
+    if(setjmp(complete)==0)sw_storage_task(NULL);
+    assert(commits==1 && head==4 && tail==4 && !state.commit_queued);
+    assert(q[3].type==SW_CMD_COMMIT);fclose(state.f_events);
+    puts("production FIFO barrier: prior queued events become dirty and precede one checkpoint");
+}
+'''
+if __name__=='__main__':
+    run('barrier',code)

--- a/scripts/session_storage_behavior_test.py
+++ b/scripts/session_storage_behavior_test.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Compile the production parser/storage functions and replay positioned raw data.
+
+Platform scheduling and allocation are stubbed. Samples, headers, timestamps,
+missing runs, min/max aggregation, and checkpoint decisions are production C.
+No physical SD/RGB timing is claimed by this deterministic host test.
+"""
+from pathlib import Path
+import os
+import re
+import subprocess
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[1]
+SW = (ROOT / 'main/session_writer.c').read_text()
+EDF = (ROOT / 'main/edf_gen.c').read_text()
+SNT = (ROOT / 'main/snt_format.h').read_text()
+
+
+def function(source, name):
+    m = re.search(r'^(?:static\s+)?[\w *]+\b' + name + r'\([^;{]*\)\s*\{', source, re.M)
+    assert m, name
+    i, depth = m.end(), 1
+    while depth:
+        depth += (source[i] == '{') - (source[i] == '}')
+        i += 1
+    return source[m.start():i] + '\n'
+
+
+COMMON = r'''
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <errno.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <time.h>
+typedef int esp_err_t;
+#define ESP_OK 0
+#define ESP_FAIL -1
+#define ESP_ERR_NO_MEM 0x101
+#define ESP_ERR_INVALID_ARG 0x102
+#define ESP_ERR_INVALID_SIZE 0x104
+#define ESP_ERR_INVALID_STATE 0x103
+#define ESP_ERR_NOT_FOUND 0x105
+#define ESP_ERR_TIMEOUT 0x107
+#define EDF_GEN_ERR_POSITION_GAPS 0x7e01
+#define ESP_LOGI(...) ((void)0)
+#define ESP_LOGW(...) ((void)0)
+#define ESP_LOGE(...) ((void)0)
+#define ESP_LOGD(...) ((void)0)
+'''
+SNT_DEFS = SNT[SNT.index('#define SNT_MAGIC'):SNT.index('/* ── Inline validation')]
+SW_DEFS = SW[SW.index('/* ── Recovery journal'):SW.index('/* ── Module state')]
+DEFS = SNT_DEFS + SW_DEFS
+PRE = COMMON + r'''
+typedef void *SemaphoreHandle_t;
+typedef void *QueueHandle_t;
+typedef struct session_writer session_writer_t;
+''' + DEFS + r'''
+static session_writer_t state;
+static stream_batch_t fill;
+static bool allow_start, s_start_intent, s_therapy_stopped;
+static bool s_in_mask_fit, s_in_cooldown, s_started_from_event, s_transport_uncertain;
+static int64_t now_us = 1000000;
+static uint32_t ui_valid, ui_missing, checkpoints;
+static int sync_fail;
+static int64_t esp_timer_get_time(void) { return now_us; }
+static void vTaskDelay(int n) { (void)n; }
+static void bsp_display_push_flow(float x) { if (isfinite(x)) ui_valid++; else ui_missing++; }
+static void bsp_display_push_flow_gap(uint32_t n) { ui_missing += n; }
+static void bsp_display_push_leak(float x) { (void)x; }
+static void bsp_display_push_metrics(float a,float b,float c) { (void)a;(void)b;(void)c; }
+static bool bsp_display_set_therapy_active(bool x) { return x; }
+static void bsp_display_set_therapy_start_time(int64_t x) { (void)x; }
+static session_writer_t *active_session_lock(void) { return state.active ? &state : NULL; }
+static void active_session_unlock(session_writer_t *s) { (void)s; }
+static session_writer_t *session_writer_start(void) {
+    s_start_intent = !allow_start;
+    if (!allow_start) return NULL;
+    state.active = true;
+    return &state;
+}
+static void sw_request_finalize(session_writer_t *s,const char *a,int64_t b,bool c) {
+    (void)a;(void)b;(void)c; s->active = false;
+}
+static bool swap_and_enqueue_locked(session_writer_t *s) { (void)s; return false; }
+static void io_fail(session_writer_t *s, const char *w) { (void)w;s->storage_failed=true; }
+static bool write_exact(session_writer_t *s,FILE *f,const void *v,size_t n,const char *w) {
+    if (fwrite(v,1,n,f) == n) return true;
+    io_fail(s,w);return false;
+}
+static int test_sync(int fd) { (void)fd; if(sync_fail) { errno=EIO;return -1; } return 0; }
+#define fsync test_sync
+static int64_t lat_begin(void) { return 0; }
+static void lat_end(int a,int64_t b) { (void)a;(void)b; }
+static void lat_report(void) {}
+#define SW_OP_FLUSH 0
+#define SW_OP_FSYNC 1
+static void update_snt_header_sample_count(session_writer_t *s,FILE *f,uint32_t n) {
+    (void)s;long p=ftell(f);fseek(f,offsetof(snt_header_t,sample_count),SEEK_SET);
+    fwrite(&n,sizeof(n),1,f);fseek(f,p,SEEK_SET);
+}
+static void ckpt_write(session_writer_t *s) { assert(!s->storage_failed);checkpoints++;s->ckpt_seq++; }
+'''
+raw = PRE + ''.join(function(SW, n) for n in [
+    'batch_reset', 'storage_mark_position_gap', 'storage_write_brp_frame',
+    'storage_fill_brp_until', 'storage_fill_stream_until', 'storage_write_batch',
+    'storage_commit'])
+raw += SW[SW.index('enum {\n    KEY_PATIENT_FLOW'):SW.index('bool session_writer_try_stream_data_raw')]
+raw += function(SW, 'session_writer_try_stream_data_raw')
+raw += r'''
+static FILE *stream(void) {
+    FILE *f=tmpfile();assert(f);
+    snt_header_t h={.magic=SNT_MAGIC,.version=2,.sample_bytes=2,.n_channels=1,.sample_hz_x10=250};
+    assert(fwrite(&h,sizeof h,1,f)==1);return f;
+}
+static void begin(void) {
+    memset(&state,0,sizeof state);memset(&fill,0,sizeof fill);
+    state.fill=&fill;state.active=true;state.files_open=true;
+    state.flow.f_l0=stream();state.press.f_l0=stream();state.flow.f_l1=stream();
+    state.sa2.f_l0=stream();state.pld_f.f_l0=stream();state.f_events=tmpfile();
+    ui_valid=ui_missing=0; s_start_intent=false;s_transport_uncertain=false;
+}
+static void end(void) {
+    fclose(state.flow.f_l0);fclose(state.press.f_l0);fclose(state.flow.f_l1);
+    fclose(state.sa2.f_l0);fclose(state.pld_f.f_l0);fclose(state.f_events);
+}
+static bool packet(int t,int base) {
+    char j[512];int h=t/3600000,m=(t/60000)%60,sec=(t/1000)%60,ms=t%1000;
+    snprintf(j,sizeof j,"{\"startTime\":\"2026-09-06T%02d:%02d:%02d.%03dZ\","
+             "\"PatientFlow\":[%d,%d,%d,%d,%d],\"MaskPressure\":[4,4,4,4,4],"
+             "\"HeartRate\":[65],\"SpO2\":[95],\"Leak\":[1]}",
+             h,m,sec,ms,base,base+1,base+2,base+3,base+4);
+    now_us+=20000;return session_writer_try_stream_data_raw(j,(int)strlen(j));
+}
+static int16_t value(FILE *f,uint32_t index) {
+    long p=ftell(f);fflush(f);assert(fseek(f,sizeof(snt_header_t)+index*2,SEEK_SET)==0);
+    int16_t v;assert(fread(&v,2,1,f)==1);fseek(f,p,SEEK_SET);return v;
+}
+static uint16_t flags(FILE *f) {
+    long p=ftell(f);fflush(f);rewind(f);snt_header_t h;assert(fread(&h,sizeof h,1,f)==1);
+    fseek(f,p,SEEK_SET);return h.reserved;
+}
+static void drain(void) { storage_write_batch(&state,&fill);batch_reset(&fill); }
+int main(void) {
+    begin();
+    assert(packet(0,1));assert(packet(400,6));assert(packet(10600,11));
+    drain();assert(state.flow.sample_count==270 && state.press.sample_count==270);
+    assert(state.committed_elapsed_us==10800000);
+    assert(value(state.flow.f_l0,0)==100 && value(state.flow.f_l0,4)==500);
+    for(int i=5;i<10;i++) assert(value(state.flow.f_l0,i)==SNT_MISSING);
+    assert(value(state.flow.f_l0,10)==600 && value(state.flow.f_l0,14)==1000);
+    for(int i=15;i<265;i++) assert(value(state.flow.f_l0,i)==SNT_MISSING);
+    assert(value(state.flow.f_l0,265)==1100 && value(state.flow.f_l0,269)==1500);
+    assert(state.sa2.sample_count==11 && state.pld_f.sample_count==6);
+    assert(value(state.sa2.f_l0,2)==SNT_MISSING && value(state.sa2.f_l0,20)==6500);
+    assert(flags(state.flow.f_l0)&1);assert(flags(state.sa2.f_l0)&1);
+    assert(ui_valid==15 && ui_missing==255);
+    packet(10600,11);packet(10400,11);
+    assert(ui_valid==15 && ui_missing==255 && fill.n_brp==0);
+    end();
+    begin();packet(0,1);packet(119000,6);drain();
+    assert(state.flow.sample_count==2980 && value(state.flow.f_l0,2975)==600);
+    assert(state.committed_elapsed_us==119200000);
+    assert(value(state.flow.f_l0,2974)==SNT_MISSING && state.sa2.sample_count==120);
+    end();
+    // Batch boundaries do not drop the partial 1-second min/max accumulator.
+    begin();packet(0,1);packet(200,6);packet(400,11);drain();
+    packet(600,16);packet(800,21);drain();
+    assert(state.flow_mm_count==1);assert(value(state.flow.f_l1,0)==100);
+    assert(value(state.flow.f_l1,1)==2500);assert(flags(state.flow.f_l0)==0);end();
+    // Fork v2 sentinel stays unambiguous in the positioned writer. Optional
+    // channel absence still triggers the current conservative export refusal;
+    // deciding which absent channels may export is a separate acceptance gate.
+    begin();
+    const char *absent="{\"startTime\":\"2026-09-06T00:00:00.000Z\","
+        "\"PatientFlow\":[-0.01,0,0,0,0],\"MaskPressure\":[4,4,4,4,4],\"Leak\":[1]}";
+    assert(session_writer_try_stream_data_raw(absent,(int)strlen(absent)));drain();
+    assert(value(state.flow.f_l0,0)==-1 && flags(state.flow.f_l0)==0);
+    assert(value(state.sa2.f_l0,0)==SNT_MISSING && value(state.sa2.f_l0,1)==SNT_MISSING);
+    assert(flags(state.sa2.f_l0)&1);
+    bool pld_missing=false,pld_present=false;
+    for(int ch=0;ch<12;ch++) {
+        int16_t v=value(state.pld_f.f_l0,(uint32_t)ch);
+        pld_missing |= v==SNT_MISSING;pld_present |= v!=SNT_MISSING;
+    }
+    assert(pld_missing && pld_present && (flags(state.pld_f.f_l0)&1));end();
+    // Source time controls position even when every replay arrives 20ms apart.
+    begin();packet(86399800,1);packet(0,6);drain();
+    assert(state.flow.sample_count==10 && !state.flow.position_gap);end();
+    // Capacity pressure loses values, never their positions, including final tail.
+    begin();for(int i=0;i<302;i++) packet(i*200,1);
+    assert(fill.n_brp==BRP_CAP && state.brp_dropped==10);drain();
+    assert(state.flow.sample_count==1510);
+    assert(value(state.flow.f_l0,1499)==500);
+    for(int i=1500;i<1510;i++) assert(value(state.flow.f_l0,i)==SNT_MISSING);
+    assert(flags(state.flow.f_l0)&1);end();
+    // Admission failure does not consume samples or publish duplicate UI points.
+    begin();state.active=false;allow_start=false;
+    assert(!packet(0,1));assert(fill.n_brp==0 && ui_valid==0);
+    allow_start=true;assert(packet(0,1));assert(fill.n_brp==5 && ui_valid==5);end();
+    // A failed sync cannot advertise new durability; event-only commit is real.
+    begin();state.have_uncommitted=true;sync_fail=1;checkpoints=0;
+    storage_commit(&state);assert(checkpoints==0 && state.have_uncommitted);
+    sync_fail=0;state.storage_failed=false;storage_commit(&state);
+    assert(checkpoints==1 && !state.have_uncommitted);end();
+    puts("production storage replay: gaps, positions, capacity, admission, checkpoints passed");
+}
+'''
+
+
+def run(name, text):
+    with tempfile.TemporaryDirectory(prefix='somno-storage-') as td:
+        src = Path(td)/f'{name}.c'; exe = Path(td)/name
+        src.write_text(text)
+        subprocess.run([os.environ.get('CC','cc'), '-std=gnu11', '-g',
+                        '-fsanitize=address,undefined', '-fno-omit-frame-pointer',
+                        str(src), '-o', str(exe), '-lm'], check=True)
+        subprocess.run([str(exe)], cwd=td, check=True)
+
+
+if __name__ == '__main__':
+    run('replay', raw)

--- a/scripts/session_writer_start_resilience_contract_test.py
+++ b/scripts/session_writer_start_resilience_contract_test.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Structural contracts for session-writer init/start failure resilience."""
+
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = (ROOT / "main/session_writer.c").read_text(encoding="utf-8")
+
+
+def function_body(name: str) -> str:
+    match = re.search(
+        rf"^[\w][\w\s*]*\b{name}\s*\([^;{{}}]*\)\s*\{{",
+        SOURCE,
+        re.MULTILINE,
+    )
+    if not match:
+        raise AssertionError(f"missing function: {name}")
+    depth = 1
+    cursor = match.end()
+    while cursor < len(SOURCE) and depth:
+        if SOURCE[cursor] == "{":
+            depth += 1
+        elif SOURCE[cursor] == "}":
+            depth -= 1
+        cursor += 1
+    if depth:
+        raise AssertionError(f"unterminated function: {name}")
+    return SOURCE[match.end():cursor - 1]
+
+
+# Workers self-park before touching shared queues. Init observes that state, so
+# deleting a partially-created worker cannot race queue/semaphore destruction.
+storage_worker = function_body("sw_storage_task")
+post_worker = function_body("sw_post_task")
+assert storage_worker.index("vTaskSuspend(NULL)") \
+       < storage_worker.index("xQueueReceive(s_storage_q")
+assert post_worker.index("vTaskSuspend(NULL)") \
+       < post_worker.index("xQueueReceive(s_post_q")
+
+park = function_body("sw_wait_startup_parked")
+assert "eTaskGetState(task) != eSuspended" in park
+assert "vTaskDelay(1)" in park
+
+unwind = function_body("session_writer_init_unwind")
+assert unwind.index("s_ready = false") \
+       < unwind.index("psram_task_delete(s_post_task)") \
+       < unwind.index("psram_task_delete(s_storage_task)") \
+       < unwind.index("vQueueDelete(s_post_q)") \
+       < unwind.index("vQueueDelete(s_storage_q)") \
+       < unwind.index("vSemaphoreDelete(s_active_mutex)")
+for global_name in (
+    "s_post_task", "s_storage_task", "s_post_q", "s_storage_q",
+    "s_active_mutex",
+):
+    assert f"{global_name} = NULL" in unwind
+assert "vTaskDelete(" not in unwind
+
+init = function_body("session_writer_init")
+storage_create = init.index("s_storage_task = psram_task_create(")
+storage_park = init.index("sw_wait_startup_parked(s_storage_task)")
+post_create = init.index("s_post_task = psram_task_create(")
+post_park = init.index("sw_wait_startup_parked(s_post_task)")
+ready = init.index("s_ready = true")
+assert storage_create < storage_park < post_create < post_park < ready
+assert ready < init.index("vTaskResume(s_storage_task)")
+assert ready < init.index("vTaskResume(s_post_task)")
+assert init.count("goto no_mem") == 3
+failure_tail = init[init.index("no_mem:"):]
+assert failure_tail.index("session_writer_init_unwind()") \
+       < failure_tail.index("return ESP_ERR_NO_MEM")
+
+# Storage ownership is admitted before any session/batch allocation. The
+# temporary session owns that claim until publication or centralized discard.
+start = function_body("session_writer_start")
+claim = start.index("sd_storage_recording_try_begin()")
+session_alloc = start.index("heap_caps_calloc(1, sizeof(session_writer_t)")
+fill_mutex_alloc = start.index("xSemaphoreCreateMutex()", session_alloc)
+batch_alloc = start.index("batch_pool_create(s)", fill_mutex_alloc)
+assert start.index("sw_start_intent_begin()") < claim
+assert "sd_storage_reserve_for_recording_cached()" in start
+assert "sw_start_intent_end()" in start
+assert claim < session_alloc < fill_mutex_alloc < batch_alloc
+assert start.count("sd_storage_recording_try_begin()") == 1
+assert start.index("s->recording_claim_held = true") \
+       < fill_mutex_alloc
+
+# The only pre-session allocation failure releases its local claim directly;
+# every later allocation/arbitration/queue failure uses one complete cleanup.
+alloc_failure = start[session_alloc:start.index("s->recording_claim_held = true")]
+assert "sd_storage_recording_end()" in alloc_failure
+assert start.count("session_start_discard(s)") == 4
+
+discard = function_body("session_start_discard")
+assert discard.index("batch_pool_destroy(s)") \
+       < discard.index("vSemaphoreDelete(s->fill_mutex)") \
+       < discard.index("sd_storage_recording_end()") \
+       < discard.index("free(s)")
+assert "s->recording_claim_held = false" in discard
+
+# OPEN is still queued while holding the active-session gate, and the pointer
+# is published only after successful admission. Duplicate starts return the
+# healthy winner after releasing their own provisional storage claim.
+active_lock = start.index("xSemaphoreTake(s_active_mutex", batch_alloc)
+duplicate = start.index("if (s_active && s_active->active)", active_lock)
+enqueue = start.index("storage_queue_send_open(&cmd, 0)", duplicate)
+publish = start.index("s_active = s", enqueue)
+unlock = start.index("xSemaphoreGive(s_active_mutex)", publish)
+assert active_lock < duplicate < enqueue < publish < unlock
+
+duplicate_branch = start[duplicate:start.index("s->active = true", duplicate)]
+assert duplicate_branch.index("xSemaphoreGive(s_active_mutex)") \
+       < duplicate_branch.index("session_start_discard(s)") \
+       < duplicate_branch.index("return existing")
+
+enqueue_failure = start[
+    start.index("if (!storage_queue_send_open(&cmd, 0))"):
+    publish
+]
+assert enqueue_failure.index("xSemaphoreGive(s_active_mutex)") \
+       < enqueue_failure.index("session_start_discard(s)") \
+       < enqueue_failure.index("return NULL")
+assert "crash_diag_note_session(NULL)" in enqueue_failure
+
+print("session writer start resilience contract passed")

--- a/scripts/storage_export_fault_test.py
+++ b/scripts/storage_export_fault_test.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Fault injection against production export finalization and post file gates."""
+from pathlib import Path
+from session_storage_behavior_test import COMMON, DEFS, SNT_DEFS, SW, EDF, SNT, function, run
+
+POST = (Path(__file__).resolve().parents[1]/'main/post_therapy.c').read_text()
+EDF_HEADER = (Path(__file__).resolve().parents[1]/'main/edf_header.c').read_text()
+code = COMMON + SNT_DEFS + r'''
+#include <dirent.h>
+static int fault, closed, sync_calls, lease_depth;
+static bool pending, ready=true;
+static int real_close(FILE *f) { return fclose(f); }
+static int test_close(FILE *f) { closed++;int r=fclose(f);if(fault==3 || fault==6){errno=EIO;return -1;}return r; }
+static int test_flush(FILE *f) { if(fault==1 || fault==6){errno=ENOSPC;return -1;}return fflush(f); }
+static int test_sync(int fd) { (void)fd;sync_calls++;if(fault==2){errno=EROFS;return -1;}return 0; }
+static int test_rename(const char *a,const char *b) {
+    if(fault==4 && strstr(a,".tmp")){errno=EBUSY;return -1;}return rename(a,b);
+}
+static int test_stat(const char *p, struct stat *s) {
+    if(fault==5){errno=EIO;return -1;}return stat(p,s);
+}
+#define fclose test_close
+#define fflush test_flush
+#define fsync test_sync
+#define rename test_rename
+#define stat test_stat
+#define SD_LEASE_EXPORT 1
+static bool sd_storage_lease_acquire(int x,int y) { (void)x;(void)y;lease_depth++;return true; }
+static void sd_storage_lease_release(int x) { (void)x;assert(lease_depth>0);lease_depth--; }
+static bool sd_storage_is_ready(void) { return ready; }
+static bool sd_storage_recording_pending(void) { return pending; }
+static bool sd_storage_recording_active(void) { return false; }
+'''
+# A function-like macro preserves struct stat while redirecting calls.
+code = code.replace('#define stat test_stat', '#define stat(...) test_stat(__VA_ARGS__)')
+code += ''.join(function(EDF_HEADER,n) for n in [
+    'edf_open_atomic_file','edf_publish_atomic_path',
+    'edf_finalize_atomic_file','edf_discard_atomic_file'])
+code += ''.join(function(POST,n) for n in ['post_storage_begin','write_bin_atomic'])
+code += r'''
+static bool rpc_saw_no_lease;
+static esp_err_t as11_ble_spool_pull(const char *key,const char *from,uint8_t **data,size_t *len) {
+    (void)key;(void)from;assert(lease_depth==0);rpc_saw_no_lease=true;
+    *data=malloc(4);memcpy(*data,"RESP",4);*len=4;return ESP_OK;
+}
+'''
+code += function(POST,'collect_resp_events')
+code += function(SNT,'snt_read_header') + function(EDF,'validate_positioned_sources')
+code += r'''
+static void good(const char *path) {
+    fault=0;FILE *f=fopen(path,"wb");assert(f);fputs("GOOD",f);assert(real_close(f)==0);
+}
+static void expect(const char *path,const char *text) {
+    int save=fault;fault=0;FILE *f=fopen(path,"rb");assert(f);
+    char b[40]={0};assert(fread(b,1,sizeof(b)-1,f)==strlen(text));assert(!strcmp(b,text));
+    real_close(f);fault=save;
+}
+int main(void) {
+    char dir[]="/tmp/somno-export-XXXXXX";assert(mkdtemp(dir));
+    char path[300],tmp[320];snprintf(path,sizeof path,"%s/result.edf",dir);
+    for(int e=1;e<=6;e++) {
+        good(path);FILE *f=edf_open_atomic_file(path,tmp,sizeof tmp);assert(f);fputs("NEW",f);
+        closed=sync_calls=0;fault=e;assert(edf_finalize_atomic_file(f,tmp,path)==ESP_FAIL);
+        assert(closed==1);assert(errno==(e==1||e==6 ? ENOSPC : e==2 ? EROFS : e==4 ? EBUSY : EIO));
+        expect(path,"GOOD");fault=0;assert(access(tmp,F_OK)!=0);
+    }
+    good(path);FILE *f=edf_open_atomic_file(path,tmp,sizeof tmp);fputs("NEW",f);closed=0;
+    assert(edf_finalize_atomic_file(f,tmp,path)==ESP_OK && closed==1);expect(path,"NEW");
+    // A saved prior file survives restart between FAT renames and is recovered.
+    char bak[330];snprintf(bak,sizeof bak,"%s.bak",path);assert(rename(path,bak)==0);
+    f=edf_open_atomic_file(path,tmp,sizeof tmp);fputs("LATEST",f);fault=4;
+    assert(edf_finalize_atomic_file(f,tmp,path)==ESP_FAIL);expect(path,"NEW");fault=0;
+    // The post transaction closes/releases on every write/flush/sync/rename failure.
+    for(int e=1;e<=6;e++) {
+        good(path);fault=e;closed=0;
+        assert(write_bin_atomic(path,(const uint8_t*)"POST",4)==ESP_FAIL);
+        assert(lease_depth==0);assert(closed==(e==5 ? 0 : 1));expect(path,"GOOD");
+    }
+    fault=0;pending=true;closed=0;
+    assert(write_bin_atomic(path,(const uint8_t*)"POST",4)==ESP_ERR_TIMEOUT);
+    assert(closed==0 && lease_depth==0);expect(path,"GOOD");pending=false;
+    assert(write_bin_atomic(path,(const uint8_t*)"POST",4)==ESP_OK);expect(path,"POST");
+    assert(collect_resp_events(dir,"session","2026-09-06")==ESP_OK);
+    assert(rpc_saw_no_lease && lease_depth==0);
+    char resp[340];snprintf(resp,sizeof resp,"%s/session_resp_events.bin",dir);expect(resp,"RESP");unlink(resp);
+    // Legacy v1 and unflagged v2 accept; newly positioned gaps fail before output.
+    char raw[320];snprintf(raw,sizeof raw,"%s/s_flow.snt",dir);
+    for(int version=1;version<=2;version++) {
+        f=fopen(raw,"wb");snt_header_t h={.magic=SNT_MAGIC,.version=version};
+        fwrite(&h,sizeof h,1,f);real_close(f);
+        assert(validate_positioned_sources(dir,"s")==ESP_OK);
+    }
+    f=fopen(raw,"r+b");snt_header_t h={.magic=SNT_MAGIC,.version=2,.reserved=1};
+    fwrite(&h,sizeof h,1,f);real_close(f);
+    assert(validate_positioned_sources(dir,"s")==EDF_GEN_ERR_POSITION_GAPS);
+    expect(path,"POST");
+    f=fopen(raw,"wb");fwrite(&h,1,10,f);real_close(f);
+    assert(validate_positioned_sources(dir,"s")==ESP_FAIL);expect(path,"POST");
+    unlink(raw);unlink(path);rmdir(dir);
+    puts("production export faults: always-close, first-error, prior-output recovery, gates, gap refusal passed");
+}
+'''
+if __name__ == '__main__':
+    run('export_faults',code)

--- a/scripts/test-host.sh
+++ b/scripts/test-host.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+python3 scripts/therapy_alert_ack_contract_test.py
+python3 scripts/clock_snapshot_contract_test.py
+python3 scripts/capacity_snapshot_behavior_test.py
+python3 scripts/upload_progress_snapshot_contract_test.py
+python3 scripts/idf_async_allocation_test.py
+python3 scripts/oximetry_forget_tombstone_contract_test.py
+python3 scripts/psram_task_lifecycle_contract_test.py
+python3 scripts/backend_runtime_test.py

--- a/scripts/test-host.sh
+++ b/scripts/test-host.sh
@@ -27,3 +27,5 @@ python3 scripts/upload_invalidation_behavior_test.py
 python3 scripts/backend_realtime_test.py
 python3 scripts/uploader_ox_lease_contract_test.py
 python3 scripts/fork_backend_reconciliation_test.py
+
+./scripts/test-platform4.sh

--- a/scripts/test-host.sh
+++ b/scripts/test-host.sh
@@ -9,3 +9,13 @@ python3 scripts/idf_async_allocation_test.py
 python3 scripts/oximetry_forget_tombstone_contract_test.py
 python3 scripts/psram_task_lifecycle_contract_test.py
 python3 scripts/backend_runtime_test.py
+python3 scripts/session_storage_behavior_test.py
+python3 scripts/session_checkpoint_barrier_test.py
+python3 scripts/rapid_session_lifecycle_contract_test.py
+python3 scripts/session_writer_start_resilience_contract_test.py
+python3 scripts/sd_recording_arbitration_contract_test.py
+python3 scripts/oximetry_sd_lease_contract_test.py
+python3 scripts/sd_mount_fallback_contract_test.py
+python3 scripts/backend_recording_test.py
+python3 scripts/therapy_lifecycle_race_contract_test.py
+python3 scripts/therapy_gate_behavior_test.py

--- a/scripts/test-host.sh
+++ b/scripts/test-host.sh
@@ -19,3 +19,11 @@ python3 scripts/sd_mount_fallback_contract_test.py
 python3 scripts/backend_recording_test.py
 python3 scripts/therapy_lifecycle_race_contract_test.py
 python3 scripts/therapy_gate_behavior_test.py
+python3 scripts/storage_export_fault_test.py
+python3 scripts/edf_rebuild_behavior_test.py
+python3 scripts/pending_export_behavior_test.py
+python3 scripts/pending_export_service_test.py
+python3 scripts/upload_invalidation_behavior_test.py
+python3 scripts/backend_realtime_test.py
+python3 scripts/uploader_ox_lease_contract_test.py
+python3 scripts/fork_backend_reconciliation_test.py

--- a/scripts/test-platform4.sh
+++ b/scripts/test-platform4.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+PLATFORM_TEST_DIR=$(mktemp -d)
+trap 'rm -rf "$PLATFORM_TEST_DIR"' EXIT
+cc -std=c11 -Wall -Wextra -Werror -I main scripts/touch_observation_test.c main/touch_observation.c -o "$PLATFORM_TEST_DIR/touch"
+"$PLATFORM_TEST_DIR/touch"
+cc -std=c11 -Wall -Wextra -DCONTROLLER_DIAGNOSTICS_HOST_TEST -I scripts/test_include -I main scripts/controller_diagnostics_test.c main/controller_diagnostics.c -o "$PLATFORM_TEST_DIR/diagnostics"
+"$PLATFORM_TEST_DIR/diagnostics"
+python3 scripts/compact_display_init_test.py
+python3 scripts/rgb_frame_handoff_test.py
+python3 scripts/touch_recovery_test.py
+python3 scripts/waveshare_7b_contract_test.py

--- a/scripts/test_include/esp_err.h
+++ b/scripts/test_include/esp_err.h
@@ -38,6 +38,9 @@ typedef int esp_err_t;
 #define ESP_ERR_TIMEOUT          0x107
 #define ESP_ERR_INVALID_RESPONSE 0x108
 #define ESP_ERR_INVALID_CRC      0x109
+#define ESP_ERR_INVALID_VERSION  0x10A
+#define ESP_ERR_NVS_BASE         0x1100
+#define ESP_ERR_NVS_NOT_FOUND    (ESP_ERR_NVS_BASE + 0x02)
 
 static inline const char *esp_err_to_name(esp_err_t e)
 {
@@ -50,6 +53,8 @@ static inline const char *esp_err_to_name(esp_err_t e)
     case ESP_ERR_INVALID_SIZE:  return "ESP_ERR_INVALID_SIZE";
     case ESP_ERR_NOT_FOUND:     return "ESP_ERR_NOT_FOUND";
     case ESP_ERR_TIMEOUT:       return "ESP_ERR_TIMEOUT";
+    case ESP_ERR_INVALID_VERSION: return "ESP_ERR_INVALID_VERSION";
+    case ESP_ERR_NVS_NOT_FOUND: return "ESP_ERR_NVS_NOT_FOUND";
     default:                    return "ESP_ERR_?";
     }
 }

--- a/scripts/therapy_alert_ack_contract_test.py
+++ b/scripts/therapy_alert_ack_contract_test.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Production C lifecycle and task ownership under saturated wake queues."""
+from pathlib import Path
+import re, subprocess, tempfile
+ROOT=Path(__file__).resolve().parents[1]
+s=(ROOT/'components/therapy_alert/therapy_alert.c').read_text()
+def function(name):
+    m=re.search(r'^(?:static\s+)?[\w\s*]+\b'+name+r'\([^;]*?\)\s*\{',s,re.M)
+    assert m,name
+    i=m.end(); depth=1
+    while depth:
+        if s[i]=='{':depth+=1
+        elif s[i]=='}':depth-=1
+        i+=1
+    return s[m.start():i]
+pre=r'''
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include "therapy_alert.h"
+#include "alert_lifecycle.h"
+#define ESP_LOGI(...) ((void)0)
+#define ESP_LOGD(...) ((void)0)
+#define ESP_LOGE(...) ((void)0)
+#define portENTER_CRITICAL(p) ((void)(p))
+#define portEXIT_CRITICAL(p) ((void)(p))
+#define pdTRUE 1
+#define ALERT_DELIVERY_FAILED 1
+#define pdMS_TO_TICKS(x) (x)
+typedef void *TaskHandle_t;
+typedef struct { uint32_t gen, history_id; } alert_routine_args_t;
+typedef enum { EVT_THERAPY_START,EVT_THERAPY_STOP,EVT_BLE_DISCONNECT,EVT_ACK,EVT_ROUTINE_EXIT } alert_evt_type_t;
+typedef struct { uint8_t type,state; uint32_t gen; } alert_evt_t;
+static void *s_evt_q=(void *)1,*s_ack_pending=(void *)2;
+static int wakes,ack_latched,s_lifecycle_lock,live_tasks,created,deleted;
+static bool clock_set=true,window=true,therapy_on=true,spawn_fail,ack_during_history;
+static therapy_alert_config_t s_cfg={.enabled=true};
+static alert_state_t s_state;
+static uint32_t s_routine_gen,s_active_history_id;
+static bool s_routine_active;
+static alert_lifecycle_t s_lifecycle,s_lifecycle_cursor;
+static int xQueueSend(void *q,const void *p,int timeout) { ++wakes; return 0; } // all 8 ordinary slots occupied
+static void xSemaphoreGive(void *p) { ++ack_latched; }
+static void set_state(alert_state_t st) { s_state=st; }
+static uint32_t alert_history_begin(bool b) { if(ack_during_history) therapy_alert_acknowledge(); return 1; }
+static void alert_history_result(uint32_t id,int result,bool b) {}
+static void alert_history_cancel(uint32_t id) {}
+static void alert_history_ack(uint32_t id) {}
+static bool time_is_set(void) { return clock_set; }
+static int current_minutes_from_midnight(void) { return 0; }
+static bool time_in_window(int now,int a,int b) { return window; }
+static bool currently_in_window(void) { return window; }
+static bool therapy_is_active(void) { return therapy_on; }
+alert_state_t therapy_alert_get_state(void) { return s_state; }
+static void report_stack_headroom(const char *s) {}
+static void alert_routine_task(void *p) {}
+static TaskHandle_t create_task(void (*fn)(void *),const char *name,uint32_t bytes,void *arg,unsigned priority,int core,void *stack,void *tcb) {
+ assert(fn==alert_routine_task && bytes==16384 && !stack && !tcb);
+ if(spawn_fail) return NULL;
+ free(arg); ++created; ++live_tasks; return (void *)3;
+}
+static void delete_task(TaskHandle_t task) { assert(!task); --live_tasks; ++deleted; }
+static TaskHandle_t (*s_task_create)(void (*)(void *),const char*,uint32_t,void*,unsigned,int,void*,void*)=create_task;
+static void (*s_task_delete)(TaskHandle_t)=delete_task;
+'''
+prod='\n'.join(function(n) for n in ['therapy_alert_is_actionable','post_evt','finish_alert_routine','start_alert_routine','cancel_alert_routine','handle_therapy_start','handle_therapy_stop','handle_ble_disconnect','handle_ack','drain_lifecycle','therapy_alert_on_therapy_start','therapy_alert_on_therapy_stop','therapy_alert_on_ble_disconnect','therapy_alert_acknowledge','therapy_alert_on_transport_loss','therapy_alert_transport_uncertain','reevaluate_state'])
+tests=r'''
+int main(void) {
+ // START STOP must survive a permanently saturated ordinary queue.
+ therapy_alert_on_therapy_start(); therapy_alert_on_therapy_stop(); drain_lifecycle();
+ assert(s_state==ALERT_PENDING && live_tasks==1);
+ therapy_alert_acknowledge(); uint32_t after_ack=s_routine_gen;
+ assert(ack_latched && after_ack>0); drain_lifecycle(); assert(s_state==ALERT_ACKED);
+ finish_alert_routine(after_ack); assert(!live_tasks);
+ // Delayed ordinary queue wakeups cannot replay START and clear sticky ACK.
+ for(int i=0;i<20;++i) { drain_lifecycle(); reevaluate_state(); }
+ assert(s_state==ALERT_ACKED);
+ therapy_alert_on_ble_disconnect(); drain_lifecycle(); reevaluate_state(); assert(s_state==ALERT_ACKED);
+ // A genuinely new cycle clears old ACK, including an undrained old ACK.
+ therapy_alert_on_therapy_start(); therapy_alert_acknowledge(); therapy_alert_on_therapy_stop();
+ therapy_alert_on_therapy_start(); therapy_alert_on_therapy_stop(); drain_lifecycle();
+ assert(s_state==ALERT_PENDING && live_tasks==1); finish_alert_routine(s_routine_gen);
+ // ACK before STOP in the same cycle suppresses escalation, even when both queued wakes drop.
+ therapy_alert_on_therapy_start(); therapy_alert_acknowledge(); therapy_alert_on_therapy_stop(); drain_lifecycle();
+ assert(s_state==ALERT_ACKED && !live_tasks);
+ therapy_alert_on_therapy_start(); drain_lifecycle(); assert(s_state==ALERT_ARMED);
+ for(int i=0;i<100;++i) therapy_alert_on_therapy_start();
+ therapy_alert_acknowledge(); drain_lifecycle(); assert(s_state==ALERT_ACKED);
+ // Loss is explicit; neither periodic stale active-checker nor disconnect can clear it.
+ therapy_alert_on_transport_loss(); drain_lifecycle(); therapy_alert_on_ble_disconnect(); drain_lifecycle();
+ assert(therapy_alert_transport_uncertain()); reevaluate_state(); assert(s_state==ALERT_ACKED);
+ therapy_alert_on_therapy_start(); drain_lifecycle(); assert(!therapy_alert_transport_uncertain() && s_state==ALERT_ARMED);
+ therapy_alert_on_ble_disconnect(); drain_lifecycle(); reevaluate_state(); assert(s_state==ALERT_DISARMED);
+ // ACK already retained after STOP must not launch a zero-delay push task.
+ therapy_alert_on_therapy_start(); therapy_alert_on_therapy_stop(); therapy_alert_acknowledge(); drain_lifecycle();
+ assert(s_state==ALERT_ACKED && !live_tasks);
+ // An ACK arriving during synchronous history creation also suppresses launch.
+ ack_during_history=true; therapy_alert_on_therapy_start(); therapy_alert_on_therapy_stop(); drain_lifecycle();
+ assert(s_state==ALERT_PENDING && !live_tasks); drain_lifecycle(); assert(s_state==ALERT_ACKED);
+ ack_during_history=false;
+ // ACK and disconnect both retained before draining must keep ACK sticky.
+ therapy_alert_on_therapy_start(); therapy_alert_on_therapy_stop(); drain_lifecycle();
+ assert(live_tasks==1); therapy_alert_acknowledge(); therapy_alert_on_ble_disconnect(); drain_lifecycle();
+ assert(s_state==ALERT_ACKED); finish_alert_routine(s_routine_gen);
+ // Every normal cycle uses paired create/delete; no detached static stack or TCB.
+ for(int i=0;i<10000;++i) {
+  therapy_alert_on_therapy_start(); therapy_alert_on_therapy_stop(); drain_lifecycle();
+  assert(s_state==ALERT_PENDING && live_tasks==1);
+  finish_alert_routine(s_routine_gen); assert(!live_tasks);
+ }
+ assert(created==deleted);
+ spawn_fail=true; therapy_alert_on_therapy_start(); therapy_alert_on_therapy_stop(); drain_lifecycle();
+ assert(s_state==ALERT_DISARMED && !live_tasks);
+}
+'''
+with tempfile.TemporaryDirectory(prefix='somno-alert-') as tmp:
+ p=Path(tmp); (p/'test.c').write_text(pre+prod+tests)
+ subprocess.run(['cc','-std=c11','-Wall','-Wextra','-Werror','-Wno-unused-parameter',
+ '-I',str(ROOT/'scripts/test_include'),'-I',str(ROOT/'components/therapy_alert'),str(p/'test.c'),'-o',str(p/'test')],check=True)
+ subprocess.run([str(p/'test')],check=True)
+print('Production alert saturated queue, cycle ordering, sticky ACK, uncertainty and 10000 paired task lifetimes passed')

--- a/scripts/therapy_gate_behavior_test.py
+++ b/scripts/therapy_gate_behavior_test.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Exercise production original-screen restart gates across racing admissions."""
+from pathlib import Path
+import re, subprocess, tempfile
+ROOT = Path(__file__).resolve().parents[1]
+source = (ROOT / 'main/bsp_display.c').read_text()
+def function(name):
+    m = re.search(r'^(?:static\s+)?[\w *]+\b'+name+r'\([^;{]*\)\s*\{', source, re.M)
+    assert m, name
+    i, depth = m.end(), 1
+    while depth:
+        depth += (source[i] == '{') - (source[i] == '}'); i += 1
+    return source[m.start():i]
+names = ['try_reserve_therapy_safe_restart', 'try_commit_therapy_safe_restart',
+         'cancel_therapy_safe_restart', 'reserve_therapy_start', 'release_therapy_start',
+         'note_as11_notification_queued', 'note_as11_notification_processed',
+         'try_begin_therapy_safe_maintenance', 'try_reserve_maintenance_commit',
+         'therapy_safe_maintenance_should_abort', 'end_therapy_safe_maintenance']
+fixture = '''#include <assert.h>
+#include <stdbool.h>
+#define portMAX_DELAY 0
+#define DISP_MODE_STATUS 0
+#define DISP_MODE_GRAPH 1
+#define DISP_MODE_INFO 2
+static int s_state_mutex = 1, s_mode;
+static bool s_therapy_safe_restart_reserving, s_therapy_safe_restart_committed;
+static unsigned s_therapy_start_waiters, s_therapy_start_claims, s_as11_notifications_pending;
+static bool s_therapy_safe_maintenance;
+static int locked;
+static void xSemaphoreTake(int m, int t) { assert(m && !locked); locked = 1; }
+static void xSemaphoreGive(int m) { assert(m && locked); locked = 0; }
+static void vTaskDelay(int t) { assert(!"unexpected blocking gate"); }
+'''+ '\n'.join(function('bsp_display_'+n) for n in names) + '''
+int main(void) {
+    assert(bsp_display_try_reserve_therapy_safe_restart());
+    bsp_display_note_as11_notification_queued();
+    assert(!bsp_display_try_commit_therapy_safe_restart());
+    bsp_display_cancel_therapy_safe_restart();
+    assert(!bsp_display_try_reserve_therapy_safe_restart());
+    bsp_display_note_as11_notification_processed();
+    assert(bsp_display_reserve_therapy_start());
+    assert(!bsp_display_try_reserve_therapy_safe_restart());
+    bsp_display_release_therapy_start();
+    assert(bsp_display_try_begin_therapy_safe_maintenance());
+    s_mode = DISP_MODE_INFO;
+    assert(bsp_display_therapy_safe_maintenance_should_abort());
+    assert(!bsp_display_try_reserve_maintenance_commit());
+    s_mode = DISP_MODE_GRAPH;
+    assert(!bsp_display_try_reserve_maintenance_commit());
+    s_mode = DISP_MODE_STATUS;
+    assert(bsp_display_try_reserve_maintenance_commit());
+    assert(bsp_display_try_commit_therapy_safe_restart());
+    assert(!bsp_display_reserve_therapy_start());
+    assert(!locked);
+}
+'''
+with tempfile.TemporaryDirectory() as tmp:
+    p=Path(tmp); (p/'test.c').write_text(fixture)
+    subprocess.run(['cc','-std=c11','-Wall','-Wextra','-Werror','-Wno-unused-parameter',str(p/'test.c'),'-o',str(p/'test')],check=True)
+    subprocess.run([str(p/'test')],check=True,timeout=5)
+print('Production therapy restart gates: pending RX, start claims, graph/info modes and final commit passed')

--- a/scripts/therapy_lifecycle_race_contract_test.py
+++ b/scripts/therapy_lifecycle_race_contract_test.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Contracts for AirSense ingress, OTA, and restart therapy arbitration."""
+
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HEADER = (ROOT / "main/bsp_display.h").read_text(encoding="utf-8")
+SMALL = (ROOT / "main/bsp_display.c").read_text(encoding="utf-8")
+AS11 = (ROOT / "main/as11_ble.c").read_text(encoding="utf-8")
+NET = (ROOT / "main/net_provision.c").read_text(encoding="utf-8")
+
+
+def function_body(source: str, name: str) -> str:
+    match = re.search(
+        rf"^[\w][\w\s*]*\b{name}\s*\([^;{{}}]*\)\s*\{{",
+        source,
+        re.MULTILINE,
+    )
+    if not match:
+        raise AssertionError(f"missing function: {name}")
+    depth = 1
+    cursor = match.end()
+    while cursor < len(source) and depth:
+        if source[cursor] == "{":
+            depth += 1
+        elif source[cursor] == "}":
+            depth -= 1
+        cursor += 1
+    if depth:
+        raise AssertionError(f"unterminated function: {name}")
+    return source[match.end():cursor - 1]
+
+
+for declaration in (
+    "void bsp_display_note_as11_notification_queued(void);",
+    "void bsp_display_note_as11_notification_processed(void);",
+    "bool bsp_display_try_begin_therapy_safe_maintenance(void);",
+    "bool bsp_display_therapy_safe_maintenance_should_abort(void);",
+    "void bsp_display_end_therapy_safe_maintenance(void);",
+):
+    assert declaration in HEADER
+
+# A restart cannot reserve or commit while a raw notification is waiting for
+# decryption/dispatch. This closes the pre-JSON queue gap for TherapyStart.
+for display in (SMALL,):
+    reserve = function_body(display, "bsp_display_try_reserve_therapy_safe_restart")
+    commit = function_body(display, "bsp_display_try_commit_therapy_safe_restart")
+    queued = function_body(display, "bsp_display_note_as11_notification_queued")
+    processed = function_body(display, "bsp_display_note_as11_notification_processed")
+    begin = function_body(display, "bsp_display_try_begin_therapy_safe_maintenance")
+    abort = function_body(display, "bsp_display_therapy_safe_maintenance_should_abort")
+    end = function_body(display, "bsp_display_end_therapy_safe_maintenance")
+    assert "s_as11_notifications_pending == 0" in reserve
+    assert "s_as11_notifications_pending == 0" in commit
+    assert "s_as11_notifications_pending++" in queued
+    assert "s_as11_notifications_pending--" in processed
+    assert "s_as11_notifications_pending == 0" in begin
+    assert "s_therapy_start_claims == 0" in begin
+    assert "s_therapy_safe_maintenance = true" in begin
+    assert "s_therapy_start_claims > 0" in abort
+    assert "therapy_active" in abort or "s_state.therapy" in abort
+    assert "s_therapy_safe_maintenance = false" in end
+
+gap = function_body(AS11, "gap_event")
+notify_case = gap[gap.index("case BLE_GAP_EVENT_NOTIFY_RX"):
+                  gap.index("case BLE_GAP_EVENT_L2CAP_UPDATE_REQ")]
+assert notify_case.index("bsp_display_note_as11_notification_queued()") \
+       < notify_case.index("heap_caps_malloc(notif_len") \
+       < notify_case.index("os_mbuf_copydata") \
+       < notify_case.index("xQueueSend(s_notif_queue")
+assert "if (lifecycle_accounted)" in notify_case
+assert notify_case.count("bsp_display_note_as11_notification_processed()") >= 3
+worker = function_body(AS11, "notif_proc_task")
+assert worker.index("handle_notify(item.data, item.len)") \
+       < worker.index("bsp_display_note_as11_notification_processed()")
+
+# Native OTA closes final publication races atomically, and releases the short
+# reservation before entering the existing therapy-aware reboot worker.
+for display in (SMALL,):
+    commit = function_body(display, "bsp_display_try_reserve_maintenance_commit")
+    for prerequisite in ("s_therapy_start_claims == 0", "s_therapy_start_waiters == 0",
+                         "s_as11_notifications_pending == 0", "s_therapy_safe_maintenance"):
+        assert prerequisite in commit
+    assert "s_therapy_safe_restart_reserving = true" in commit
+    assert "s_therapy_safe_maintenance = false" in commit
+
+print("Original-screen therapy lifecycle gates and notification accounting passed")

--- a/scripts/touch_observation_test.c
+++ b/scripts/touch_observation_test.c
@@ -1,0 +1,51 @@
+#include "touch_observation.h"
+#include <assert.h>
+#include <limits.h>
+#include <stdio.h>
+
+int main(void)
+{
+    touch_observation_t s = {0};
+    assert(!touch_observation_healthy(&s, 0));
+    touch_observation_update(&s, 10000, 0, true, true, 123, 456);
+    assert(touch_observation_pressed(&s, 10000));
+    touch_observation_update(&s, 20000, 0, false, false, 0, 0);
+    assert(touch_observation_pressed(&s, 20000));
+    assert(s.x == 123 && s.y == 456);
+    /* A responsive status register cannot refresh an old contact forever. */
+    for (int64_t now = 30000; now <= 110000; now += 10000)
+        touch_observation_update(&s, now, 0, false, false, 0, 0);
+    assert(!touch_observation_pressed(&s, 110001));
+    assert(!touch_observation_pressed(&s, 120001));
+    touch_observation_update(&s, 130001, 0, false, false, 0, 0);
+    assert(!touch_observation_pressed(&s, 130001));
+    assert(s.continuity == 1 && !s.valid);
+    touch_observation_update(&s, 140000, 0, true, true, 7, 8);
+    touch_observation_update(&s, 150000, 9, false, false, 0, 0);
+    assert(!touch_observation_pressed(&s, 150000));
+    touch_observation_update(&s, 160000, 0, false, false, 0, 0);
+    assert(!s.valid && !touch_observation_pressed(&s, 160000));
+    touch_observation_update(&s, 170000, 0, true, false, 0, 0);
+    assert(s.valid && !s.pressed);
+    for (unsigned i = 0; i < 300; ++i)
+        touch_observation_update(&s, 180000 + i, 9, false, false, 0, 0);
+    assert(s.consecutive_errors == UINT8_MAX && s.errors == 301);
+    assert(!touch_observation_healthy(&s, 180299));
+    touch_observation_recovering(&s);
+    assert(s.recovering && !s.preventive_recovery &&
+           s.recovery_attempts == 1 && !s.valid);
+    touch_observation_update(&s, 190000, 0, false, false, 0, 0);
+    assert(touch_observation_healthy(&s, 190000) && !s.valid);
+    touch_observation_preventive_recovering(&s);
+    assert(s.recovering && s.preventive_recovery &&
+           s.recovery_attempts == 2 && s.preventive_recovery_attempts == 1);
+    touch_observation_update(&s, 195000, 0, false, false, 0, 0);
+    assert(!s.recovering && !s.preventive_recovery);
+    touch_observation_update(&s, 200000, 0, true, true, 7, 8);
+    touch_observation_update(&s, 199999, 0, false, false, 0, 0);
+    assert(!s.valid); /* a clock discontinuity also releases input */
+    s.errors = UINT32_MAX;
+    touch_observation_update(&s, 210000, 1, false, false, 0, 0);
+    assert(s.errors == UINT32_MAX);
+    puts("touch observation freshness, continuity and recovery passed");
+}

--- a/scripts/touch_recovery_test.py
+++ b/scripts/touch_recovery_test.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Fault injection into production board recovery and LVGL input/power functions."""
+from pathlib import Path
+import re
+import subprocess
+import tempfile
+ROOT = Path(__file__).resolve().parents[1]
+from prepare_host_lvgl import prepare_lvgl
+LVGL_INPUT = prepare_lvgl()
+def function(path, name):
+    source = (ROOT / path).read_text()
+    match = re.search(r'^(?:static )?(?:void|bool|uint8_t|esp_err_t) ' + name + r'\([^;]*?\)\s*\{', source, re.M)
+    assert match, name
+    depth, end = 1, match.end()
+    while depth:
+        depth += (source[end] == '{') - (source[end] == '}')
+        end += 1
+    return source[match.start():end] + '\n'
+common = r'''
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <setjmp.h>
+#include "touch_observation.h"
+typedef int esp_err_t;
+#define ESP_OK 0
+#define ESP_ERR_TIMEOUT 1
+#define ESP_ERR_INVALID_STATE 2
+#define ESP_ERR_INVALID_SIZE 3
+#define ESP_ERR_INVALID_RESPONSE 4
+#define ESP_ERR_NO_MEM 5
+#define pdTRUE 1
+#define pdMS_TO_TICKS(n) (n)
+#define portENTER_CRITICAL(...) ((void)0)
+#define portEXIT_CRITICAL(...) ((void)0)
+#define ESP_LOGI(...) ((void)0)
+#define ESP_LOGW(...) ((void)0)
+#define ESP_LOGE(...) ((void)0)
+#define CONTROLLER_TOUCH_READ 0
+#define CONTROLLER_TOUCH_RECOVERY 1
+#define CONTROLLER_OUTPUT_MODE 2
+#define CONTROLLER_LCD_POWER 3
+#define CONTROLLER_BACKLIGHT_POWER 4
+#define CONTROLLER_BACKLIGHT_BRIGHTNESS 5
+static void controller_diagnostics_record(int a, int b) {(void)a;(void)b;}
+'''
+board = common + r'''
+#define BOARD_I2C_TIMEOUT_MS 20
+#define BOARD_LOCK_TIMEOUT_MS 25
+#define BOARD_VISIBILITY_RETRY_US 250000LL
+#define BOARD_TOUCH_OFF_RESET_DELAY_US 50000LL
+#define IOX_REG_MODE 2
+#define IOX_REG_OUTPUT 3
+#define IOX_REG_PWM 5
+#define IOX_TOUCH_RST 1
+#define IOX_BACKLIGHT 2
+#define IOX_LCD_POWER 6
+#define GT911_STATUS_REG 0x814e
+#define GT911_ID_REG 0x8140
+#define GT911_ADDR 0x5d
+#define I2C_HZ 400000
+#define tskNO_AFFINITY (-1)
+#define GPIO_NUM_4 4
+#define GPIO_MODE_INPUT 1
+#define GPIO_MODE_OUTPUT 2
+#define GPIO_PULLUP_ENABLE 1
+#define GPIO_PULLUP_DISABLE 0
+#define GPIO_PULLDOWN_DISABLE 0
+#define GPIO_INTR_DISABLE 0
+typedef struct {uint64_t pin_bit_mask; int mode,pull_up_en,pull_down_en,intr_type;} gpio_config_t;
+static void *s_lock=(void *)1,*s_iox=(void *)1,*s_touch_device=(void *)2;
+static void *s_i2c=(void *)3,*s_touch,*s_touch_task;
+typedef struct {unsigned device_address,scl_speed_hz;} i2c_device_config_t;
+static unsigned task_creates, device_creates, device_removes;
+static bool task_oom, running_task;
+static jmp_buf task_exit;
+static touch_observation_t published;
+static void (*created_task)(void *);
+static void publish_touch(const touch_observation_t *state) {published=*state;}
+static int64_t board_now=1000000, task_deadline;
+static int64_t esp_timer_get_time(void) {return board_now;}
+static const char *esp_err_to_name(int error) {(void)error;return "injected";}
+static int i2c_master_bus_add_device(void *bus,const i2c_device_config_t *cfg,void **out) {
+    assert(bus==s_i2c && cfg->device_address==0x5d);++device_creates;*out=(void *)2;return ESP_OK;
+}
+static void i2c_master_bus_rm_device(void *device) {assert(device==s_touch_device);++device_removes;}
+static void *psram_task_create(void (*fn)(void *),const char *name,unsigned stack,void *arg,int priority,int core,void *a,void *b) {
+    (void)name;(void)arg;(void)a;(void)b;assert(stack==4096 && priority==5 && core==tskNO_AFFINITY);
+    ++task_creates;created_task=fn;return task_oom?NULL:(void *)4;
+}
+static uint8_t s_output, s_attenuation;
+static bool s_backlight_on_acked,s_backlight_off_acked;
+static uint32_t s_backlight_off_generation,s_touch_visibility_generation;
+typedef enum {TOUCH_VISIBILITY_IDLE,TOUCH_VISIBILITY_CHECK,TOUCH_VISIBILITY_ASSERT} touch_visibility_work_t;
+static touch_visibility_work_t s_touch_visibility_work;
+static int64_t s_touch_visibility_retry_at,s_touch_visibility_requested_us;
+static uint32_t s_touch_off_reset_generation,s_touch_off_reset_requests;
+static int64_t s_touch_off_reset_due_us;
+static bool s_touch_off_reset_pending,s_touch_off_reset_active,s_touch_off_reset_cancelled;
+static unsigned writes, fail_at, lock_fail, modes, last_mode, last_pullup, status_byte;
+static uint8_t regs[32], values[32];
+static int read_failure, write_failure;
+static bool read_point;
+static bool held;
+static int xSemaphoreTake(void *lock, unsigned timeout) {
+    assert(lock && timeout==25 && !held);
+    if(lock_fail)return 0;
+    held=true;return 1;
+}
+static void xSemaphoreGive(void *lock) {assert(lock && held);held=false;}
+static int i2c_master_transmit(void *device,const uint8_t *data,size_t n,int timeout) {
+    assert(timeout==20);
+    if(device==s_touch_device) {assert(n==3 && data[0]==0x81 && data[1]==0x4e);return write_failure;}
+    assert(device==s_iox && n==2 && writes<32);
+    regs[writes]=data[0];values[writes]=data[1];++writes;
+    return writes==fail_at ? ESP_ERR_TIMEOUT : ESP_OK;
+}
+static int i2c_master_transmit_receive(void *device,const uint8_t *address,size_t an,void *data,size_t n,int timeout) {
+    assert(device==s_touch_device && an==2 && timeout==20);
+    if (read_failure) return read_failure;
+    unsigned reg=(address[0]<<8)|address[1];
+    memset(data,0,n);
+    if(reg==GT911_ID_REG) {assert(n==4);memcpy(data,"911",3);}
+    else if(reg==GT911_STATUS_REG) {assert(n==1);*(uint8_t *)data=status_byte;}
+    else {assert(reg==GT911_STATUS_REG+1 && n==8);read_point=true;uint8_t *p=data;p[1]=0x34;p[2]=1;p[3]=0x56;p[4]=2;}
+    return ESP_OK;
+}
+static int gpio_config(const gpio_config_t *g) {++modes;last_mode=g->mode;last_pullup=g->pull_up_en;return ESP_OK;}
+static int gpio_set_level(int pin,int value) {assert(pin==4 && value==0);return ESP_OK;}
+static void vTaskDelay(unsigned time) {
+    board_now+=(int64_t)time*1000;
+    if(running_task && (time==10 || time==250)) {
+        if(!task_deadline || board_now>=task_deadline) longjmp(task_exit,1);
+        return;
+    }
+    assert(time==100 || time==200);
+}
+'''
+for name in ['iox_write','iox_output','waveshare_7b_recovery_brightness','reassert_visible_locked','waveshare_7b_reassert_visible','touch_read_register','touch_read_frame','assert_touch_reset','recover_touch','service_touch_visibility','request_visible','queue_touch_wake_check','service_touch_off_reset','touch_task','waveshare_7b_start_touch']:
+    board += function('main/board_waveshare_7b.c', name)
+board += r'''
+int main(void) {
+    for(unsigned failure=0;failure<=3;++failure) {
+        s_output=0x99;writes=0;fail_at=failure;
+        waveshare_7b_recovery_brightness(33);
+        int result=waveshare_7b_reassert_visible();
+        assert((result!=0)==(failure!=0));assert(writes==3);
+        assert(regs[0]==2 && values[0]==255 && regs[1]==5 && values[1]==170);
+        assert(regs[2]==3 && values[2]==0xdd); /* USB, SD and reset preserved */
+    }
+    lock_fail=1;writes=0;assert(waveshare_7b_reassert_visible()==ESP_ERR_TIMEOUT && !writes);lock_fail=0;
+    bool frame,pressed;uint16_t x,y;
+    status_byte=0;assert(!touch_read_frame(&frame,&pressed,&x,&y) && !frame);
+    status_byte=0x81;assert(!touch_read_frame(&frame,&pressed,&x,&y));
+    assert(frame && pressed && x==0x134 && y==0x256 && read_point);
+    status_byte=0x80;assert(!touch_read_frame(&frame,&pressed,&x,&y) && frame && !pressed);
+    status_byte=0x86;assert(touch_read_frame(&frame,&pressed,&x,&y)==ESP_ERR_INVALID_SIZE && !frame);
+    status_byte=0x81;write_failure=ESP_ERR_TIMEOUT;
+    assert(touch_read_frame(&frame,&pressed,&x,&y)==ESP_ERR_TIMEOUT && !frame);
+    write_failure=0;read_failure=ESP_ERR_TIMEOUT;
+    assert(touch_read_frame(&frame,&pressed,&x,&y)==ESP_ERR_TIMEOUT && !frame);
+    for (unsigned failure=0;failure<=2;++failure) {
+        read_failure=0;fail_at=failure;writes=0;modes=0;
+        assert((recover_touch(false,NULL)!=ESP_OK)==(failure!=0));
+        assert(writes==2 && (s_output&2));assert(last_mode==GPIO_MODE_INPUT);
+        assert(last_pullup==GPIO_PULLUP_DISABLE);
+    }
+    /* No legacy vendor object after boot NACK: one retained worker repairs
+     * reset/INT and publishes fresh input. Repeated start cannot duplicate it. */
+    assert(!s_touch);task_oom=true;
+    assert(waveshare_7b_start_touch()==ESP_ERR_NO_MEM && device_removes==1 && !s_touch_device);
+    task_oom=false;assert(waveshare_7b_start_touch()==ESP_OK);
+    assert(task_creates==2 && device_creates==2);
+    assert(waveshare_7b_start_touch()==ESP_OK && task_creates==2 && device_creates==2);
+    fail_at=0;writes=0;modes=0;status_byte=0x81;running_task=true;
+    if(!setjmp(task_exit)) created_task(NULL);
+    assert(published.recovery_attempts==1 && published.valid && published.pressed);
+    assert(published.x==0x134 && last_mode==GPIO_MODE_INPUT);
+    /* A physical wake retry remains pending until the controller acknowledges
+     * it, and a newer OFF generation cancels stale work. */
+    memset(&published,0,sizeof(published));writes=0;fail_at=3;held=false;
+    s_backlight_off_generation=0;s_touch_visibility_work=TOUCH_VISIBILITY_CHECK;
+    s_touch_visibility_generation=0;s_touch_visibility_requested_us=board_now;
+    s_touch_visibility_retry_at=0;s_backlight_on_acked=false;
+    service_touch_visibility(&published);
+    assert(writes==3 && s_touch_visibility_work==TOUCH_VISIBILITY_ASSERT);
+    board_now+=250000;fail_at=0;service_touch_visibility(&published);
+    assert(writes==6 && s_backlight_on_acked && published.visibility_requests==1);
+    s_touch_visibility_work=TOUCH_VISIBILITY_CHECK;s_touch_visibility_generation=0;
+    assert(iox_output(IOX_BACKLIGHT,false)==ESP_OK);
+    service_touch_visibility(&published);
+    assert(s_touch_visibility_work==TOUCH_VISIBILITY_IDLE);
+    puts("production board recovery: bounded I2C, reset cleanup, sticky wake retry and OFF ordering passed");
+}
+'''
+bsp = common + r'''
+#define CONFIG_SOMNOTRACE_BOARD_QEMU 0
+#define WAVESHARE_7B_H_RES 1024
+#define WAVESHARE_7B_V_RES 600
+#define TOUCH_FAILURE_THRESHOLD 3
+#define BACKLIGHT_RETRY_US 250000
+#define LV_OBJ_FLAG_HIDDEN 1
+#define LV_INDEV_STATE_PRESSED 1
+#define LV_INDEV_STATE_RELEASED 0
+typedef struct {int unused;} lv_indev_drv_t;
+typedef struct {struct {int x,y;} point;int state;} lv_indev_data_t;
+typedef struct {int x,y;} lv_point_t;
+typedef struct {int unused;} lv_obj_t;
+typedef struct {
+    unsigned wait_until_release,pr_timestamp,longpr_rep_timestamp,long_pr_sent;
+    struct {struct {lv_obj_t *act_obj,*last_obj,*scroll_obj;lv_point_t scroll_throw_vect,scroll_throw_vect_ori;} pointer;} types;
+} _lv_indev_proc_t;
+typedef struct {_lv_indev_proc_t proc;} lv_indev_t;
+static lv_indev_t active_indev;
+static lv_indev_t *indev_act=&active_indev;
+static lv_obj_t *indev_obj_act;
+static lv_obj_t button;
+static unsigned clicks,press_lost;
+#define LV_EVENT_PRESS_LOST 1
+#define LV_EVENT_RELEASED 2
+#define LV_EVENT_SHORT_CLICKED 3
+#define LV_EVENT_CLICKED 4
+#define LV_IMG_ZOOM_NONE 256
+#define LV_LOG_INFO(...) ((void)0)
+static lv_indev_t *lv_indev_get_act(void) {return indev_act;}
+static void lv_event_send(lv_obj_t *object,int event,void *input) {
+    (void)input;if(!object)return;
+    if(event==LV_EVENT_CLICKED)++clicks;
+    if(event==LV_EVENT_PRESS_LOST) {++press_lost;}
+}
+static bool indev_reset_check(_lv_indev_proc_t *proc) {(void)proc;return false;}
+static int lv_obj_get_style_transform_angle(lv_obj_t *o,int p) {(void)o;(void)p;return 0;}
+static int lv_obj_get_style_transform_zoom(lv_obj_t *o,int p) {(void)o;(void)p;return 256;}
+static lv_obj_t *lv_obj_get_parent(lv_obj_t *o) {(void)o;return NULL;}
+static void lv_point_transform(lv_point_t *v,int a,int z,lv_point_t *p) {(void)v;(void)a;(void)z;(void)p;}
+static void _lv_indev_scroll_throw_handler(_lv_indev_proc_t *p) {(void)p;}
+static bool s_backlight=true,s_backlight_known=true,s_backlight_requested=true;
+static bool s_wake_gesture_pending,s_touch_was_pressed;
+static uint32_t s_touch_seen_visibility,s_touch_seen_continuity,s_backlight_revision,s_touch_read_errors,s_backlight_write_errors;
+static uint8_t s_touch_consecutive_errors,s_brightness=66;
+static uint16_t s_last_touch_x,s_last_touch_y;
+static int64_t s_last_touch_activity_us,s_backlight_retry_after_us,now;
+static int s_wake_overlay=1,power_error,brightness_error;
+static unsigned power_calls,brightness_calls;static bool hidden=true;
+static touch_observation_t observation;
+static int64_t esp_timer_get_time(void) {return now;}
+static void waveshare_7b_touch_snapshot(touch_observation_t *out) {*out=observation;}
+static void bsp_display_set_notice(const char *s) {(void)s;}
+static void lv_obj_add_flag(int o,int f) {(void)o;(void)f;hidden=true;}
+static void lv_obj_clear_flag(int o,int f) {(void)o;(void)f;hidden=false;}
+static void lv_obj_move_foreground(int o) {(void)o;}
+static int waveshare_7b_reassert_visible(void) {++power_calls;return power_error;}
+static int waveshare_7b_set_backlight(bool on) {assert(!on);++power_calls;return power_error;}
+static int waveshare_7b_set_brightness(unsigned p) {assert(p==33);++brightness_calls;return brightness_error;}
+'''
+bsp += function(LVGL_INPUT, 'lv_indev_wait_release')
+bsp += function(LVGL_INPUT, 'indev_proc_release')
+for name in ['physical_brightness','bsp_display_set_backlight','touch_read_cb','apply_pending_backlight_locked']:
+    bsp += function('main/bsp_display_7b.c', name)
+bsp += r'''
+int main(void) {
+    apply_pending_backlight_locked();assert(!power_calls);
+    bsp_display_set_backlight(true);apply_pending_backlight_locked();
+    assert(power_calls==1 && brightness_calls==1 && s_backlight_known);
+    bsp_display_set_backlight(true);power_error=ESP_ERR_TIMEOUT;apply_pending_backlight_locked();
+    assert(power_calls==2 && !s_backlight_known);
+    now=249999;apply_pending_backlight_locked();assert(power_calls==2);
+    now=250000;power_error=0;brightness_error=ESP_ERR_TIMEOUT;apply_pending_backlight_locked();
+    assert(power_calls==3 && !s_backlight_known);
+    now=500000;brightness_error=0;apply_pending_backlight_locked();assert(s_backlight_known);
+    bsp_display_set_backlight(false);power_error=ESP_ERR_TIMEOUT;apply_pending_backlight_locked();
+    assert(s_backlight && s_backlight_requested && !s_backlight_known);
+    power_error=0;apply_pending_backlight_locked();
+    bsp_display_set_backlight(false);apply_pending_backlight_locked();assert(!s_backlight && !hidden);
+    now+=10000;touch_observation_update(&observation,now,0,true,true,300,200);++observation.visibility_requests;
+    lv_indev_drv_t driver={0};lv_indev_data_t input={0};
+    touch_read_cb(&driver,&input);assert(input.state==LV_INDEV_STATE_RELEASED && s_backlight_requested);
+    apply_pending_backlight_locked();assert(s_backlight && hidden);
+    touch_read_cb(&driver,&input);assert(input.state==LV_INDEV_STATE_RELEASED);
+    now+=10000;touch_observation_update(&observation,now,0,true,false,0,0);
+    touch_read_cb(&driver,&input);assert(!s_wake_gesture_pending);
+    now+=10000;touch_observation_update(&observation,now,0,true,true,300,200);
+    touch_read_cb(&driver,&input);assert(input.state==LV_INDEV_STATE_PRESSED && input.point.x==300);
+    now+=100001;touch_read_cb(&driver,&input);assert(input.state==LV_INDEV_STATE_RELEASED);
+    /* A complete fresh down frame after a 120 ms gap still loses continuity. */
+    now += 19000;touch_observation_update(&observation,now,0,true,true,300,200);
+    touch_read_cb(&driver,&input);assert(input.state==LV_INDEV_STATE_RELEASED && s_wake_gesture_pending);
+    now += 10000;touch_observation_update(&observation,now,0,true,false,0,0);
+    touch_read_cb(&driver,&input);assert(!s_wake_gesture_pending);
+    ++observation.visibility_requests;apply_pending_backlight_locked();assert(s_backlight_known && s_wake_gesture_pending);
+    /* Production LVGL release processing must send PRESS_LOST, never CLICKED,
+     * for a 101-150 ms discontinuity, read error, expired point or recovery. */
+    for(unsigned fault=0;fault<4;++fault) {
+        memset(&observation,0,sizeof(observation));s_touch_seen_continuity=0;
+        s_touch_seen_visibility=0;s_wake_gesture_pending=false;s_touch_was_pressed=false;
+        memset(&active_indev,0,sizeof(active_indev));clicks=0;press_lost=0;now=1000000;
+
+        for(;now<=3940000;now+=10000) {
+            touch_observation_update(&observation,now,0,true,true,300,200);
+            touch_read_cb(&driver,&input);assert(input.state==LV_INDEV_STATE_PRESSED);
+            active_indev.proc.types.pointer.act_obj=&button;
+        }
+        now=4050000;
+        if(fault==0)touch_observation_update(&observation,now,0,true,true,300,200);
+        if(fault==1)touch_observation_update(&observation,now,ESP_ERR_TIMEOUT,false,false,0,0);
+        if(fault==3)touch_observation_recovering(&observation);
+        touch_read_cb(&driver,&input);assert(input.state==LV_INDEV_STATE_RELEASED);
+        indev_proc_release(&active_indev.proc);
+        assert(press_lost==1 && clicks==0);
+        /* Recovery requires a fresh release, then a new uninterrupted hold. */
+        now+=10000;touch_observation_update(&observation,now,0,true,false,0,0);
+        touch_read_cb(&driver,&input);assert(!s_wake_gesture_pending);
+        now+=10000;
+        for(unsigned elapsed=0;elapsed<=3000;elapsed+=10,now+=10000) {
+            touch_observation_update(&observation,now,0,true,true,300,200);
+            touch_read_cb(&driver,&input);assert(input.state==LV_INDEV_STATE_PRESSED);
+        }
+        active_indev.proc.types.pointer.act_obj=&button;
+        touch_observation_update(&observation,now,0,true,false,0,0);
+        touch_read_cb(&driver,&input);indev_proc_release(&active_indev.proc);
+        assert(clicks==1); /* an ordinary fresh release still works */
+    }
+    /* Healthy idle polling may return no new zero-contact frame. It must not
+     * consume the next ordinary tap as a recovery gesture. */
+    for(unsigned idle=0;idle<500;++idle) {
+        now+=10000;touch_observation_update(&observation,now,0,false,false,0,0);
+        touch_read_cb(&driver,&input);assert(!s_wake_gesture_pending);
+    }
+    now+=10000;touch_observation_update(&observation,now,0,true,true,300,200);
+    touch_read_cb(&driver,&input);assert(input.state==LV_INDEV_STATE_PRESSED);
+    puts("production LVGL wake: cached-on reassertion, retry, input freshness and gesture suppression passed");
+}
+'''
+assert 'esp_lcd_touch_read_data' not in function('main/bsp_display_7b.c','touch_read_cb')
+with tempfile.TemporaryDirectory(prefix='somno-touch-recovery-') as directory:
+    for name, source in [('board',board),('bsp',bsp)]:
+        path=Path(directory)/f'{name}.c';path.write_text(source)
+        output=Path(directory)/name
+        subprocess.run(['cc','-std=c11','-Wall','-Wextra','-Werror','-Wno-unused-function','-fsanitize=address,undefined','-I',str(ROOT/'main'),str(path),str(ROOT/'main/touch_observation.c'),'-o',str(output)],check=True)
+        subprocess.run([str(output)],check=True)

--- a/scripts/upload_invalidation_behavior_test.py
+++ b/scripts/upload_invalidation_behavior_test.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""Production scheduler/index handoff under queue loss, restart and I/O faults.
+
+Compiles real public types, scheduler loop/polling, index deletion and group
+reconciliation. Platform scheduling and storage callback persistence are explicit
+test doubles over temporary host files; this is not a FAT durability simulation.
+"""
+from pathlib import Path
+import os
+import subprocess
+import tempfile
+from session_storage_behavior_test import COMMON, function
+import pending_export_behavior_test as pending_fixture
+
+ROOT = Path(__file__).resolve().parents[1]
+INDEX = (ROOT / 'components/uploader/upload_index.c').read_text()
+SCHED = (ROOT / 'components/uploader/upload_sched.c').read_text()
+SCAN = (ROOT / 'components/uploader/upload_scan.c').read_text()
+
+code = COMMON + r'''
+#include <setjmp.h>
+#include "uploader.h"
+#include "upload_sched.h"
+#undef UPLOAD_STATE_DIR
+#define UPLOAD_STATE_DIR "./upload_state"
+#define MALLOC_CAP_SPIRAM 1
+#define MALLOC_CAP_8BIT 2
+#define pdTRUE 1
+#define portMAX_DELAY -1
+#define pdMS_TO_TICKS(x) (x)
+typedef int TickType_t;
+typedef void *TaskHandle_t;
+typedef void *QueueHandle_t;
+typedef void *SemaphoreHandle_t;
+static upload_day_t *s_days[UPLOAD_MAX_DAYS_CAP];
+static int s_n_days;
+static int lease_depth, unlink_error, next_calls, ack_calls, ack_error;
+static bool cancel, deny_lease, deny_callback, cancel_after_next;
+static bool cancel_after_take, cancel_after_give, newer_after_give;
+static int64_t clock_us;
+bool uploader_should_cancel(void) { return cancel; }
+static void *heap_caps_calloc(size_t n,size_t z,int caps) {(void)caps;return calloc(n,z);}
+static void *idx_alloc(size_t n) {return calloc(1,n);}
+static void put(const char *path,const char *value) {
+    FILE *f=fopen(path,"w");assert(f);assert(fputs(value,f)>=0);
+    assert(fflush(f)==0 && fsync(fileno(f))==0);assert(fclose(f)==0);
+}
+static bool get(const char *path,char *out,size_t cap) {
+    FILE *f=fopen(path,"r");if(!f)return false;
+    size_t n=fread(out,1,cap-1,f);out[n]=0;assert(fclose(f)==0);return true;
+}
+static int checked_unlink(const char *path) {
+    assert(lease_depth==1);
+    if(unlink_error) {errno=unlink_error;return -1;}
+    return unlink(path);
+}
+#define unlink checked_unlink
+'''
+code += ''.join(function(INDEX,n) for n in [
+    'day_path','find_day_idx','upload_index_day','upload_index_group',
+    'upload_index_drop_group','upload_index_forget_day'])
+code += r'''
+#undef unlink
+static bool next_work(uint32_t *day,char *token,size_t cap) {
+    assert(lease_depth==0);next_calls++;
+    if(deny_callback || !get("./pending",token,cap))return false;
+    *day=20260906;if(cancel_after_next)cancel=true;return true;
+}
+static esp_err_t ack_work(uint32_t day,const char *token) {
+    assert(lease_depth==0 && day==20260906);ack_calls++;
+    char current[128];if(ack_error)return ESP_FAIL;
+    if(!get("./pending",current,sizeof current) || strcmp(current,token))
+        return ESP_ERR_INVALID_STATE;
+    assert(unlink("./pending")==0);return ESP_OK;
+}
+bool uploader_lease_take(uint32_t timeout) {
+    assert(timeout==0 && lease_depth==0);
+    if(cancel || deny_lease)return false;
+    lease_depth=1;if(cancel_after_take)cancel=true;return true;
+}
+void uploader_lease_give(void) {
+    assert(lease_depth==1);lease_depth=0;
+    if(cancel_after_give)cancel=true;
+    if(newer_after_give) {put("./pending","session:new-generation");newer_after_give=false;}
+}
+int upload_scan_day_groups(const char *day,upload_group_ref_t *out,int max_out) {
+    assert(!strcmp(day,"20260906") && max_out>0);memset(out,0,sizeof *out);
+    out->prefix_sec=100;out->kinds=UGK_BRP;out->n_files=1;return 1;
+}
+esp_err_t upload_index_save_day(upload_day_t *d) {
+    char path[160];day_path(d->day,path,sizeof path);
+    put(path,d->groups[0].be[0].status==UG_OK?"old-ok":"new-pending");
+    d->dirty=false;return ESP_OK;
+}
+'''
+code += function(SCAN,'upload_scan_reconcile_day')
+code += SCHED[SCHED.index('#define SCAN_INTERVAL_MS'):SCHED.index('/* Per-backend cooldown')]
+code += SCHED[SCHED.index('typedef enum {\n    SB_DISABLED'):SCHED.index('/* ── Helpers')]
+code += r'''
+static int scans,passes,queue_calls,queue_stop_at,queue_count,queue_head,dropped;
+static sched_ev_t queue_items[8];
+static jmp_buf task_exit;
+static int64_t now_us(void) {return clock_us;}
+static uint32_t now_s(void) {return 1700000000;}
+static void set_next_scan(int64_t t) {s_next_scan_us=t;}
+static void refresh_index_progress_cache(void) {}
+static void set_status(const char *format,...) {(void)format;}
+static int xPortGetCoreID(void) {return 1;}
+static void xSemaphoreTake(void *s,int n) {(void)s;(void)n;}
+static void xSemaphoreGive(void *s) {(void)s;}
+static void cooldown_reset(backend_rt_t *r) {r->retry_at_us=0;}
+static void set_be_state(backend_rt_t *r,sb_state_t s) {r->state=s;}
+static void do_scan(void) {scans++;set_next_scan(now_us()+600000000);}
+static void run_pass(void) {passes++;}
+static bool run_backend(backend_rt_t *r,int d) {(void)r;(void)d;return true;}
+esp_err_t uploader_smb_probe(void) {return ESP_OK;}
+esp_err_t uploader_sleephq_probe(void) {return ESP_OK;}
+int uploader_max_days(void) {return 30;}
+esp_err_t upload_index_clear(void) {return ESP_OK;}
+static int xQueueSend(void *q,const void *item,int wait) {
+    (void)q;assert(wait==0);
+    if(queue_count==8) {dropped++;return 0;}
+    queue_items[(queue_head+queue_count++)%8]=*(const sched_ev_t*)item;return pdTRUE;
+}
+static int xQueueReceive(void *q,void *item,int wait) {
+    (void)q;if(++queue_calls>queue_stop_at)longjmp(task_exit,1);
+    assert(wait>=0 && wait<=INVALIDATION_POLL_MS);
+    if(queue_count) {*(sched_ev_t*)item=queue_items[queue_head];queue_head=(queue_head+1)%8;queue_count--;return pdTRUE;}
+    clock_us+=(int64_t)wait*1000;return 0;
+}
+'''
+code += ''.join(function(SCHED,n) for n in [
+    'service_pending_invalidation','poll_pending_invalidation','sched_task',
+    'upload_sched_set_invalidation_hooks','post','upload_sched_notify_invalidate'])
+code += r'''
+static void reset_ram(void) {
+    for(int i=0;i<s_n_days;i++)free(s_days[i]);s_n_days=0;
+    lease_depth=unlink_error=next_calls=ack_calls=ack_error=0;
+    cancel=deny_lease=deny_callback=cancel_after_next=false;
+    cancel_after_take=cancel_after_give=newer_after_give=false;
+    clock_us=s_next_invalidation_poll_us=0;s_task=NULL;s_queue=(void*)1;
+    scans=passes=queue_calls=queue_count=queue_head=dropped=0;s_n_rt=0;
+    upload_sched_set_invalidation_hooks(next_work,ack_work);
+}
+static upload_day_t *seed(void) {
+    reset_ram();mkdir(UPLOAD_STATE_DIR,0700);put("./pending","session:old-generation");
+    upload_day_t *d=upload_index_day(20260906,true);assert(d);
+    upload_group_t *g=upload_index_group(d,100,true);assert(g);
+    g->kinds=UGK_BRP;g->n_files=1;g->be[0].status=UG_OK;upload_index_save_day(d);
+    return d;
+}
+static bool pending(void) {return access("./pending",F_OK)==0;}
+static bool index_file(void) {return access(UPLOAD_STATE_DIR "/20260906.json",F_OK)==0;}
+static void scheduler_turns(int turns) {
+    queue_stop_at=turns;queue_calls=0;if(setjmp(task_exit)==0)sched_task(NULL);
+    assert(lease_depth==0);
+}
+int main(void) {
+    // Failed deletion cannot evict RAM success or acknowledge persisted work.
+    const int errors[]={EIO,EROFS,ENOSPC};
+    for(size_t i=0;i<sizeof errors/sizeof *errors;i++) {
+        upload_day_t *d=seed();unlink_error=errors[i];assert(!service_pending_invalidation());
+        assert(pending() && index_file() && ack_calls==0 && s_days[0]==d);
+        assert(d->groups[0].be[0].status==UG_OK && lease_depth==0);
+    }
+    // A pending recording or denied gate never waits or loses the token.
+    for(int phase=0;phase<5;phase++) {
+        seed();if(phase==0)cancel=true;if(phase==1)deny_lease=true;
+        if(phase==2)cancel_after_next=true;if(phase==3)cancel_after_take=true;
+        if(phase==4)deny_callback=true;
+        assert(!service_pending_invalidation());assert(pending() && index_file() && ack_calls==0);
+        assert(lease_depth==0);if(phase==0)assert(next_calls==0);
+    }
+    // Reset/cancellation after checked deletion, before acknowledgement.
+    seed();cancel_after_give=true;assert(!service_pending_invalidation());
+    assert(pending() && !index_file() && ack_calls==0);reset_ram();
+    assert(service_pending_invalidation());assert(!pending() && !index_file());
+    // Same prefix/count/kinds was already uploaded: real reconcile now reoffers it.
+    assert(upload_scan_reconcile_day(20260906)==1);
+    assert(s_days[0]->groups[0].be[0].status==UG_PENDING);
+    // A failed ack is likewise retryable after losing all scheduler RAM state.
+    seed();ack_error=1;assert(!service_pending_invalidation());
+    assert(pending() && !index_file());reset_ram();assert(service_pending_invalidation());
+    // Another completed publication between the short leases must survive old ack.
+    seed();newer_after_give=true;assert(!service_pending_invalidation());
+    char token[128];assert(get("./pending",token,sizeof token));assert(!strcmp(token,"session:new-generation"));
+    assert(service_pending_invalidation());assert(!pending());
+    // Queue saturation loses only a nudge. Actual scheduler polls persisted work.
+    seed();for(int i=0;i<8;i++)post(EV_EXPORT,20260906);
+    upload_sched_notify_invalidate(20260906);assert(dropped==1);
+    scheduler_turns(12);assert(!pending() && !index_file() && ack_calls==1);
+    // Process restart needs no event at all; unchanged filenames are invalidated.
+    seed();reset_ram();scheduler_turns(3);assert(!pending() && !index_file());
+    // Idle polling neither spins nor launches network/scans before their deadline.
+    reset_ram();scheduler_turns(6);assert(next_calls==7 && clock_us==6000000);
+    assert(scans==0 && passes==0);
+    // Immutable startup registration rejects partial hook replacement at runtime.
+    s_task=(void*)1;upload_sched_set_invalidation_hooks(NULL,NULL);
+    assert(s_invalidation_next==next_work && s_invalidation_ack==ack_work);
+    reset_ram();unlink(UPLOAD_STATE_DIR "/20260906.json");rmdir(UPLOAD_STATE_DIR);
+    puts("production invalidation: checked deletion, full queue/restart, exact tokens, same-file-set reconcile, cancellation and idle cadence passed");
+}
+'''
+
+joint = COMMON + r'''
+#include "uploader.h"
+#undef UPLOAD_STATE_DIR
+#define UPLOAD_STATE_DIR "./upload_state"
+static int lease_depth,fail_index_unlink,fail_marker_unlink;
+static bool index_owner,recording,new_generation_on_release,deny_ack_on_release;
+static int fault_unlink(const char *path) {
+    assert(lease_depth==1);
+    bool index=strstr(path,"/upload_state/")!=NULL;
+    assert(index_owner==index);
+    if((index && fail_index_unlink) || (!index && fail_marker_unlink)) {errno=EIO;return -1;}
+    return unlink(path);
+}
+#define unlink fault_unlink
+'''
+# Reuse the storage owner's fixture without changing its test: production
+# next/ack/nonce journal functions, explicit scalar JSON fields, real FILE I/O.
+storage = pending_fixture.code.split('int main(void) {')[0][len(COMMON):]
+# The joint fixture distinguishes index deletion from marker deletion; retain
+# that stronger owner-aware injector instead of the storage-only fault toggle.
+storage = storage.replace('#define unlink fake_unlink',
+                          '#undef unlink\n#define unlink fault_unlink')
+storage = storage.replace('(void)a;(void)b;if(!allow_lease)return false;',
+                          'assert(a==SD_LEASE_EXPORT && b==0 && lease_depth==0);'
+                          'if(!allow_lease)return false;')
+joint += storage + r'''
+static upload_day_t *s_days[UPLOAD_MAX_DAYS_CAP];
+static int s_n_days;
+static uploader_invalidation_next_fn_t s_invalidation_next=session_writer_next_upload_invalidation;
+static uploader_invalidation_ack_fn_t s_invalidation_ack=session_writer_ack_upload_invalidation;
+static void refresh_index_progress_cache(void) {assert(lease_depth==0);}
+static void set_next_scan(int64_t t) {assert(t==0 && lease_depth==0);}
+bool uploader_should_cancel(void) {return recording;}
+bool uploader_lease_take(uint32_t timeout) {
+    assert(timeout==0 && lease_depth==0);if(recording)return false;
+    lease_depth=1;index_owner=true;return true;
+}
+void uploader_lease_give(void) {
+    assert(lease_depth==1 && index_owner);lease_depth=0;index_owner=false;
+    if(new_generation_on_release) {
+        new_generation_on_release=false;
+        assert(session_writer_mark_upload_invalidation("20260906")==ESP_OK);
+    }
+    if(deny_ack_on_release)allow_lease=false;
+}
+'''
+joint += ''.join(function(INDEX,n) for n in ['day_path','find_day_idx','upload_index_forget_day'])
+joint += function(SCHED,'service_pending_invalidation')
+joint += r'''
+#undef unlink
+static void boot_ram(void) {
+    assert(lease_depth==0);for(int i=0;i<s_n_days;i++)free(s_days[i]);s_n_days=0;
+    fail_index_unlink=fail_marker_unlink=0;allow_lease=true;deny_ack_on_release=false;
+}
+static void seed_joint(void) {
+    boot_ram();assert(session_writer_mark_upload_invalidation("20260906")==ESP_OK);
+    mkdir(UPLOAD_STATE_DIR,0700);FILE *f=fopen(UPLOAD_STATE_DIR "/20260906.json","w");
+    assert(f);fputs("old success",f);assert(fclose(f)==0);
+    s_days[s_n_days++]=calloc(1,sizeof(upload_day_t));s_days[0]->day=20260906;
+    s_days[0]->groups[0].be[0].status=UG_OK;
+}
+static void require_work(char *token) {
+    uint32_t day;assert(session_writer_next_upload_invalidation(&day,token,128));assert(day==20260906);
+}
+int main(void) {
+    char token[128],newer[128];uint32_t day;
+    seed_joint();require_work(token);fail_index_unlink=1;
+    assert(!service_pending_invalidation());require_work(newer);assert(!strcmp(token,newer));
+    assert(s_n_days==1 && s_days[0]->groups[0].be[0].status==UG_OK);
+    fail_index_unlink=0;fail_marker_unlink=1;
+    assert(!service_pending_invalidation());assert(s_n_days==0);
+    require_work(newer);assert(!strcmp(token,newer));
+    // Both production parties recover using only persisted token/file state.
+    boot_ram();assert(service_pending_invalidation());
+    assert(!session_writer_next_upload_invalidation(&day,newer,sizeof newer));
+    seed_joint();require_work(token);new_generation_on_release=true;
+    assert(!service_pending_invalidation());require_work(newer);assert(strcmp(token,newer));
+    assert(service_pending_invalidation());
+    seed_joint();deny_ack_on_release=true;assert(!service_pending_invalidation());
+    boot_ram();require_work(token);assert(service_pending_invalidation());
+    boot_ram();unlink(UPLOAD_STATE_DIR "/20260906.json");rmdir(UPLOAD_STATE_DIR);
+    rmdir(SD_PENDING_EXPORT_DIR);
+    puts("joint production storage/scheduler: checked disk deletion, persisted nonce, failed ack, restart and newer-publication fencing passed");
+}
+'''
+
+def compile_run(source):
+    with tempfile.TemporaryDirectory(prefix='somno-invalidation-') as tmp:
+        p = Path(tmp)
+        (p / 'esp_err.h').write_text('#pragma once\n')
+        (p / 'test.c').write_text(source)
+        subprocess.run([os.environ.get('CC', 'cc'), '-std=gnu11', '-Wall', '-Wextra',
+                        '-Werror', '-Wno-unused-function', '-Wno-unused-variable',
+                        '-fsanitize=address,undefined', '-fno-omit-frame-pointer',
+                        '-I', str(p), '-I', str(ROOT / 'components/uploader'),
+                        str(p / 'test.c'), '-o', str(p / 'test')], check=True)
+        subprocess.run([str(p / 'test')], cwd=p, check=True, timeout=15)
+
+if __name__ == '__main__':
+    compile_run(code)
+    compile_run(joint)

--- a/scripts/upload_progress_snapshot_contract_test.py
+++ b/scripts/upload_progress_snapshot_contract_test.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Keep concurrent upload progress readers off the mutable upload index."""
+
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHED = (ROOT / "components/uploader/upload_sched.c").read_text(encoding="utf-8")
+HOST_TEST = (ROOT / "scripts/test-host.sh").read_text(encoding="utf-8")
+
+
+def function_body(source: str, name: str) -> str:
+    match = re.search(
+        rf"^[\w][\w\s*]*\b{name}\s*\([^;{{}}]*\)\s*\{{",
+        source,
+        re.MULTILINE,
+    )
+    if not match:
+        raise AssertionError(f"missing function: {name}")
+    depth = 1
+    cursor = match.end()
+    while cursor < len(source) and depth:
+        if source[cursor] == "{":
+            depth += 1
+        elif source[cursor] == "}":
+            depth -= 1
+        cursor += 1
+    if depth:
+        raise AssertionError(f"unterminated function: {name}")
+    return source[match.end(): cursor - 1]
+
+
+snapshot = function_body(SCHED, "upload_sched_progress_snapshot")
+refresh = function_body(SCHED, "refresh_index_progress_cache")
+init = function_body(SCHED, "upload_sched_init")
+invalidate = function_body(SCHED, "reconcile_day_leased")
+scan = function_body(SCHED, "do_scan")
+run_pass = function_body(SCHED, "run_pass")
+sched_task = function_body(SCHED, "sched_task")
+
+# Display/httpd/WebSocket callers may run concurrently with reset and scan.
+# Their snapshot must be a bounded copy under the runtime lock, never a walk
+# through upload_index's replaceable s_days pointers.
+for forbidden in (
+    "upload_index_",
+    "opendir(",
+    "fopen(",
+    "heap_caps_malloc(",
+    "malloc(",
+):
+    assert forbidden not in snapshot, f"progress snapshot performs work: {forbidden}"
+assert "xSemaphoreTake(s_lock, portMAX_DELAY)" in snapshot
+assert "dst->days_done = src->days_done" in snapshot
+assert "dst->days_total = src->days_total" in snapshot
+assert "out->max_days = progress_max_days" in snapshot
+
+# Only the scheduler-side cache producer may aggregate the index. It computes
+# into locals, then publishes the whole set while holding the snapshot lock.
+assert "upload_index_backend_progress(" in refresh
+assert "s_rt[i].days_done = done[i]" in refresh
+assert "s_rt[i].days_total = total[i]" in refresh
+assert "s_progress_max_days = max_days" in refresh
+assert refresh.count("xSemaphoreTake(s_lock, portMAX_DELAY)") >= 2
+
+# Prime after the boot-time index load, and refresh after every scheduler path
+# that reconciles, uploads, or clears the in-memory index.
+assert "refresh_index_progress_cache();" in init
+assert "refresh_index_progress_cache();" in invalidate
+assert scan.count("refresh_index_progress_cache();") >= 2
+assert run_pass.count("refresh_index_progress_cache();") >= 2
+assert re.search(
+    r"upload_index_clear\(\);\s*refresh_index_progress_cache\(\);",
+    sched_task,
+), "reset publishes a stale progress cache"
+
+assert "upload_progress_snapshot_contract_test.py" in HOST_TEST
+
+print("upload progress snapshot contract passed")

--- a/scripts/upload_progress_snapshot_contract_test.py
+++ b/scripts/upload_progress_snapshot_contract_test.py
@@ -34,7 +34,7 @@ def function_body(source: str, name: str) -> str:
 snapshot = function_body(SCHED, "upload_sched_progress_snapshot")
 refresh = function_body(SCHED, "refresh_index_progress_cache")
 init = function_body(SCHED, "upload_sched_init")
-invalidate = function_body(SCHED, "reconcile_day_leased")
+invalidate = function_body(SCHED, "service_pending_invalidation")
 scan = function_body(SCHED, "do_scan")
 run_pass = function_body(SCHED, "run_pass")
 sched_task = function_body(SCHED, "sched_task")

--- a/scripts/uploader_ox_lease_contract_test.py
+++ b/scripts/uploader_ox_lease_contract_test.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Contracts for leasing every uploader-side O2 card traversal."""
+
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = (ROOT / "components/uploader/upload_sched.c").read_text(
+    encoding="utf-8"
+)
+
+
+def function(name: str) -> str:
+    match = re.search(
+        rf"^[\w][\w\s*]*\b{name}\s*\([^;{{}}]*\)\s*\{{",
+        SOURCE,
+        re.MULTILINE,
+    )
+    if not match:
+        raise AssertionError(f"missing function {name}")
+    depth = 1
+    cursor = match.end()
+    while cursor < len(SOURCE) and depth:
+        if SOURCE[cursor] == "{":
+            depth += 1
+        elif SOURCE[cursor] == "}":
+            depth -= 1
+        cursor += 1
+    if depth:
+        raise AssertionError(f"unterminated function {name}")
+    return SOURCE[match.end():cursor - 1]
+
+
+backend = function("run_backend")
+take = backend.index("uploader_lease_take(LEASE_WAIT_MS)")
+bundle_scan = backend.index("upload_scan_bundle(&bundle)")
+ox_scan = backend.index("upload_ox_reconcile(")
+discovery_release = backend.index("uploader_lease_give()", ox_scan)
+assert take < bundle_scan < ox_scan < discovery_release
+
+day_scan = backend.index("upload_scan_day_groups(")
+day_take = backend.rfind("uploader_lease_take(LEASE_WAIT_MS)", 0, day_scan)
+day_release = backend.index("uploader_lease_give()", day_scan)
+day_end = backend.index("be->day_end", day_release)
+assert day_take < day_scan < day_release < day_end
+
+ox_put = backend.index("be->put_oximetry(")
+ox_take = backend.rfind("uploader_lease_take(LEASE_WAIT_MS)", 0, ox_put)
+ox_mark = backend.index("upload_ox_mark(", ox_put)
+ox_release = backend.index("uploader_lease_give()", ox_mark)
+assert ox_take < ox_put < ox_mark < ox_release
+
+# The final post-pass summary also reconciles the O2 tree and therefore needs
+# its own short lease after backend transactions have completed.
+run_pass = function("run_pass")
+summary_alloc = run_pass.rindex("upload_ox_ref_t *ox_refs")
+summary = run_pass[summary_alloc:]
+assert summary.index("uploader_lease_take(LEASE_WAIT_MS)") < summary.index(
+    "upload_ox_reconcile("
+) < summary.index("uploader_lease_give()")
+
+# Boot-time state loading can overlap an already-live maintenance HTTP server.
+init = function("upload_sched_init")
+assert init.index("uploader_lease_take(LEASE_WAIT_MS)") < init.index(
+    "upload_ox_init()"
+) < init.index("uploader_lease_give()")
+
+print("uploader O2 lease contract passed")

--- a/scripts/waveshare_7b_contract_test.py
+++ b/scripts/waveshare_7b_contract_test.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Static hardware-contract checks for the Waveshare 7B board profile.
+
+The expected values come from Waveshare's ESP32-S3-Touch-LCD-7B ESP-IDF
+reference at commit c652c902db607f7ffb376257393cfd7657aa6428. These checks do not
+replace a physical bring-up, but they make accidental pin, timing, framebuffer,
+or target-config regressions fail loudly during ordinary host testing.
+"""
+
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def source(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def require(text: str, pattern: str, description: str) -> None:
+    if not re.search(pattern, text, re.MULTILINE | re.DOTALL):
+        raise AssertionError(f"missing 7B contract: {description}")
+
+
+board = source("main/board_waveshare_7b.c")
+display = source("main/bsp_display_7b.c")
+storage = source("main/sd_storage.c")
+defaults = source("sdkconfig.7b.defaults")
+cmake = source("main/CMakeLists.txt")
+root_cmake = source("CMakeLists.txt")
+lvgl_allocator = source("main/somnotrace_lvgl_psram.h")
+expected_scalars = {
+    r"#define\s+I2C_SDA\s+GPIO_NUM_8\b": "I2C SDA GPIO8",
+    r"#define\s+I2C_SCL\s+GPIO_NUM_9\b": "I2C SCL GPIO9",
+    r"#define\s+IOX_ADDR\s+0x24\b": "CH32V003 controller address 0x24",
+    r"\.pclk_hz\s*=\s*30850000\b": "accepted 30.85 MHz pixel clock",
+    r"\.hsync_pulse_width\s*=\s*162\b": "HSYNC pulse",
+    r"\.hsync_back_porch\s*=\s*152\b": "HSYNC back porch",
+    r"\.hsync_front_porch\s*=\s*48\b": "HSYNC front porch",
+    r"\.vsync_pulse_width\s*=\s*45\b": "VSYNC pulse",
+    r"\.vsync_back_porch\s*=\s*13\b": "VSYNC back porch",
+    r"\.vsync_front_porch\s*=\s*3\b": "VSYNC front porch",
+    r"\.hsync_gpio_num\s*=\s*GPIO_NUM_46\b": "HSYNC GPIO46",
+    r"\.vsync_gpio_num\s*=\s*GPIO_NUM_3\b": "VSYNC GPIO3",
+    r"\.de_gpio_num\s*=\s*GPIO_NUM_5\b": "DE GPIO5",
+    r"\.pclk_gpio_num\s*=\s*GPIO_NUM_7\b": "PCLK GPIO7",
+    r"\.num_fbs\s*=\s*2\b": "double framebuffer",
+    r"\.bounce_buffer_size_px\s*=\s*WAVESHARE_7B_H_RES\s*\*\s*10\b":
+        "cache-sized ten-line bounce buffer",
+    r"\.flags\.fb_in_psram\s*=\s*true\b": "PSRAM framebuffers",
+    r"\.flags\.pclk_active_neg\s*=\s*true\b": "negative PCLK edge",
+}
+for pattern, description in expected_scalars.items():
+    require(board, pattern, description)
+
+rgb_match = re.search(r"\.data_gpio_nums\s*=\s*\{(.*?)\}", board, re.DOTALL)
+if not rgb_match:
+    raise AssertionError("missing 7B RGB data pin array")
+rgb_pins = [int(value) for value in re.findall(r"GPIO_NUM_(\d+)", rgb_match.group(1))]
+expected_rgb = [14, 38, 18, 17, 10, 39, 0, 45, 48, 47, 21, 1, 2, 42, 41, 40]
+assert rgb_pins == expected_rgb, f"RGB pin order changed: {rgb_pins}"
+assert len(set(rgb_pins)) == 16, "RGB data pins must be unique"
+
+rgb_bus = set(rgb_pins) | {3, 5, 7, 46}
+control_bus = {4, 8, 9, 11, 12, 13}
+assert not rgb_bus & control_bus, f"RGB/control GPIO collision: {rgb_bus & control_bus}"
+
+require(board, r"\.x_max\s*=\s*WAVESHARE_7B_H_RES", "GT911 X range")
+require(board, r"\.y_max\s*=\s*WAVESHARE_7B_V_RES", "GT911 Y range")
+require(board, r"\.int_gpio_num\s*=\s*GPIO_NUM_4", "GT911 interrupt GPIO4")
+require(board, r"IOX_TOUCH_RST,\s*false.*pdMS_TO_TICKS\(100\).*GPIO_NUM_4,\s*0.*pdMS_TO_TICKS\(100\).*IOX_TOUCH_RST,\s*true.*pdMS_TO_TICKS\(200\)",
+        "Waveshare GT911 reset/address-selection timing")
+
+require(storage, r"s\.clk\s*=\s*GPIO_NUM_12", "TF CLK GPIO12")
+require(storage, r"s\.cmd\s*=\s*GPIO_NUM_11", "TF CMD GPIO11")
+require(storage, r"s\.d0\s*=\s*GPIO_NUM_13", "TF D0 GPIO13")
+require(storage, r"s\.width\s*=\s*1", "TF one-bit SDMMC mode")
+require(board, r"iox_output\(IOX_SD_CS,\s*true\)", "TF DAT3/CS held high")
+require(board,
+        r"attenuation\s*=\s*\(uint8_t\)\(100U\s*-\s*percent\).*?"
+        r"attenuation\s*>\s*97.*?IOX_REG_PWM,\s*pwm",
+        "active-low backlight PWM mapping with vendor attenuation limit")
+require(display,
+        r"physical_brightness.*?tenth_percent\s*\+\s*1U\)\s*/\s*2U",
+        "7B legacy brightness range mapped to 1-100 percent")
+require(display, r'waveshare_7b_set_brightness\(100\)',
+        "steady full-brightness display initialization")
+require(board,
+        r"waveshare_7b_set_panel_pclk\s*\(uint32_t\s+hz\).*?"
+        r"hz\s*!=\s*18000000U\s*&&\s*hz\s*!=\s*30850000U.*?"
+        r"esp_lcd_rgb_panel_set_pclk\(s_panel,\s*hz\)",
+        "runtime PCLK diagnostic restricted to the two A/B clocks")
+require(display, r"\.on_frame_buf_complete\s*=\s*on_frame_complete", "frame-buffer handoff")
+require(display, r"display_driver\.hor_res\s*=\s*WAVESHARE_7B_H_RES", "LVGL width")
+require(display, r"display_driver\.ver_res\s*=\s*WAVESHARE_7B_V_RES", "LVGL height")
+require(display, r"esp_lcd_rgb_panel_get_frame_buffer\(s_panel,\s*2,\s*&fb1,\s*&fb2\)",
+        "two panel-owned framebuffers")
+require(display, r"display_driver\.direct_mode\s*=\s*1", "dirty-region direct rendering")
+require(display, r"if\s*\(!lv_disp_flush_is_last\(drv\)\).*?lv_disp_flush_ready\(drv\).*?return",
+        "one panel handoff after the final dirty area")
+require(display,
+        r"esp_lcd_panel_draw_bitmap.*?ulTaskNotifyTake\(pdTRUE,\s*0\).*?"
+        r"ulTaskNotifyTake\(pdTRUE,\s*pdMS_TO_TICKS\(100\)\)",
+        "discard stale completions after framebuffer selection")
+require(display, r"boot_scanout\s*=\s*fb1;\s*fb1\s*=\s*fb2;\s*fb2\s*=\s*boot_scanout;",
+        "first LVGL render starts outside the boot scanout buffer")
+require(root_cmake, r"LV_MEM_CUSTOM_ALLOC=somnotrace_lvgl_alloc",
+        "7-inch LVGL allocator override")
+require(lvgl_allocator, r"heap_caps_malloc_prefer.*?MALLOC_CAP_SPIRAM.*?MALLOC_CAP_INTERNAL",
+        "LVGL PSRAM-first allocation with internal fallback")
+require(lvgl_allocator, r"heap_caps_realloc_prefer", "matched LVGL reallocator")
+require(lvgl_allocator, r"heap_caps_free", "matched LVGL free")
+
+assert "CONFIG_BT_NIMBLE_HOST_TASK_STACK_SIZE=6144" in source("sdkconfig.defaults")
+print("7B physical pins, transport, allocator and original NimBLE contracts passed")

--- a/sdkconfig.7b.defaults
+++ b/sdkconfig.7b.defaults
@@ -1,0 +1,41 @@
+# SomnoTrace board overlay for Waveshare ESP32-S3-Touch-LCD-7B.
+CONFIG_SOMNOTRACE_BOARD_WAVESHARE_7B=y
+
+# The RGB peripheral reads its framebuffers from octal PSRAM continuously.
+CONFIG_ESP32S3_DATA_CACHE_64KB=y
+CONFIG_ESP32S3_DATA_CACHE_SIZE=0x10000
+CONFIG_ESP32S3_DATA_CACHE_LINE_64B=y
+CONFIG_ESP32S3_DATA_CACHE_LINE_SIZE=64
+CONFIG_FREERTOS_HZ=1000
+# Waveshare's current 1024x600 reference enables both options to keep the
+# display path stable under redraw, flash, and network load.
+CONFIG_SPIRAM_FETCH_INSTRUCTIONS=y
+CONFIG_SPIRAM_RODATA=y
+
+# Catch stack corruption close to its source in the larger touch/LVGL build.
+CONFIG_COMPILER_STACK_CHECK_MODE_STRONG=y
+# build_ui() creates the full bedside object tree before the dedicated LVGL
+# task starts. Keep explicit headroom for that one-time construction path.
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=14336
+
+# Native 1024x600 UI (LVGL 8).
+CONFIG_LV_COLOR_DEPTH_16=y
+# Read touch at 100 Hz and schedule invalidated UI work at 60 Hz. The RGB
+# panel scans continuously at the physically accepted 30.85 MHz timing; these
+# values control how quickly input and dirty UI regions are prepared.
+CONFIG_LV_INDEV_DEF_READ_PERIOD=10
+CONFIG_LV_DISP_DEF_REFR_PERIOD=16
+CONFIG_LV_MEM_CUSTOM=y
+CONFIG_LV_MEMCPY_MEMSET_STD=y
+CONFIG_LV_USE_FONT_COMPRESSED=y
+CONFIG_LV_FONT_MONTSERRAT_14=y
+CONFIG_LV_FONT_MONTSERRAT_18=y
+CONFIG_LV_FONT_MONTSERRAT_22=y
+CONFIG_LV_FONT_MONTSERRAT_28=y
+CONFIG_LV_SPRINTF_USE_FLOAT=y
+CONFIG_LV_FONT_MONTSERRAT_36=y
+CONFIG_LV_FONT_MONTSERRAT_48=y
+CONFIG_LV_USE_CHART=y
+CONFIG_LV_USE_BTN=y
+CONFIG_LV_USE_LABEL=y
+CONFIG_LV_USE_MSGBOX=y

--- a/third_party/esp-idf-patches/LICENSE
+++ b/third_party/esp-idf-patches/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/third_party/esp-idf-patches/README.md
+++ b/third_party/esp-idf-patches/README.md
@@ -1,0 +1,19 @@
+# ESP-IDF HTTP asynchronous request cleanup
+
+The Docker runner applies a checked, idempotent one-line fix to the container's
+ESP-IDF v5.5.1 `httpd_req_async_handler_begin`. If response-header allocation fails
+after the request scratch buffer was copied, the SDK must free that scratch
+buffer before freeing the auxiliary structure.
+
+`scripts/idf-sdk-patches.py` checks both async functions against the unchanged
+reference in this directory before applying the fix. An unexpected SDK version
+fails the build and requires review. The host SDK is never changed. All commands
+through `scripts/idf.sh`, including builds from linked worktrees, use the fix.
+Direct builds outside this runner must apply the same fix before deployment.
+
+`scripts/idf_async_allocation_test.py` injects failure at every allocation into
+the patched reference functions and checks retained allocations and session
+ownership. The build-time identity check ties that test to the SDK being used.
+
+The reference functions are Espressif code under Apache-2.0, extracted from
+[ESP-IDF v5.5.1](https://github.com/espressif/esp-idf/blob/v5.5.1/components/esp_http_server/src/httpd_txrx.c).

--- a/third_party/esp-idf-patches/httpd_async_v5_5_1.c
+++ b/third_party/esp-idf-patches/httpd_async_v5_5_1.c
@@ -1,0 +1,81 @@
+/* SPDX-License-Identifier: Apache-2.0
+ * Extracted unchanged from Espressif ESP-IDF v5.5.1 httpd_txrx.c.
+ * Copyright 2015-2025 Espressif Systems (Shanghai) CO LTD.
+ * Reference fixture for SDK identity and allocation fault tests only.
+ * https://github.com/espressif/esp-idf/blob/v5.5.1/components/esp_http_server/src/httpd_txrx.c
+ */
+esp_err_t httpd_req_async_handler_begin(httpd_req_t *r, httpd_req_t **out)
+{
+    if (r == NULL || out == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    // alloc async req
+    httpd_req_t *async = malloc(sizeof(httpd_req_t));
+    if (async == NULL) {
+        return ESP_ERR_NO_MEM;
+    }
+    memcpy(async, r, sizeof(httpd_req_t));
+
+    // alloc async aux
+    async->aux = malloc(sizeof(struct httpd_req_aux));
+    if (async->aux == NULL) {
+        free(async);
+        return ESP_ERR_NO_MEM;
+    }
+    memcpy(async->aux, r->aux, sizeof(struct httpd_req_aux));
+
+    // Copy response header block
+    struct httpd_data *hd = (struct httpd_data *) r->handle;
+    struct httpd_req_aux *async_aux = (struct httpd_req_aux *) async->aux;
+    struct httpd_req_aux *r_aux = (struct httpd_req_aux *) r->aux;
+
+    if (r_aux->scratch) {
+        async_aux->scratch = malloc(r_aux->scratch_cur_size);
+        if (async_aux->scratch == NULL) {
+            free(async_aux);
+            free(async);
+            return ESP_ERR_NO_MEM;
+        }
+        memcpy(async_aux->scratch, r_aux->scratch, r_aux->scratch_cur_size);
+    } else {
+        async_aux->scratch = NULL;
+    }
+
+    async_aux->resp_hdrs = calloc(hd->config.max_resp_headers, sizeof(struct resp_hdr));
+    if (async_aux->resp_hdrs == NULL) {
+        free(async_aux);
+        free(async);
+        return ESP_ERR_NO_MEM;
+    }
+    memcpy(async_aux->resp_hdrs, r_aux->resp_hdrs, hd->config.max_resp_headers * sizeof(struct resp_hdr));
+
+    // Prevent the main thread from reading the rest of the request after the handler returns.
+    r_aux->remaining_len = 0;
+
+    // mark socket as "in use"
+    r_aux->sd->for_async_req = true;
+
+    *out = async;
+
+    return ESP_OK;
+}
+
+esp_err_t httpd_req_async_handler_complete(httpd_req_t *r)
+{
+    if (r == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    struct httpd_req_aux *ra = r->aux;
+    ra->sd->for_async_req = false;
+    free(ra->scratch);
+    ra->scratch = NULL;
+    ra->scratch_cur_size = 0;
+    ra->scratch_size_limit = 0;
+    free(ra->resp_hdrs);
+    free(r->aux);
+    free(r);
+
+    return ESP_OK;
+}


### PR DESCRIPTION
Stack: **4/12** · depends on #238 · next #240

What changed and why:
- **Add the 1024×600 panel, SD wiring and synchronized framebuffer handoff.** Supports the Waveshare 7B without corrupting scanout or storage ownership.
- **Recover GT911 after repeated dark cycles and retain failed reset work.** Keeps recovery pending until the controller responds.
- **Fence stale touch frames after Screen off.** Prevents an old press from waking or activating the interface after a newer OFF request.
- **Document the exact 7B touch board and installation.** The README links the correct model/SKU and explains full versus OTA images, USB flashing and the separate compact-board route.

Checks: README links and artifact names verified against the build scripts; production code is unchanged by this documentation follow-up. Physical acceptance remains open.


![Minimal status view using the PR5 QEMU adapter](https://github.com/user-attachments/assets/bd5e0f0d-6d90-4857-9401-096bd55ff30f)
