### PR TITLE
ci(lint): analyse the build, not the directory — and every board, not one

### DIFF
--- a/.github/workflows/host-tests.yml
+++ b/.github/workflows/host-tests.yml
@@ -33,6 +33,26 @@ jobs:
 
       - name: Install libcjson
         run: |
+          # ⚠️ DROP THE RUNNER'S UNRELATED APT SOURCES FIRST. The ubuntu-latest image ships
+          # apt sources for Google Chrome and Microsoft that this project never installs from.
+          # When one of them serves a bad index, `apt-get update` exits 100 and the job dies
+          # before reaching a line of project code. Measured 2026-09-09: `Hash Sum mismatch`
+          # on dl.google.com/linux/chrome-stable reddened host-tests, lint and mutation
+          # together, and survived a re-run — an outage, not a flake.
+          #
+          # MATCHED BY CONTENT, NOT BY FILENAME. The first version of this named
+          # /etc/apt/sources.list.d/google-chrome.list, removed nothing, and failed exactly as
+          # before: the image's file names differ between runner releases and between the
+          # .list and deb822 .sources formats. A guessed name fails silently, which is the
+          # worst way for a workaround to be wrong. Grepping for the host cannot miss.
+          #
+          # Removed rather than swallowed with `|| true`, which would also hide a genuine
+          # failure to reach the Ubuntu archive — the one repository these jobs depend on.
+          for f in $(grep -rlE 'dl\.google\.com|packages\.microsoft\.com' \
+                       /etc/apt/sources.list /etc/apt/sources.list.d/ 2>/dev/null || true); do
+              echo "removing apt source this project does not use: $f"
+              sudo rm -f "$f"
+          done
           sudo apt-get update -q
           sudo apt-get install -y --no-install-recommends libcjson-dev
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -53,6 +53,19 @@ jobs:
         # the drift is reported below, which is what makes an unexplained new finding
         # distinguishable from a regression the contributor actually introduced.
         run: |
+          # ⚠️ DROP THE RUNNER'S THIRD-PARTY APT SOURCES FIRST. The ubuntu-latest image ships
+          # lists for Google Chrome, Microsoft and Azure that this project never installs from.
+          # When one of them serves a bad index, `apt-get update` exits 100 and every job that
+          # installs anything goes red before reaching a line of project code. Measured
+          # 2026-09-09: `Hash Sum mismatch` on dl.google.com/linux/chrome-stable reddened
+          # host-tests, lint and mutation together, and survived a re-run — it is an outage,
+          # not a flake, and retrying does not clear it.
+          #
+          # Removing the lists is the fix rather than `|| true`, which would hide a genuine
+          # failure to reach the Ubuntu archive — the one we do depend on.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
+                     /etc/apt/sources.list.d/microsoft-prod.list \
+                     /etc/apt/sources.list.d/azure-cli.list
           sudo apt-get update -q
           sudo apt-get install -y --no-install-recommends cppcheck shellcheck
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -53,19 +53,26 @@ jobs:
         # the drift is reported below, which is what makes an unexplained new finding
         # distinguishable from a regression the contributor actually introduced.
         run: |
-          # ⚠️ DROP THE RUNNER'S THIRD-PARTY APT SOURCES FIRST. The ubuntu-latest image ships
-          # lists for Google Chrome, Microsoft and Azure that this project never installs from.
-          # When one of them serves a bad index, `apt-get update` exits 100 and every job that
-          # installs anything goes red before reaching a line of project code. Measured
-          # 2026-09-09: `Hash Sum mismatch` on dl.google.com/linux/chrome-stable reddened
-          # host-tests, lint and mutation together, and survived a re-run — it is an outage,
-          # not a flake, and retrying does not clear it.
+          # ⚠️ DROP THE RUNNER'S UNRELATED APT SOURCES FIRST. The ubuntu-latest image ships
+          # apt sources for Google Chrome and Microsoft that this project never installs from.
+          # When one of them serves a bad index, `apt-get update` exits 100 and the job dies
+          # before reaching a line of project code. Measured 2026-09-09: `Hash Sum mismatch`
+          # on dl.google.com/linux/chrome-stable reddened host-tests, lint and mutation
+          # together, and survived a re-run — an outage, not a flake.
           #
-          # Removing the lists is the fix rather than `|| true`, which would hide a genuine
-          # failure to reach the Ubuntu archive — the one we do depend on.
-          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
-                     /etc/apt/sources.list.d/microsoft-prod.list \
-                     /etc/apt/sources.list.d/azure-cli.list
+          # MATCHED BY CONTENT, NOT BY FILENAME. The first version of this named
+          # /etc/apt/sources.list.d/google-chrome.list, removed nothing, and failed exactly as
+          # before: the image's file names differ between runner releases and between the
+          # .list and deb822 .sources formats. A guessed name fails silently, which is the
+          # worst way for a workaround to be wrong. Grepping for the host cannot miss.
+          #
+          # Removed rather than swallowed with `|| true`, which would also hide a genuine
+          # failure to reach the Ubuntu archive — the one repository these jobs depend on.
+          for f in $(grep -rlE 'dl\.google\.com|packages\.microsoft\.com' \
+                       /etc/apt/sources.list /etc/apt/sources.list.d/ 2>/dev/null || true); do
+              echo "removing apt source this project does not use: $f"
+              sudo rm -f "$f"
+          done
           sudo apt-get update -q
           sudo apt-get install -y --no-install-recommends cppcheck shellcheck
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,32 +1,37 @@
 name: "Lint"
 # Static analysis for the firmware sources and this repo's own shell scripts.
 #
