### PR TITLE
test(mutation): the harness was not counting five files it already runs

### DIFF
--- a/scripts/mutate_host.py
+++ b/scripts/mutate_host.py
@@ -67,12 +67,30 @@ INC = [os.path.join(ROOT, "main"), os.path.join(HERE, "test_include"), ROOT]
 # A header a test #includes is a mutation target too, not just a .c it links: the shipped
 # spool_to_edf() lives in edf_data_dict.h and is the code #202 was about. Headers are listed
 # for targeting and reach; they are never passed to the compiler.
+#
+# A "#" prefix means the same thing for a .c file: v2.0.0 split the EDF converter into five
+# modules, and edf_gen_test.c #includes all five so it can reach their statics. They are part
+# of that test's own translation unit, so listing them WITHOUT the prefix would hand gcc a
+# second copy and every build would fail on duplicate symbols. They are still shipped code a
+# host test executes, so they are targeted and counted; they are just not passed to the
+# compiler. Before this marker existed they were invisible: five files the suite has exercised
+# since v2.0.0 were reported as untested, because the map is what the harness believes.
 TESTS = {
     "as11_time_test":       ["main/as11_time.c"],
     "as11_events_test":     ["main/as11_time.c", "@cjson"],
-    "edf_properties_test":  ["main/as11_time.c", "main/edf_data_dict.h", "@cjson"],
+    "edf_gen_test":         ["main/as11_time.c", "@cjson",
+                             "#main/edf_header.c", "#main/edf_waveform.c",
+                             "#main/edf_annotations.c", "#main/edf_summary.c",
+                             "#main/edf_gen.c"],
+    "edf_properties_test":  ["main/as11_time.c", "main/edf_data_dict.h", "@cjson",
+                             "#main/edf_summary.c"],
     "vld3_decoder_test":    ["main/oximetry_vld3.c"],
 }
+
+
+def target_path(entry: str) -> str:
+    """The repo-relative path a TESTS entry names, without the "#" include-marker."""
+    return entry[1:] if entry.startswith("#") else entry
 
 EQUIV_FILE = os.path.join(HERE, "mutate_equivalent.txt")
 
@@ -117,6 +135,8 @@ def sources_for(test: str) -> list[str] | None:
             if not CJSON:
                 return None
             out.append(CJSON)
+        elif s.startswith("#"):
+            continue      # already inside the test's translation unit -- see TESTS
         elif not s.endswith(".h"):
             out.append(os.path.join(ROOT, s))
     return out
@@ -130,9 +150,23 @@ def build(test: str, outdir: str, coverage: bool = False) -> str | None:
     cmd = ["gcc", "-O0", "-o", exe, os.path.join(HERE, test + ".c"), *src]
     if coverage:
         cmd += ["--coverage"]
-    cmd += [f"-I{d}" for d in INC]
-    if CJSON:
+    # Header order depends on what the test links, and it has to.
+    #
+    # scripts/test_include/cJSON.h is not a declaration set: it is a working stub, 17 static
+    # inline functions. A test that does NOT link cJSON.c therefore gets its implementation
+    # from that header alone, and putting the real cJSON.h in front turns those inlines into
+    # ordinary externs -- as11_time.c then fails to link on undefined cJSON_GetObjectItem.
+    #
+    # A test that DOES link cJSON.c needs the opposite. The stub covers a 20-function subset
+    # and lacks cJSON_Print, cJSON_IsTrue and cJSON_AddItemReferenceToObject, so behind the
+    # shim such a test dies on implicit declarations. edf_gen_test is the first wired test to
+    # reach past the subset, which is why this stayed invisible until it was added to TESTS.
+    #
+    # run_host_tests.sh has always ordered it this way -- $CJ_INC ahead of $SHIM, and only on
+    # the two cJSON legs. This is the harness catching up with the suite it measures.
+    if CJSON and "@cjson" in TESTS[test]:
         cmd.append("-I" + os.path.dirname(CJSON))
+    cmd += [f"-I{d}" for d in INC]
     cmd.append("-lm")
     r = subprocess.run(cmd, capture_output=True, cwd=outdir)
     return exe if r.returncode == 0 else None
