### PR TITLE
ci(idf-build): build every board configuration, discovered rather than listed

### DIFF
--- a/.github/workflows/idf-build.yml
+++ b/.github/workflows/idf-build.yml
@@ -15,7 +15,7 @@ on:
       - "components/**"
       - "third_party/**"
       - "CMakeLists.txt"
-      - "sdkconfig.defaults"
+      - "sdkconfig*.defaults"
       - "partitions.csv"
       - "scripts/idf.sh"
       - "scripts/build-dist.sh"
@@ -27,7 +27,7 @@ on:
       - "components/**"
       - "third_party/**"
       - "CMakeLists.txt"
-      - "sdkconfig.defaults"
+      - "sdkconfig*.defaults"
       - "partitions.csv"
       - "scripts/idf.sh"
       - "scripts/build-dist.sh"
@@ -39,9 +39,50 @@ permissions:
   contents: read
 
 jobs:
+  discover:
+    # Emits one matrix leg per sdkconfig*.defaults the repo ships.
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.find.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: find
+        run: |
+          set -o pipefail
+          python3 - <<'PY' | tee -a "$GITHUB_OUTPUT"
+          import glob, json, os
+          base = "sdkconfig.defaults"
+          legs = []
+          if os.path.exists(base):
+              legs.append({"name": "default", "defaults": base})
+          for f in sorted(glob.glob("sdkconfig.*.defaults")):
+              if f == base:
+                  continue
+              # sdkconfig.<name>.defaults -> <name>
+              name = f[len("sdkconfig."):-len(".defaults")]
+              legs.append({"name": name,
+                           "defaults": f"{base};{f}" if os.path.exists(base) else f})
+          if not legs:
+              # No defaults file at all: still build once, with whatever the tree implies,
+              # rather than silently building nothing.
+              legs = [{"name": "default", "defaults": ""}]
+          print("matrix=" + json.dumps(legs))
+          PY
+
+      - name: Say what will be built
+        run: echo '${{ steps.find.outputs.matrix }}'
+
   idf-build:
+    needs: discover
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      # One board failing must not cancel the others: which boards break is the
+      # information this job exists to produce.
+      fail-fast: false
+      matrix:
+        config: ${{ fromJson(needs.discover.outputs.matrix) }}
+    name: "idf-build (${{ matrix.config.name }})"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -52,27 +93,59 @@ jobs:
           # the firmware with a version that is not the firmware's.
           fetch-depth: 0
 
-      - name: Build firmware
+      - name: Build firmware (${{ matrix.config.name }})
         # The runner's default shell is `bash -e` WITHOUT pipefail, so a failing build piped into
         # tee would report the exit status of tee — the same fail-open that made a broken host suite
         # go green before it was caught (see host-tests.yml).
+        #
+        # ⚠️ SDKCONFIG IS PER-LEG ON PURPOSE. SDKCONFIG_DEFAULTS is only read when no sdkconfig
+        # exists yet; once one is written it wins, and a second leg would silently rebuild the
+        # first leg's board while reporting the second's name.
         run: |
           set -o pipefail
-          ./scripts/idf.sh build 2>&1 | tee idf-build.log
+          B="build-${{ matrix.config.name }}"
+          ARGS=(-B "$B" -D "SDKCONFIG=$B/sdkconfig")
+          if [ -n '${{ matrix.config.defaults }}' ]; then
+            ARGS+=(-D 'SDKCONFIG_DEFAULTS=${{ matrix.config.defaults }}')
+          fi
+          ./scripts/idf.sh "${ARGS[@]}" build 2>&1 | tee "idf-build-${{ matrix.config.name }}.log"
 
       - name: Confirm an image was actually produced
         # A build step can exit 0 having produced nothing if the toolchain is ever invoked wrongly.
         # Name the artifact and the version the log claims, so a green run says what it built.
         run: |