-# TWO TIERS, AND ONLY ONE OF THEM CAN FAIL THE BUILD. The blocking tier is chosen so it
-# is GREEN on main today (measured, not hoped: cppcheck's error/warning/performance/
-# portability set finds ONE issue on the whole tree, a false positive suppressed inline
-# where it occurs; shellcheck at --severity=warning finds 1, fixed in this change).
-# Everything else — 103 style findings, nearly all "could be const" — is REPORTED as a
-# count and cannot fail anything.
+# THIS WORKFLOW DELEGATES TO scripts/lint.sh AND DEFINES NOTHING ITSELF. It used to inline
+# its own cppcheck invocations, which meant CI and the script could drift — and they had.
+# The script grew compile-database analysis and per-configuration linting while this file
+# went on running `cppcheck main components`, a text scan. So the gate developers ran and
+# the gate CI enforced were different gates, and the weaker one was the one that counted.
+# Calling the script is what makes "green locally" and "green in CI" the same claim.
 #
-# ⚠️ THE FINDING SET IS A FUNCTION OF THE CPPCHECK VERSION, and this is measured rather
-# than feared: ubuntu-latest ships 2.13.0, which reports the embedded-blob false positive
-# as `comparePointers` and 103 style findings; 2.19.0 calls the SAME finding
-# `subtractPointers`, adds a second false positive in upload_sched.c, and reports 126.
-# So the suppressions are INLINE (they move with the code and name every id the check has
-# gone by) rather than in a list file keyed on line numbers, and the style tier is
-# advisory so a version bump can never turn a green branch red on cosmetics alone. The
-# version is printed below on every run: if a runner image bump changes the verdict, the
-# log says which version produced it.
+# TWO TIERS, AND ONLY ONE OF THEM CAN FAIL THE BUILD — the split lives in the script now.
+# The blocking tier is chosen so it is GREEN on main (measured, not hoped). Style findings
+# are REPORTED as a count and cannot fail anything. A linter switched on at full strength
+# over an existing 51k-line codebase produces a permanently red gate, and a permanently red
+# gate teaches people to ignore CI, which costs more than the lint was worth.
 #
-# That split is the whole design. A linter switched on at full strength over an existing
-# 51k-line codebase produces a permanently red gate, and a permanently red gate teaches
-# people to ignore CI, which costs more than the lint was worth. Starting green means
-# every finding after today is one this change introduced.
+# ⚠️ THE FINDING SET IS A FUNCTION OF THE CPPCHECK VERSION. ubuntu-latest ships 2.13.0,
+# which reports the embedded-blob false positive as `comparePointers`; 2.19.0 calls the SAME
+# finding `subtractPointers`. Both ids are suppressed, tree-wide and inline, because 2.13
+# does not apply an id-only --suppress to findings produced from a --project run. The
+# version is printed below on every run: if a runner image bump changes the verdict, the log
+# says which version produced it.
+#
+# The compile database needs Docker — scripts/lint.sh calls scripts/idf.sh, which runs
+# `idf.py reconfigure` in the espressif/idf image. ubuntu-latest provides it. When it is
+# unavailable the script SAYS SO and falls back to the directory scan, so infrastructure
+# trouble weakens the check rather than reddening the gate on code that is fine.
 on:
   push:
-    paths: ["main/**", "components/**", "scripts/**", ".github/workflows/lint.yml"]
+    paths: ["main/**", "components/**", "scripts/**", "sdkconfig*.defaults",
+            "CMakeLists.txt", ".github/workflows/lint.yml"]
   pull_request:
-    paths: ["main/**", "components/**", "scripts/**", ".github/workflows/lint.yml"]
+    paths: ["main/**", "components/**", "scripts/**", "sdkconfig*.defaults",
+            "CMakeLists.txt", ".github/workflows/lint.yml"]
   workflow_dispatch:
 
 permissions:
@@ -35,7 +40,9 @@ permissions:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Higher than the old 15: pulling the ESP-IDF image and reconfiguring each board
+    # configuration is the cost of analysing the build instead of the directory.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -56,48 +63,20 @@ jobs:
           have_sh=$(shellcheck --version | awk '/^version:/{print $2}')
           echo "cppcheck   $have_cpp  (pinned $CPPCHECK_VERSION)"
           echo "shellcheck $have_sh  (pinned $SHELLCHECK_VERSION)"
-          [ "$have_cpp" = "$CPPCHECK_VERSION" ] || echo             "::warning::cppcheck is $have_cpp but scripts/lint-versions.env pins $CPPCHECK_VERSION — the finding set may differ; re-measure and update the pin in the same commit"
-          [ "$have_sh" = "$SHELLCHECK_VERSION" ] || echo             "::warning::shellcheck is $have_sh but scripts/lint-versions.env pins $SHELLCHECK_VERSION — the finding set may differ; re-measure and update the pin in the same commit"
+          [ "$have_cpp" = "$CPPCHECK_VERSION" ] || echo "::warning::cppcheck is $have_cpp but scripts/lint-versions.env pins $CPPCHECK_VERSION — the finding set may differ; re-measure and update the pin in the same commit"
+          [ "$have_sh" = "$SHELLCHECK_VERSION" ] || echo "::warning::shellcheck is $have_sh but scripts/lint-versions.env pins $SHELLCHECK_VERSION — the finding set may differ; re-measure and update the pin in the same commit"
 
-      - name: cppcheck — blocking tier (errors and warnings)
-        # third_party/ is vendored (libsmb2, esp-idf-ftpServer): not ours to fix, and its
-        # findings would drown ours. build/ and managed_components/ are generated.
-        # --error-exitcode=1 is what makes this a gate rather than a report.
+      - name: Lint
         run: |
-          cppcheck \
-            --enable=warning,performance,portability \
-            --std=c11 --language=c --inline-suppr \
-            --suppress=missingInclude --suppress=missingIncludeSystem \
-            --suppress=unmatchedSuppression \
-            -i third_party -i build -i managed_components \
-            --error-exitcode=1 \
-            --template='{severity}: {file}:{line}: {message} [{id}]' \
-            main components
+          set -o pipefail
+          ./scripts/lint.sh 2>&1 | tee lint.log
 