@@ -234,9 +268,14 @@ def harness_blind_spot() -> tuple[int, int, list[str]]:
     Silence about the denominator is how a mutation score becomes a comfort."""
     covered = set()
     for t in TESTS:
+        # A test that cannot build covers nothing. Counting its sources anyway inflates the
+        # numerator on exactly the machines where it is least true: without cJSON the two EDF
+        # suites are skipped, and before this check the summary still credited them.
+        if sources_for(t) is None:
+            continue
         for src in TESTS[t]:
             if src != "@cjson":
-                covered.add(os.path.abspath(os.path.join(ROOT, src)))
+                covered.add(os.path.abspath(os.path.join(ROOT, target_path(src))))
     total = []
     for base in ("main", "components"):
         for dirpath, _dirs, files in os.walk(os.path.join(ROOT, base)):
@@ -515,7 +554,8 @@ def main() -> int:
     print("REACH     " + ("gcov line coverage available" if reach is not None
                           else "UNAVAILABLE — failing closed, every mutant will be run"))
 
-    targets = a.files or ([os.path.join(ROOT, s) for t in TESTS for s in TESTS[t] if s != "@cjson"]
+    targets = a.files or ([os.path.join(ROOT, target_path(s))
+                           for t in TESTS for s in TESTS[t] if s != "@cjson"]
                           if a.all else [])
     targets = sorted({os.path.abspath(t if os.path.isabs(t) else os.path.join(ROOT, t))
                       for t in targets})

--- a/scripts/mutate_host.py
+++ b/scripts/mutate_host.py
@@ -128,13 +128,40 @@ def find_cjson() -> str | None:
 CJSON = find_cjson()
 
 
+def find_cjson_system() -> str | None:
+    """The include directory of a cJSON installed as a system library, or None.
+
+    apt's libcjson-dev -- which is what BOTH workflows install -- ships cJSON.h and
+    libcjson.so and no cJSON.c at all. find_cjson() above hunts only for the source, so it
+    returns None there and every cJSON-linking test is skipped.
+
+    scripts/run_host_tests.sh has always handled this case, with -lcjson. The harness did not,
+    and the consequence was measured rather than guessed: in a ubuntu:24.04 container carrying
+    exactly the packages the workflows install, run_host_tests.sh reports "5 run, 0 failed,
+    0 skipped" while this harness built 2 of the 5 tests and printed SCOPE 2 of 80. A tool
+    whose job is to report what the suite does not cover was itself covering less than the
+    suite, on the one machine where CI runs.
+
+    Deliberately not a fallback for a missing source: build() prefers cJSON.c when there is
+    one, because a source can be compiled in with the same flags as everything else."""
+    for d in ("/usr/include/cjson", "/usr/local/include/cjson"):
+        if os.path.exists(os.path.join(d, "cJSON.h")):
+            return d
+    return None
+
+
+CJSON_SYS = find_cjson_system()
+
+
 def sources_for(test: str) -> list[str] | None:
     out = []
     for s in TESTS[test]:
         if s == "@cjson":
-            if not CJSON:
-                return None
-            out.append(CJSON)
+            if CJSON:
+                out.append(CJSON)       # compiled in from source
+            elif CJSON_SYS is None:
+                return None             # neither source nor system library: genuinely skipped
+            # else: linked as -lcjson in build(), so there is no source to add here
         elif s.startswith("#"):
             continue      # already inside the test's translation unit -- see TESTS
         elif not s.endswith(".h"):
@@ -164,10 +191,15 @@ def build(test: str, outdir: str, coverage: bool = False) -> str | None:
     #
     # run_host_tests.sh has always ordered it this way -- $CJ_INC ahead of $SHIM, and only on
     # the two cJSON legs. This is the harness catching up with the suite it measures.
-    if CJSON and "@cjson" in TESTS[test]:
+    links_cjson = "@cjson" in TESTS[test]
+    if links_cjson and CJSON:
         cmd.append("-I" + os.path.dirname(CJSON))
+    elif links_cjson and CJSON_SYS:
+        cmd.append("-I" + CJSON_SYS)
     cmd += [f"-I{d}" for d in INC]
     cmd.append("-lm")
+    if links_cjson and not CJSON and CJSON_SYS:
+        cmd.append("-lcjson")           # -l goes after the objects that need it
     r = subprocess.run(cmd, capture_output=True, cwd=outdir)
     return exe if r.returncode == 0 else None
 
@@ -530,7 +562,8 @@ def main() -> int:
         print("gcc not found", file=sys.stderr)
         return 3
     outdir = tempfile.mkdtemp(prefix="snt-mutate-")
-    print(f"cJSON: {CJSON or '<not found — tests needing it are SKIPPED, not failed>'}")
+    print("cJSON: " + (CJSON or (f"-lcjson from {CJSON_SYS}" if CJSON_SYS else
+                                 "<not found — tests needing it are SKIPPED, not failed>")))
 
     if a.selftest:
         return selftest(outdir)


### PR DESCRIPTION
The `SCOPE` line from #250 said **3 of 80 C sources are linked by a wired host test**. It was wrong, in the direction that flatters us. This corrects it and fixes the two bugs that correcting it exposed.

## The five files

`scripts/edf_gen_test.c:47-59` `#include`s the modules from the v2.0.0 split:

```c
#include "edf_header.c"       /* found via -I<main dir>, see run_host_tests.sh */
#include "edf_waveform.c"
#include "edf_annotations.c"
#include "edf_summary.c"
#include "edf_gen.c"
```

and `edf_properties_test.c:58` includes `edf_summary.c`. All five are compiled and executed on every run of the suite, and have been since v2.0.0. They were reported as untested only because `TESTS` didn't mention them — and `TESTS` is what the harness believes.

`edf_gen_test` wasn't in the map at all. The largest test in the suite was invisible to the tool that measures the suite.

A `#` prefix in `TESTS` now marks a source that belongs to a test's own translation unit: targeted and counted, but not handed to gcc, since listing it plainly would give the compiler a second copy. That is the same treatment `.h` entries already get, for the same reason.

## Two bugs that only appeared once the map was right

**Header order has to follow what each test links.** `scripts/test_include/cJSON.h` is not a declaration set — it is a working stub of 17 `static inline` functions. A test that does *not* link `cJSON.c` gets its implementation from that header, so putting the real `cJSON.h` first turns the inlines into externs and `as11_time.c` fails to link. A test that *does* link it needs the reverse, because the stub covers 20 functions and lacks `cJSON_Print`, `cJSON_IsTrue` and `cJSON_AddItemReferenceToObject`. `run_host_tests.sh:115` has always ordered it correctly (`$CJ_INC` ahead of `$SHIM`, only on the cJSON legs); the harness now agrees with the suite it measures. This stayed latent because no wired test reached past the subset until `edf_gen_test` did.

**A test that cannot build no longer counts as coverage.** Without cJSON the two EDF suites are skipped, and the summary still credited `edf_data_dict.h` — inflating the numerator on exactly the machines where it was least true.

## The one that affects CI

`find_cjson()` hunts only for `cJSON.c`. `libcjson-dev` — which both `host-tests.yml` and `mutation.yml` install — ships this and nothing else:

```
/usr/include/cjson/cJSON.h
/usr/lib/x86_64-linux-gnu/libcjson.so
```

One of the three probes is `/usr/include/cjson/cJSON.c`, a path that cannot exist because that directory holds only headers. So on a CI runner the harness finds no cJSON and skips every test that needs one. In a `ubuntu:24.04` container carrying exactly the packages the workflows install:

```
scripts/run_host_tests.sh    5 run, 0 failed, 0 skipped
scripts/mutate_host.py       2 of 5 tests built, SCOPE 2 of 80
```

`run_host_tests.sh:108` has handled this since it was written, with `CJ_LIB="-lcjson"`. `find_cjson_system()` teaches the harness the same thing. Source is still preferred when there is one, so a checkout with `cJSON.c` is unchanged — the system library is not a fallback for a missing source but for a differently shaped install.

| environment | cJSON | SCOPE |
| :--- | :--- | :--- |
| `libcjson-dev` only | `-lcjson from /usr/include/cjson` | 8 of 80 |
| `cJSON.c` present | compiled from source | 8 of 80 |
| neither | skipped, honestly | 2 of 80 |

The third row matters as much as the first. With no cJSON anywhere those suites really are skipped, and the summary should say 2 rather than credit tests it could not build.

## What became visible

At `--limit 25`:

```
edf_annotations.c  canary killed   5 unasserted, 20 unreached
edf_waveform.c     canary killed  18 unasserted,  0 unreached
edf_summary.c      canary killed   0 unasserted, 24 unreached
edf_gen.c          canary killed  12 unasserted, 10 unreached
edf_header.c       CANARY SURVIVED — VOID
```

35 unasserted survivors in code that reported as untested yesterday. Examples worth a look:

```
main/edf_waveform.c:32   relational:<=→<   if (!f || channels_in_file <= 0) return UINT32_MAX;
main/edf_gen.c:126       relational:<→<=   if (start_epoch_ms < 946684800000LL)
main/edf_annotations.c:68 arithmetic:*→/   snt_event_t *ev_list = malloc(capacity * sizeof(snt_event_t));
```

`edf_header.c` is the interesting result and it is correct. The canary lands on `edf_generate_identification_files()`, which no test calls, so the harness refuses a verdict on the whole file rather than reporting a clean sweep over code it never ran. That is what fail-closed was for. I have left it as it is — the honest `VOID` is more useful than a canary chosen to succeed.

## Scope and cost

- One file changed, `scripts/mutate_host.py`.
- **No CI timing change.** No workflow invokes `mutate_host.py`. `scripts/mutants.py`, which `mutation.yml` does run, is untouched and gives an identical result before and after (`baseline PASS`, canary killed, `15/15 mutants killed`).
- Because nothing runs it in CI, the `libcjson` fix is latent until something does — it pays off the moment the harness is wired in, or run on a box that has only the system package.

## Verification

Host suite on the rig: `5 run, 0 failed, 0 skipped` with cJSON, `3 run, 0 failed, 2 skipped` without. All workflows green on my fork. The CI-environment numbers above are from a container with `libcjson-dev build-essential python3`, and the mutants there are real, not just the link:

```
edf_waveform.c     canary killed  3 killed, 8 unasserted
edf_annotations.c  canary killed  0 killed, 4 unasserted
```

Unrelated and already covered by #249: `scripts/lint.sh --docker` fails its blocking tier on current `main` with `0 script(s)` and a shellcheck usage dump, because `git ls-files` returns nothing inside the container. It reproduces on a clean checkout with none of this branch present.