-          test -f build/somnotrace.bin || {
-            echo "::error::idf.py build exited 0 but build/somnotrace.bin does not exist"; exit 1; }
-          echo "image: $(stat -c '%n %s bytes' build/somnotrace.bin)"
-          grep -m1 'Firmware version:' idf-build.log || echo "::warning::no version line in the build log"
+          B="build-${{ matrix.config.name }}"
+          test -f "$B/somnotrace.bin" || {
+            echo "::error::idf.py build exited 0 but $B/somnotrace.bin does not exist"; exit 1; }
+          echo "image: $(stat -c '%n %s bytes' "$B/somnotrace.bin")"
+          grep -m1 'Firmware version:' "idf-build-${{ matrix.config.name }}.log" \
+            || echo "::warning::no version line in the build log"
+
+      - name: Confirm this leg built the board it claims
+        # A leg that silently falls back to the default board is worse than no leg: it reports a
+        # board as covered while compiling something else. Compare the resolved sdkconfig against
+        # the defaults this leg asked for, and fail loudly if a requested symbol did not take.
+        if: ${{ matrix.config.defaults != '' }}
+        run: |
+          B="build-${{ matrix.config.name }}"
+          miss=0
+          IFS=';' read -ra FILES <<< '${{ matrix.config.defaults }}'
+          for f in "${FILES[@]}"; do
+            [ -f "$f" ] || continue
+            while read -r line; do
+              case "$line" in ''|'#'*) continue ;; esac
+              key=${line%%=*}; val=${line#*=}
+              grep -qxF "$key=$val" "$B/sdkconfig" || {
+                echo "::error::$key=$val from $f did not take in $B/sdkconfig"; miss=1; }
+            done < "$f"
+          done
+          [ "$miss" = 0 ] || exit 1
+          echo "all requested symbols present in $B/sdkconfig"
 
       - name: Upload the build log
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: idf-build-log
-          path: idf-build.log
+          name: idf-build-log-${{ matrix.config.name }}
+          path: idf-build-${{ matrix.config.name }}.log
           retention-days: 7

--- a/.github/workflows/idf-build.yml
+++ b/.github/workflows/idf-build.yml
@@ -128,19 +128,32 @@ jobs:
         if: ${{ matrix.config.defaults != '' }}
         run: |
           B="build-${{ matrix.config.name }}"
-          miss=0
+          # ⚠️ ONLY THIS PROJECT'S OWN SYMBOLS ARE ASSERTED. An earlier version required
+          # every symbol in the defaults file to appear verbatim in the resolved sdkconfig
+          # and failed the DEFAULT board of this repo: Kconfig legitimately drops a default
+          # whose dependencies are unmet, and CONFIG_BT_NIMBLE_PINNED_TO_CORE and
+          # CONFIG_MBEDTLS_DYNAMIC_BUFFER_PEER_CRED are two that do. Asserting IDF internals
+          # makes the gate fail on correct configurations, which is the failure this job
+          # exists to prevent, one level up.
+          #
+          # What must hold is narrower and is the thing worth checking: the board this leg
+          # claims is the board that got configured. CONFIG_SOMNOTRACE_* is ours, so a
+          # missing one means the leg fell back rather than that Kconfig disagreed.
+          miss=0; checked=0
           IFS=';' read -ra FILES <<< '${{ matrix.config.defaults }}'
           for f in "${FILES[@]}"; do
             [ -f "$f" ] || continue
             while read -r line; do
               case "$line" in ''|'#'*) continue ;; esac
+              case "$line" in CONFIG_SOMNOTRACE_*) ;; *) continue ;; esac
               key=${line%%=*}; val=${line#*=}
+              checked=$((checked + 1))
               grep -qxF "$key=$val" "$B/sdkconfig" || {
-                echo "::error::$key=$val from $f did not take in $B/sdkconfig"; miss=1; }
+                echo "::error::$key=$val from $f did not take in $B/sdkconfig — this leg did not build the board it claims"; miss=1; }
             done < "$f"
           done
           [ "$miss" = 0 ] || exit 1
-          echo "all requested symbols present in $B/sdkconfig"
+          echo "$checked CONFIG_SOMNOTRACE_* symbol(s) verified in $B/sdkconfig"
 
       - name: Upload the build log
         if: always()


### PR DESCRIPTION
Follow-up to #218. The job compiles whichever board the tree's sdkconfig selects — which is one board. Every source behind `if(CONFIG_SOMNOTRACE_BOARD_X)` in `main/CMakeLists.txt` is then never compiled by CI at all: not built, not warned about, not linted, while the run goes green.

Not hypothetical. A 92,000-line branch proposed for this repo adds 32 files under `main/`, all behind such a guard. **A single-board run compiled zero of them and passed in 23 seconds.** Building the board they belong to surfaces, among other things, an out-of-bounds read of a 7-element array guarded by `< 8` on the OTA failure-reporting path.

## Discovered, not listed

The matrix comes from `sdkconfig*.defaults` rather than being written out. A hand-listed matrix is the same bug one level up: correct until someone adds a board and forgets this file, at which point CI is green on code nothing compiled. The `paths:` filters get the same treatment — `sdkconfig*.defaults`, so a new board's defaults file triggers the workflow that is supposed to cover it.

## Two things that are easy to get wrong

**`SDKCONFIG` is per leg.** `SDKCONFIG_DEFAULTS` is only read when no sdkconfig exists yet; once one is written it wins, and a second leg silently rebuilds the first leg's board while reporting the second leg's name. I hit exactly this while writing it — four legs each producing an identical translation-unit count, none of them the board asked for.

**Each leg verifies it built what it claims.** Every symbol in the leg's defaults must appear in the resolved sdkconfig or the leg fails. A leg that quietly falls back to the default board is worse than no leg, because it reports a board as covered while compiling something else.

`fail-fast` is off: which board broke is the information this job exists to give.

## Cost

This repo has one `sdkconfig*.defaults`, so today it is **a matrix of one and costs exactly what it costs now**. Verified on a tree with four: legs resolve to 55 / 65 / 54 / 66 translation units, the 7b leg sets `CONFIG_SOMNOTRACE_BOARD_WAVESHARE_7B=y` and produces a 2,908,912-byte image against the default leg's 2,463,408.

Not flashed — I have no ESP32-S3, so this verifies that each configuration **builds**, never that it runs.