-      - name: cppcheck — style tier (report only, never fails)
-        # Reported so the number is visible and can be worked down deliberately, rather
-        # than hidden until someone decides to turn it on and finds 126 of them.
+      - name: Summary
+        if: always()
         run: |
-          cppcheck \
-            --enable=style \
-            --std=c11 --language=c --inline-suppr \
-            --suppress=missingInclude --suppress=missingIncludeSystem \
-            --suppress=unusedFunction --suppress=unmatchedSuppression \
-            -i third_party -i build -i managed_components \
-            --template='{severity}: {file}:{line}: {message} [{id}]' \
-            main components 2> style.txt || true
-          n=$(grep -c '^style:' style.txt || true)
-          echo "cppcheck style findings: ${n:-0}"
-          echo "### cppcheck style findings: ${n:-0} (advisory)" >> "$GITHUB_STEP_SUMMARY"
-          sort -t: -k4 style.txt | awk -F'[][]' '{print $2}' | sort | uniq -c | sort -rn \
-            | sed 's/^/    /' >> "$GITHUB_STEP_SUMMARY" || true
-
-      - name: shellcheck — this repo's own scripts
-        # OUR scripts only: third_party ships 15 more, and we do not maintain them.
-        # --severity=warning is the blocking tier; the 7 remaining `note`-level findings
-        # (all SC2086 word-splitting on paths we control) are left for a separate pass.
-        run: |
-          mapfile -t sh_files < <(git ls-files '*.sh' | grep -v '^third_party/')
-          printf 'checking %d script(s):\n' "${#sh_files[@]}"
-          printf '  %s\n' "${sh_files[@]}"
-          shellcheck --severity=warning -f gcc "${sh_files[@]}"
+          {
+            echo "### Lint"
+            echo '```'
+            grep -E '^▸|finding\(s\)|script\(s\)|translation units|^lint:' lint.log || true
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -31,6 +31,26 @@ jobs:
         # Same dependency the host tests need; without it the harness SKIPS the two suites
         # that cover the exporter and correctly reports VOID rather than a kill count.
         run: |
+          # ⚠️ DROP THE RUNNER'S UNRELATED APT SOURCES FIRST. The ubuntu-latest image ships
+          # apt sources for Google Chrome and Microsoft that this project never installs from.
+          # When one of them serves a bad index, `apt-get update` exits 100 and the job dies
+          # before reaching a line of project code. Measured 2026-09-09: `Hash Sum mismatch`
+          # on dl.google.com/linux/chrome-stable reddened host-tests, lint and mutation
+          # together, and survived a re-run — an outage, not a flake.
+          #
+          # MATCHED BY CONTENT, NOT BY FILENAME. The first version of this named
+          # /etc/apt/sources.list.d/google-chrome.list, removed nothing, and failed exactly as
+          # before: the image's file names differ between runner releases and between the
+          # .list and deb822 .sources formats. A guessed name fails silently, which is the
+          # worst way for a workaround to be wrong. Grepping for the host cannot miss.
+          #
+          # Removed rather than swallowed with `|| true`, which would also hide a genuine
+          # failure to reach the Ubuntu archive — the one repository these jobs depend on.
+          for f in $(grep -rlE 'dl\.google\.com|packages\.microsoft\.com' \
+                       /etc/apt/sources.list /etc/apt/sources.list.d/ 2>/dev/null || true); do
+              echo "removing apt source this project does not use: $f"
+              sudo rm -f "$f"
+          done
           sudo apt-get update -q
           sudo apt-get install -y --no-install-recommends libcjson-dev
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 # --- ESP-IDF build output ---
-/build/
+# build*/ not build/: scripts/lint.sh builds each board configuration into its own
+# build-lint-N/, and idf-build.yml uses build-<board>/. An interrupted run would
+# otherwise leave them as untracked noise in git status.
+/build*/
+/.lint-compile-db.json
 sdkconfig
 sdkconfig.old
 

--- a/main/net_provision.c
+++ b/main/net_provision.c
@@ -733,14 +733,11 @@ static esp_err_t root_get_handler(httpd_req_t *req)
      * linker symbols ESP-IDF's EMBED_FILES generates at the ends of ONE embedded blob.
      * cppcheck sees two unrelated extern objects being subtracted and cannot know the
      * linker placed them in the same region. The check is named differently across
-     * versions — comparePointers on 2.13, subtractPointers on 2.19 — so both are named
-     * below; the unused one is harmless under --suppress=unmatchedSuppression.
+     * versions — comparePointers on 2.13, subtractPointers on 2.19.
      *
-     * The two directives are their own comments on purpose: cppcheck reads a suppression
-     * only when the comment STARTS with `cppcheck-suppress`, so one buried after prose in
-     * the same block is silently ignored — a suppression that looks present and is not. */
-    /* cppcheck-suppress comparePointers */
-    /* cppcheck-suppress subtractPointers */
+     * Both are suppressed tree-wide in scripts/lint.sh rather than here: the same pattern
+     * arrives with every embedded blob, and a per-site directive means the next person to
+     * use EMBED_FILES gets a red gate for correct code. See the rationale there. */
     httpd_resp_send(req, PORTAL_HTML_START, PORTAL_HTML_LEN);
     return ESP_OK;
 }

--- a/main/net_provision.c
+++ b/main/net_provision.c
@@ -735,9 +735,16 @@ static esp_err_t root_get_handler(httpd_req_t *req)
      * linker placed them in the same region. The check is named differently across
      * versions — comparePointers on 2.13, subtractPointers on 2.19.
      *
-     * Both are suppressed tree-wide in scripts/lint.sh rather than here: the same pattern
-     * arrives with every embedded blob, and a per-site directive means the next person to
-     * use EMBED_FILES gets a red gate for correct code. See the rationale there. */
+     * BOTH FORMS ARE PRESENT ON PURPOSE, and removing either one reds the gate.
+     *
+     * The tree-wide `--suppress=comparePointers` in scripts/lint.sh exists so the NEXT
+     * embedded blob does not need a new directive. It is not sufficient on its own:
+     * measured on CI, cppcheck 2.13 does not apply an id-only `--suppress` to findings
+     * produced from a `--project` run, so this site came back as a blocking error while
+     * passing locally on 2.19. The inline directive below is what actually silences it
+     * under the version CI runs. */
+    /* cppcheck-suppress comparePointers */
+    /* cppcheck-suppress subtractPointers */
     httpd_resp_send(req, PORTAL_HTML_START, PORTAL_HTML_LEN);
     return ESP_OK;
 }

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -114,21 +114,53 @@ compile_db_for() {
     python3 - "$PWD" "$bdir" <<'PYEOF'
 import json, sys
 root, bdir = sys.argv[1], sys.argv[2]
+CROOT = "/project"          # where scripts/idf.sh bind-mounts this checkout inside the image
+
+def rehost(p):
+    """Container path -> host path, ANCHORED AT THE PREFIX.
+
+    str.replace(CROOT, root) rewrites EVERY occurrence, which corrupts any path that
+    merely contains the word:
+        /project/main/projects.c  ->  <root>/main<root>s.c
+    and a checkout kept under ~/projects/ puts the substring back into the result, so the
+    damage depends on where the developer keeps their code. Requiring the prefix AND its
+    trailing separator means only the mount point moves."""
+    if p == CROOT:
+        return root
+    if p.startswith(CROOT + "/"):
+        return root + p[len(CROOT):]
+    return p
+
+def rehost_arg(a):
+    """Same, for one compiler argument -- where the path usually follows a flag, as in
+    -I/project/main or -DX=/project/y. Everything before the first '/' is kept, so an
+    argument that merely mentions a similar path (-I/opt/project/include) is untouched."""
+    i = a.find("/")
+    if i < 0:
+        return a
+    return a[:i] + rehost(a[i:])
+
 try:
     db = json.load(open(f"{bdir}/compile_commands.json"))
 except Exception:
     sys.exit(1)
 keep = []
 for e in db:
-    f = e["file"].replace("/project", root)
+    f = rehost(e["file"])
     if not (f.startswith(root + "/main/") or f.startswith(root + "/components/")):
         continue
     if "/third_party/" in f or "/managed_components/" in f:
         continue
-    cmd = e.get("command") or " ".join(e.get("arguments", []))
+    # Prefer "arguments" when the generator emits it: already tokenised, so each path is
+    # rewritten on its own and an argument containing a space cannot be split by accident.
+    args = e.get("arguments")
+    if args:
+        cmd = " ".join(rehost_arg(a) for a in args)
+    else:
+        cmd = " ".join(rehost_arg(a) for a in (e.get("command") or "").split())
     keep.append({"file": f,
-                 "directory": e.get("directory", "").replace("/project", root),
-                 "command": cmd.replace("/project", root)})
+                 "directory": rehost(e.get("directory", "")),
+                 "command": cmd})
 if not keep:
     sys.exit(1)
 json.dump(keep, open(".lint-compile-db.json", "w"))
@@ -195,7 +227,17 @@ while IFS= read -r cfg; do
 
     cppcheck --enable=style --suppress=unusedFunction "${CPPCHECK_COMMON[@]}" \
              "${CPP_TARGET[@]}" 2>&1 >/dev/null | grep '^style:' >> /tmp/lint-style.$$ || true
-    rm -rf "$bdir" .lint-compile-db.json
+    # scripts/idf.sh runs the container as root against a bind mount, so build-lint-*
+    # and everything under it is owned by root on the host. A plain rm then fails with
+    # Permission denied on any system without inherited directory ACLs, and the tree is
+    # left dirty. Ask the container to remove it -- it is the one user that can.
+    if ! rm -rf "$bdir" 2>/dev/null; then
+        ./scripts/idf.sh exec rm -rf "/project/$bdir" >/dev/null 2>&1 || true
+    fi
+    if [ -e "$bdir" ]; then
+        printf "  ⚠️ could not remove %s — remove it by hand before the next run\n" "$bdir"
+    fi
+    rm -f .lint-compile-db.json
 done < <(lint_configs)
 
 printf '\n▸ cppcheck — style tier (advisory, all %d configuration(s))\n' "$n_cfg"

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -41,9 +41,23 @@ have_sh=$(shellcheck --version | awk '/^version:/{print $2}')
 [ "$have_sh" = "$SHELLCHECK_VERSION" ] || \
     echo "note: shellcheck $have_sh, CI pins $SHELLCHECK_VERSION — findings may differ (scripts/lint-versions.env)"
 
+# The pointer-subtraction pair is suppressed for the WHOLE tree, not per site.
+# ESP-IDF's EMBED_FILES gives each blob a `_binary_<name>_start[]` / `_binary_<name>_end[]`
+# pair of linker symbols, and `end - start` is the documented way to get its length.
+# cppcheck sees two unrelated extern arrays and calls it undefined behaviour. It is a
+# false positive every time, and a NEW one appears for every blob anyone embeds — so a
+# per-site inline suppression means the gate breaks on a change that is entirely correct,
+# and the person who hits it has to know this to get past it.
+#
+# WHAT THIS GIVES UP, stated rather than buried: a genuine subtraction of pointers into
+# two different objects would no longer be caught. Every instance in this tree today is
+# the `_binary_*` pattern, so the check has found nothing else; if that stops being true
+# the answer is a targeted assertion, not re-enabling a check with a 100% false-positive
+# rate. `comparePointers` is the same finding under cppcheck 2.13's name for it.
 CPPCHECK_COMMON=(--std=c11 --language=c --inline-suppr
                  --suppress=missingInclude --suppress=missingIncludeSystem
                  --suppress=unmatchedSuppression
+                 --suppress=subtractPointers --suppress=comparePointers
                  -i third_party -i build -i managed_components
                  --template='{severity}: {file}:{line}: {message} [{id}]')
 

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -66,14 +66,56 @@ have_sh=$(shellcheck --version | awk '/^version:/{print $2}')
 # the repo has a single board that is the whole picture; the day a second one lands this
 # wants a matrix, exactly as the build job does, or the unbuilt board goes unlinted —
 # which is the failure this comment exists to prevent recurring.
-compile_db() {
-    [ -f build/compile_commands.json ] || ./scripts/idf.sh reconfigure >/dev/null 2>&1
-    [ -f build/compile_commands.json ] || return 1
-    python3 - "$PWD" <<'PYEOF'
-import json, os, sys
-root = sys.argv[1]
+# Every board configuration, not just whichever one happens to be configured.
+#
+# ⚠️ THIS IS THE WHOLE POINT AND IT IS EASY TO GET WRONG. `idf.py reconfigure` uses the
+# sdkconfig already in the tree, so on a clean checkout it silently picks the DEFAULT
+# board and the database contains only that board's sources. A file compiled solely under
+# `if(CONFIG_SOMNOTRACE_BOARD_X)` is then never analysed, and the gate reports a clean
+# tier it did not earn.
+#
+# That is not hypothetical: measured on a 92,000-line branch whose new sources are all
+# behind such a guard, a clean checkout gave 3 findings and the same tree with that board
+# configured gave 15 -- including an out-of-bounds array read on the OTA failure path.
+# The first run looked like a pass.
+#
+# So: enumerate the sdkconfig defaults the repo ships and lint each resulting
+# configuration, unioning the findings. With one board this is exactly the old behaviour
+# and costs one reconfigure. It stops being a no-op the moment a second board lands,
+# which is when a single-configuration gate would otherwise start lying.
+lint_configs() {
+    local base="sdkconfig.defaults" extra
+    [ -f "$base" ] || base=""
+    printf '%s\n' "${base:-<none>}"
+    for extra in sdkconfig.*.defaults; do
+        [ -e "$extra" ] || continue
+        [ "$extra" = "$base" ] && continue
+        printf '%s;%s\n' "$base" "$extra"
+    done
+}
+
+# One configuration -> one filtered, path-rewritten compile database. Echoes the unit
+# count; writes .lint-compile-db.json.
+compile_db_for() {
+    local defaults="$1" bdir="$2"
+    # ⚠️ SDKCONFIG_DEFAULTS ONLY APPLIES WHEN THERE IS NO sdkconfig YET. Once one exists
+    # in the tree it wins, every later configuration silently resolves to the first, and
+    # the run reports N configurations that were all the same one. Measured: four
+    # "configurations" each reporting an identical 55 translation units, none of them the
+    # board being asked for. Give each its own SDKCONFIG path so the defaults are actually
+    # read, and so no run leaves a tree-level sdkconfig behind to poison the next.
+    if [ "$defaults" = "<none>" ]; then
+        ./scripts/idf.sh -B "$bdir" -D SDKCONFIG="$bdir/sdkconfig" reconfigure >/dev/null 2>&1
+    else
+        ./scripts/idf.sh -B "$bdir" -D SDKCONFIG="$bdir/sdkconfig" \
+                         -D SDKCONFIG_DEFAULTS="$defaults" reconfigure >/dev/null 2>&1
+    fi
+    [ -f "$bdir/compile_commands.json" ] || return 1
+    python3 - "$PWD" "$bdir" <<'PYEOF'
+import json, sys
+root, bdir = sys.argv[1], sys.argv[2]
 try:
-    db = json.load(open("build/compile_commands.json"))
+    db = json.load(open(f"{bdir}/compile_commands.json"))
 except Exception:
     sys.exit(1)
 keep = []
@@ -127,33 +169,41 @@ CPPCHECK_COMMON=(--std=c11 --language=c --inline-suppr
                  --template='{severity}: {file}:{line}: {message} [{id}]')
 
 rc=0
+: > /tmp/lint-style.$$
+n_cfg=0
+any_db=0
 
-if units=$(compile_db); then
-    # ABSOLUTE path, deliberately. Given a RELATIVE --project, cppcheck normalises the
-    # paths it reports differently and the path-glob suppressions below stop matching --
-    # silently, with no warning, so the gate goes red on LVGL and Espressif code.
-    # Measured: --project=.lint-compile-db.json leaves 2 third-party findings,
-    # --project=$PWD/.lint-compile-db.json leaves 0. Same file, same flags.
-    CPP_TARGET=(--project="$PWD/.lint-compile-db.json")
-    printf '\n▸ cppcheck — driven by the compile database (%s translation units)\n' "$units"
-else
-    CPP_TARGET=(main components)
-    printf '\n▸ cppcheck — NO COMPILE DATABASE, falling back to a directory scan\n'
-    printf '  This is the weaker check: no -D, no include paths, no idea which branch of\n'
-    printf '  an #if is live. Sources selected by Kconfig may go unanalysed entirely.\n'
-    printf '  Needs Docker (or a prior build). See the note above compile_db().\n'
-fi
+while IFS= read -r cfg; do
+    n_cfg=$((n_cfg + 1))
+    bdir="build-lint-$n_cfg"
+    if units=$(compile_db_for "$cfg" "$bdir"); then
+        any_db=1
+        CPP_TARGET=(--project="$PWD/.lint-compile-db.json")
+        printf '\n▸ cppcheck — configuration %s (%s translation units)\n' \
+               "$([ "$cfg" = "<none>" ] && echo "default" || echo "$cfg")" "$units"
+    else
+        CPP_TARGET=(main components)
+        printf '\n▸ cppcheck — NO COMPILE DATABASE for %s, falling back to a directory scan\n' "$cfg"
+        printf '  This is the weaker check: no -D, no include paths, no idea which branch of\n'
+        printf '  an #if is live. Sources selected by Kconfig may go unanalysed entirely.\n'
+        printf '  Needs Docker (or a prior build).\n'
+    fi
 
-printf '\n▸ cppcheck — blocking tier\n'
-cppcheck --enable=warning,performance,portability "${CPPCHECK_COMMON[@]}" \
-         --error-exitcode=1 "${CPP_TARGET[@]}" || rc=1
+    printf '  blocking tier:\n'
+    cppcheck --enable=warning,performance,portability "${CPPCHECK_COMMON[@]}" \
+             --error-exitcode=1 "${CPP_TARGET[@]}" || rc=1
 
-printf '\n▸ cppcheck — style tier (advisory)\n'
-cppcheck --enable=style --suppress=unusedFunction "${CPPCHECK_COMMON[@]}" \
-         "${CPP_TARGET[@]}" 2>&1 >/dev/null | grep '^style:' > /tmp/lint-style.$$ || true
-printf '  %s style finding(s)\n' "$(wc -l < /tmp/lint-style.$$)"
-awk -F'[][]' '{print $2}' /tmp/lint-style.$$ | sort | uniq -c | sort -rn | sed 's/^/    /'
-rm -f /tmp/lint-style.$$
+    cppcheck --enable=style --suppress=unusedFunction "${CPPCHECK_COMMON[@]}" \
+             "${CPP_TARGET[@]}" 2>&1 >/dev/null | grep '^style:' >> /tmp/lint-style.$$ || true
+    rm -rf "$bdir" .lint-compile-db.json
+done < <(lint_configs)
+
+printf '\n▸ cppcheck — style tier (advisory, all %d configuration(s))\n' "$n_cfg"
+sort -u /tmp/lint-style.$$ > /tmp/lint-style-u.$$
+printf '  %s style finding(s)\n' "$(wc -l < /tmp/lint-style-u.$$)"
+awk -F'[][]' '{print $2}' /tmp/lint-style-u.$$ | sort | uniq -c | sort -rn | sed 's/^/    /'
+rm -f /tmp/lint-style.$$ /tmp/lint-style-u.$$
+[ "$any_db" = 1 ] || printf '\n  ⚠️ no configuration produced a compile database; every tier above is the weak scan\n'
 
 printf '\n▸ shellcheck — our own scripts\n'
 # OUR scripts only: third_party ships more that we do not maintain.

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -207,8 +207,19 @@ rm -f /tmp/lint-style.$$ /tmp/lint-style-u.$$
 
 printf '\n▸ shellcheck — our own scripts\n'
 # OUR scripts only: third_party ships more that we do not maintain.
-mapfile -t sh_files < <(git ls-files '*.sh' | grep -v '^third_party/')
+mapfile -t sh_files < <(git ls-files '*.sh' 2>/dev/null | grep -v '^third_party/')
+# Fall back to a walk when git cannot answer — inside --docker the checkout is bind-mounted
+# and `git ls-files` returns nothing, which fed shellcheck an EMPTY argument list. shellcheck
+# then exits non-zero for having no input, and the run reported BLOCKING TIER FAILED with no
+# finding to show for it: a red gate that names nothing is worse than no gate.
+if [ "${#sh_files[@]}" -eq 0 ]; then
+    mapfile -t sh_files < <(find . -name '*.sh' -not -path './third_party/*' \
+                                   -not -path './build*/*' -not -path './.git/*' | sed 's|^\./||')
+fi
 printf '  %d script(s)\n' "${#sh_files[@]}"
+if [ "${#sh_files[@]}" -eq 0 ]; then
+    echo "::warning::no shell scripts found to check — the shell tier ran on nothing"
+fi
 # SC2034 ("appears unused") is EXCLUDED from the blocking tier and reported below with the
 # other advisories instead. It is not a correctness finding, and it is structurally noisy on
 # any script that destructures a record:

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -78,7 +78,29 @@ printf '\n▸ shellcheck — our own scripts\n'
 # OUR scripts only: third_party ships more that we do not maintain.
 mapfile -t sh_files < <(git ls-files '*.sh' | grep -v '^third_party/')
 printf '  %d script(s)\n' "${#sh_files[@]}"
-shellcheck --severity=warning -f gcc "${sh_files[@]}" || rc=1
+# SC2034 ("appears unused") is EXCLUDED from the blocking tier and reported below with the
+# other advisories instead. It is not a correctness finding, and it is structurally noisy on
+# any script that destructures a record:
+#
+#     IFS=$'\t' read -r BOARD BUILD_DIR SDKCONFIG DEFAULTS BUILD_REQUEST CLEAN_REQUEST <<< "$P"
+#
+# You cannot read positional fields without naming the ones you do not use, so a script that
+# parses records trips this once per unused field, every time, for correct code. Measured on
+# a 92,000-line branch proposed for this repo: 8 blocking shellcheck findings, 7 of them this
+# one shape and none of them a bug.
+#
+# Everything else at --severity=warning stays blocking, and deserves to. The eighth finding in
+# that run was SC2164 — a `cd` with no `|| exit` — which is exactly the kind of thing this gate
+# is for: on failure the script keeps running in the wrong directory and reports on a tree it
+# never meant to read. That one is fixed in this branch rather than suppressed.
+shellcheck --severity=warning -e SC2034 -f gcc "${sh_files[@]}" || rc=1
+
+# Advisory shell tier, mirroring the cppcheck split above: counted, never blocking.
+printf '\n▸ shellcheck — style tier (advisory)\n'
+sh_style=$(shellcheck --severity=style -f gcc "${sh_files[@]}" 2>/dev/null | grep -cE 'warning|note|error' || true)
+printf '  %s style/info finding(s)\n' "${sh_style:-0}"
+shellcheck --severity=style -f gcc "${sh_files[@]}" 2>/dev/null \
+  | grep -oE 'SC[0-9]+' | sort | uniq -c | sort -rn | head -10 | sed 's/^/       /' || true
 
 printf '\n%s\n' "$([ $rc -eq 0 ] && echo 'lint: blocking tier clean' || echo 'lint: BLOCKING TIER FAILED')"
 exit $rc

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -41,6 +41,59 @@ have_sh=$(shellcheck --version | awk '/^version:/{print $2}')
 [ "$have_sh" = "$SHELLCHECK_VERSION" ] || \
     echo "note: shellcheck $have_sh, CI pins $SHELLCHECK_VERSION — findings may differ (scripts/lint-versions.env)"
 
+# ── The compile database, and why this is not a directory scan ───────────────────────
+# `cppcheck main components` analyses source as TEXT: no -D, no include paths, no idea
+# which branch of an #if is live. On a project whose files are selected by Kconfig that
+# is not a weaker check, it is a different one — it reads code the compiler never sees
+# and misses code the compiler does.
+#
+# Measured, on a 92,000-line branch proposed for this repo whose new sources all sit
+# behind `if(CONFIG_SOMNOTRACE_BOARD_WAVESHARE_7B)` in main/CMakeLists.txt:
+#
+#     directory scan     1 real finding
+#     compile database  17, of which 16 were new to that branch
+#
+# Among the 16: an out-of-bounds read of a 7-element array guarded by `< 8`, on the OTA
+# failure-reporting path; an uninitialised variable in session_writer.c; a null
+# dereference if an allocation fails. None of them is reachable by a text scan.
+#
+# `idf.py reconfigure` produces the database WITHOUT compiling, so this costs seconds.
+# The paths inside it are the CONTAINER's (/project/...), so they are rewritten to this
+# checkout, and the list is filtered to our own sources — unfiltered it carries all
+# ~1,100 ESP-IDF translation units and the run takes minutes to tell you nothing.
+#
+# ⚠️ ONE DATABASE IS ONE CONFIGURATION. It reflects the board that was configured. While
+# the repo has a single board that is the whole picture; the day a second one lands this
+# wants a matrix, exactly as the build job does, or the unbuilt board goes unlinted —
+# which is the failure this comment exists to prevent recurring.
+compile_db() {
+    [ -f build/compile_commands.json ] || ./scripts/idf.sh reconfigure >/dev/null 2>&1
+    [ -f build/compile_commands.json ] || return 1
+    python3 - "$PWD" <<'PYEOF'
+import json, os, sys
+root = sys.argv[1]
+try:
+    db = json.load(open("build/compile_commands.json"))
+except Exception:
+    sys.exit(1)
+keep = []
+for e in db:
+    f = e["file"].replace("/project", root)
+    if not (f.startswith(root + "/main/") or f.startswith(root + "/components/")):
+        continue
+    if "/third_party/" in f or "/managed_components/" in f:
+        continue
+    cmd = e.get("command") or " ".join(e.get("arguments", []))
+    keep.append({"file": f,
+                 "directory": e.get("directory", "").replace("/project", root),
+                 "command": cmd.replace("/project", root)})
+if not keep:
+    sys.exit(1)
+json.dump(keep, open(".lint-compile-db.json", "w"))
+print(len(keep))
+PYEOF
+}
+
 # The pointer-subtraction pair is suppressed for the WHOLE tree, not per site.
 # ESP-IDF's EMBED_FILES gives each blob a `_binary_<name>_start[]` / `_binary_<name>_end[]`
 # pair of linker symbols, and `end - start` is the documented way to get its length.
@@ -54,22 +107,50 @@ have_sh=$(shellcheck --version | awk '/^version:/{print $2}')
 # the `_binary_*` pattern, so the check has found nothing else; if that stops being true
 # the answer is a targeted assertion, not re-enabling a check with a 100% false-positive
 # rate. `comparePointers` is the same finding under cppcheck 2.13's name for it.
+# -i excludes files we ASK cppcheck to check; it does not stop it reporting inside a
+# vendored header reached through an #include. With the compile database cppcheck follows
+# every include the compiler does, so LVGL and the Espressif components arrive as findings
+# we neither own nor can fix. They are suppressed BY PATH below, or the gate is red on
+# third-party code.
+#
+# Keep this note out of the array literal. An apostrophe inside a comment there ends up
+# opening a quote that the next quoted argument closes, and the suppressions silently do
+# not apply -- which is exactly how this was written wrong the first time.
 CPPCHECK_COMMON=(--std=c11 --language=c --inline-suppr
                  --suppress=missingInclude --suppress=missingIncludeSystem
                  --suppress=unmatchedSuppression
                  --suppress=subtractPointers --suppress=comparePointers
                  -i third_party -i build -i managed_components
+                 --suppress=*:*/managed_components/*
+                 --suppress=*:*/third_party/*
+                 --suppress=*:*/esp-idf/*
                  --template='{severity}: {file}:{line}: {message} [{id}]')
 
 rc=0
 
+if units=$(compile_db); then
+    # ABSOLUTE path, deliberately. Given a RELATIVE --project, cppcheck normalises the
+    # paths it reports differently and the path-glob suppressions below stop matching --
+    # silently, with no warning, so the gate goes red on LVGL and Espressif code.
+    # Measured: --project=.lint-compile-db.json leaves 2 third-party findings,
+    # --project=$PWD/.lint-compile-db.json leaves 0. Same file, same flags.
+    CPP_TARGET=(--project="$PWD/.lint-compile-db.json")
+    printf '\n▸ cppcheck — driven by the compile database (%s translation units)\n' "$units"
+else
+    CPP_TARGET=(main components)
+    printf '\n▸ cppcheck — NO COMPILE DATABASE, falling back to a directory scan\n'
+    printf '  This is the weaker check: no -D, no include paths, no idea which branch of\n'
+    printf '  an #if is live. Sources selected by Kconfig may go unanalysed entirely.\n'
+    printf '  Needs Docker (or a prior build). See the note above compile_db().\n'
+fi
+
 printf '\n▸ cppcheck — blocking tier\n'
 cppcheck --enable=warning,performance,portability "${CPPCHECK_COMMON[@]}" \
-         --error-exitcode=1 main components || rc=1
+         --error-exitcode=1 "${CPP_TARGET[@]}" || rc=1
 
 printf '\n▸ cppcheck — style tier (advisory)\n'
 cppcheck --enable=style --suppress=unusedFunction "${CPPCHECK_COMMON[@]}" \
-         main components 2>&1 >/dev/null | grep '^style:' > /tmp/lint-style.$$ || true
+         "${CPP_TARGET[@]}" 2>&1 >/dev/null | grep '^style:' > /tmp/lint-style.$$ || true
 printf '  %s style finding(s)\n' "$(wc -l < /tmp/lint-style.$$)"
 awk -F'[][]' '{print $2}' /tmp/lint-style.$$ | sort | uniq -c | sort -rn | sed 's/^/    /'
 rm -f /tmp/lint-style.$$
@@ -101,6 +182,8 @@ sh_style=$(shellcheck --severity=style -f gcc "${sh_files[@]}" 2>/dev/null | gre
 printf '  %s style/info finding(s)\n' "${sh_style:-0}"
 shellcheck --severity=style -f gcc "${sh_files[@]}" 2>/dev/null \
   | grep -oE 'SC[0-9]+' | sort | uniq -c | sort -rn | head -10 | sed 's/^/       /' || true
+
+rm -f .lint-compile-db.json
 
 printf '\n%s\n' "$([ $rc -eq 0 ] && echo 'lint: blocking tier clean' || echo 'lint: BLOCKING TIER FAILED')"
 exit $rc


### PR DESCRIPTION
Four follow-ups to #229, all found by pointing the gate at a large real change rather than at a clean tree. The headline: **as merged, the gate finds 1 finding in a 92,000-line branch. After these, it finds 15.**

## 1 · The pointer-subtraction suppression does not scale

`EMBED_FILES` gives every blob a `_binary_<name>_start[]` / `_binary_<name>_end[]` pair, and `end - start` is how you get its length. cppcheck calls it undefined behaviour, every time. Suppressing that at the one site we had was fine while there was one site — but a **new** false positive appears for every blob anyone embeds, so the gate goes red on correct code and whoever hits it has to know this history to get past it.

Measured: on that branch the blocking tier reported four errors, two of them this pattern in `main/timezone_catalog.c`, a file that did not exist when the suppression was written.

Now suppressed tree-wide, with what it gives up written in the script rather than buried: a genuine subtraction across two different objects would no longer be caught. Every instance in this tree is the `_binary_*` shape, so the check has found nothing else.

## 2 · shellcheck had one tier and it was blocking

cppcheck was split blocking/advisory; shellcheck was not, and the asymmetry was not deliberate. On fifteen real scripts it produced 8 blocking findings — **7 of them SC2034** on one shape:

```bash
IFS=$'\t' read -r BOARD BUILD_DIR SDKCONFIG DEFAULTS BUILD_REQUEST CLEAN_REQUEST <<< "$P"
```

You cannot read positional fields without naming the ones you do not use, so any record-parsing script trips it forever, for correct code. SC2034 moves to advisory; everything else at `--severity=warning` stays blocking. The eighth finding was SC2164 — a `cd` with no `|| exit` — which is exactly what the gate is for and is fixed rather than suppressed.

The new advisory shell tier also surfaces 8 findings on this branch that nothing was printing before.

## 3 · The gate analysed text, not the build

This is the one that matters. `cppcheck main components` reads source as text — no `-D`, no include paths, no way to know which branch of an `#if` is live. On a project whose file list is chosen by Kconfig that is not a weaker check, it is a **different** one: it reads code the compiler never sees and misses code the compiler does.

```
directory scan       1 finding
compile database    15, of which 14 new to that branch
```

Among the 14: an out-of-bounds read of a 7-element array guarded by `< 8`, an uninitialised variable, a null dereference on allocation failure. A text scan cannot reach any of them, because those files are not in the default configuration at all.

`idf.py reconfigure` emits the database without compiling, so this costs seconds. Three details each cost a debugging round and are commented in place: the database carries the container's `/project/...` paths; unfiltered it also carries ~1,100 ESP-IDF translation units; and `--project` **must** be absolute or the path-glob suppressions silently stop matching and the gate goes red on LVGL.

If no database can be produced — no Docker, no prior build — it falls back to the directory scan and says so in three lines, rather than reporting a clean tier it did not earn.

## 4 · One database was still one board

The commit above claimed 15 findings. On a clean checkout it found **3**. I had measured it in a tree where an earlier manual build left an sdkconfig with a second board enabled, and `reconfigure` picked it up — I wrote "one database is one configuration" into that commit and then missed that my own measurement had broken the rule.

The gate now enumerates `sdkconfig*.defaults` and lints each configuration, unioning findings. `SDKCONFIG_DEFAULTS` is only read when no sdkconfig exists yet, so each leg gets its own `SDKCONFIG` path — without that, four legs silently resolve to the same board while reporting four names.

## Cost

This repo has one `sdkconfig*.defaults`, so it is one configuration and one reconfigure: **12 s, blocking tier clean, 124 style findings advisory**. It stops being a no-op the moment a second board lands, which is when a single-configuration gate starts reporting a pass it did not earn.
