### PR TITLE
test(edf): the identification profile had no test, and the harness runs nowhere

### DIFF
--- a/.github/workflows/host-tests.yml
+++ b/.github/workflows/host-tests.yml
@@ -33,19 +33,26 @@ jobs:
 
       - name: Install libcjson
         run: |
-          # ⚠️ DROP THE RUNNER'S THIRD-PARTY APT SOURCES FIRST. The ubuntu-latest image ships
-          # lists for Google Chrome, Microsoft and Azure that this project never installs from.
-          # When one of them serves a bad index, `apt-get update` exits 100 and every job that
-          # installs anything goes red before reaching a line of project code. Measured
-          # 2026-09-09: `Hash Sum mismatch` on dl.google.com/linux/chrome-stable reddened
-          # host-tests, lint and mutation together, and survived a re-run — it is an outage,
-          # not a flake, and retrying does not clear it.
+          # ⚠️ DROP THE RUNNER'S UNRELATED APT SOURCES FIRST. The ubuntu-latest image ships
+          # apt sources for Google Chrome and Microsoft that this project never installs from.
+          # When one of them serves a bad index, `apt-get update` exits 100 and the job dies
+          # before reaching a line of project code. Measured 2026-09-09: `Hash Sum mismatch`
+          # on dl.google.com/linux/chrome-stable reddened host-tests, lint and mutation
+          # together, and survived a re-run — an outage, not a flake.
           #
-          # Removing the lists is the fix rather than `|| true`, which would hide a genuine
-          # failure to reach the Ubuntu archive — the one we do depend on.
-          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
-                     /etc/apt/sources.list.d/microsoft-prod.list \
-                     /etc/apt/sources.list.d/azure-cli.list
+          # MATCHED BY CONTENT, NOT BY FILENAME. The first version of this named
+          # /etc/apt/sources.list.d/google-chrome.list, removed nothing, and failed exactly as
+          # before: the image's file names differ between runner releases and between the
+          # .list and deb822 .sources formats. A guessed name fails silently, which is the
+          # worst way for a workaround to be wrong. Grepping for the host cannot miss.
+          #
+          # Removed rather than swallowed with `|| true`, which would also hide a genuine
+          # failure to reach the Ubuntu archive — the one repository these jobs depend on.
+          for f in $(grep -rlE 'dl\.google\.com|packages\.microsoft\.com' \
+                       /etc/apt/sources.list /etc/apt/sources.list.d/ 2>/dev/null || true); do
+              echo "removing apt source this project does not use: $f"
+              sudo rm -f "$f"
+          done
           sudo apt-get update -q
           sudo apt-get install -y --no-install-recommends libcjson-dev
 

--- a/.github/workflows/host-tests.yml
+++ b/.github/workflows/host-tests.yml
@@ -33,6 +33,19 @@ jobs:
 
       - name: Install libcjson
         run: |
+          # ⚠️ DROP THE RUNNER'S THIRD-PARTY APT SOURCES FIRST. The ubuntu-latest image ships
+          # lists for Google Chrome, Microsoft and Azure that this project never installs from.
+          # When one of them serves a bad index, `apt-get update` exits 100 and every job that
+          # installs anything goes red before reaching a line of project code. Measured
+          # 2026-09-09: `Hash Sum mismatch` on dl.google.com/linux/chrome-stable reddened
+          # host-tests, lint and mutation together, and survived a re-run — it is an outage,
+          # not a flake, and retrying does not clear it.
+          #
+          # Removing the lists is the fix rather than `|| true`, which would hide a genuine
+          # failure to reach the Ubuntu archive — the one we do depend on.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
+                     /etc/apt/sources.list.d/microsoft-prod.list \
+                     /etc/apt/sources.list.d/azure-cli.list
           sudo apt-get update -q
           sudo apt-get install -y --no-install-recommends libcjson-dev
 

--- a/.github/workflows/mutation-sweep.yml
+++ b/.github/workflows/mutation-sweep.yml
@@ -39,19 +39,26 @@ jobs:
         # linking -lcjson; before that it silently skipped those suites and reported a
         # smaller SCOPE than the suite it was measuring.
         run: |
-          # ⚠️ DROP THE RUNNER'S THIRD-PARTY APT SOURCES FIRST. The ubuntu-latest image ships
-          # lists for Google Chrome, Microsoft and Azure that this project never installs from.
-          # When one of them serves a bad index, `apt-get update` exits 100 and every job that
-          # installs anything goes red before reaching a line of project code. Measured
-          # 2026-09-09: `Hash Sum mismatch` on dl.google.com/linux/chrome-stable reddened
-          # host-tests, lint and mutation together, and survived a re-run — it is an outage,
-          # not a flake, and retrying does not clear it.
+          # ⚠️ DROP THE RUNNER'S UNRELATED APT SOURCES FIRST. The ubuntu-latest image ships
+          # apt sources for Google Chrome and Microsoft that this project never installs from.
+          # When one of them serves a bad index, `apt-get update` exits 100 and the job dies
+          # before reaching a line of project code. Measured 2026-09-09: `Hash Sum mismatch`
+          # on dl.google.com/linux/chrome-stable reddened host-tests, lint and mutation
+          # together, and survived a re-run — an outage, not a flake.
           #
-          # Removing the lists is the fix rather than `|| true`, which would hide a genuine
-          # failure to reach the Ubuntu archive — the one we do depend on.
-          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
-                     /etc/apt/sources.list.d/microsoft-prod.list \
-                     /etc/apt/sources.list.d/azure-cli.list
+          # MATCHED BY CONTENT, NOT BY FILENAME. The first version of this named
+          # /etc/apt/sources.list.d/google-chrome.list, removed nothing, and failed exactly as
+          # before: the image's file names differ between runner releases and between the
+          # .list and deb822 .sources formats. A guessed name fails silently, which is the
+          # worst way for a workaround to be wrong. Grepping for the host cannot miss.
+          #
+          # Removed rather than swallowed with `|| true`, which would also hide a genuine
+          # failure to reach the Ubuntu archive — the one repository these jobs depend on.
+          for f in $(grep -rlE 'dl\.google\.com|packages\.microsoft\.com' \
+                       /etc/apt/sources.list /etc/apt/sources.list.d/ 2>/dev/null || true); do
+              echo "removing apt source this project does not use: $f"
+              sudo rm -f "$f"
+          done
           sudo apt-get update -q
           sudo apt-get install -y --no-install-recommends libcjson-dev
 

--- a/.github/workflows/mutation-sweep.yml
+++ b/.github/workflows/mutation-sweep.yml
@@ -39,6 +39,19 @@ jobs:
         # linking -lcjson; before that it silently skipped those suites and reported a
         # smaller SCOPE than the suite it was measuring.
         run: |
+          # ⚠️ DROP THE RUNNER'S THIRD-PARTY APT SOURCES FIRST. The ubuntu-latest image ships
+          # lists for Google Chrome, Microsoft and Azure that this project never installs from.
+          # When one of them serves a bad index, `apt-get update` exits 100 and every job that
+          # installs anything goes red before reaching a line of project code. Measured
+          # 2026-09-09: `Hash Sum mismatch` on dl.google.com/linux/chrome-stable reddened
+          # host-tests, lint and mutation together, and survived a re-run — it is an outage,
+          # not a flake, and retrying does not clear it.
+          #
+          # Removing the lists is the fix rather than `|| true`, which would hide a genuine
+          # failure to reach the Ubuntu archive — the one we do depend on.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
+                     /etc/apt/sources.list.d/microsoft-prod.list \
+                     /etc/apt/sources.list.d/azure-cli.list
           sudo apt-get update -q
           sudo apt-get install -y --no-install-recommends libcjson-dev
 

--- a/.github/workflows/mutation-sweep.yml
+++ b/.github/workflows/mutation-sweep.yml
@@ -1,0 +1,84 @@
+name: "Mutation sweep"
+# The SEARCHING half of the mutation setup, on a schedule rather than on every push.
+#
+# scripts/mutants.py — run by mutation.yml on every push — is the PINNING half: a fixed
+# set of mutants that must all die, 15/15 today, and a red result there means someone
+# broke a test that was working. This job is the other kind. scripts/mutate_host.py
+# generates mutants it has never seen, so its output is a REPORT and not a verdict:
+# it currently finds 40 unasserted survivors on a green tree. Wiring that as a gate
+# would mean a permanently red build, and a permanently red gate teaches people to
+# ignore CI — the same reasoning that made lint's style tier advisory.
+#
+# ⚠️ WHY THIS IS NOT ON EVERY PUSH. Measured on a developer machine: 391 seconds,
+# against 30 for mutants.py. The slowest per-push job in this repo is the IDF build
+# at roughly 200s, and the jobs run concurrently, so a 391s job would become the
+# critical path and roughly double the wait on every pull request — to deliver a
+# report that nobody is required to act on before merging. Weekly costs contributors
+# nothing and still surfaces a trend.
+#
+# It runs on Saturday evening UTC so the result is already waiting on Sunday, which
+# is historically the busiest merge day in this repo.
+on:
+  schedule:
+    - cron: "0 20 * * 6"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install libcjson
+        # The harness needs cJSON to build the two EDF suites. apt ships the header and
+        # the shared library and no cJSON.c, which scripts/mutate_host.py now handles by
+        # linking -lcjson; before that it silently skipped those suites and reported a
+        # smaller SCOPE than the suite it was measuring.
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y --no-install-recommends libcjson-dev
+
+      - name: Sweep
+        run: |
+          set -o pipefail
+          python3 scripts/mutate_host.py --all 2>&1 | tee mutation-sweep.log
+
+      - name: Check the run actually measured something
+        # THE ONLY FAILING CONDITION. A survivor count is a report; a VOID is not.
+        # VOID means the harness could not detect a change it made on purpose — a
+        # canary that survived, or a baseline that does not pass — and every number
+        # in the log is then meaningless. Reporting that as a quiet success is how a
+        # mutation score becomes a comfort, so it fails loudly instead.
+        run: |
+          if grep -q '^ *VOID' mutation-sweep.log; then
+            echo "::error::the sweep reported VOID — it measured nothing, see the log"
+            grep -B2 '^ *VOID' mutation-sweep.log || true
+            exit 1
+          fi
+          grep -qE '[0-9]+ unasserted survivor\(s\)' mutation-sweep.log || {
+            echo "::error::no survivor-count line — the sweep did not run to completion"; exit 1; }
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "### Mutation sweep (advisory)"
+            echo '```'
+            grep -E '^SCOPE|^ *not seen|unasserted survivor\(s\)|^ *canary|^ *killed ' mutation-sweep.log || true
+            echo '```'
+            echo ""
+            echo "UNASSERTED means the mutant ran and every test still passed."
+            echo "This job never fails on that count — only on VOID, which means the run measured nothing."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload the sweep log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutation-sweep-log
+          path: mutation-sweep.log
+          retention-days: 30

--- a/.github/workflows/mutation-sweep.yml
+++ b/.github/workflows/mutation-sweep.yml
@@ -62,13 +62,26 @@ jobs:
           grep -qE '[0-9]+ unasserted survivor\(s\)' mutation-sweep.log || {
             echo "::error::no survivor-count line — the sweep did not run to completion"; exit 1; }
 
+      - name: Flag survivors that are not in the committed inventory
+        # scripts/mutation_survivors.txt is checked in, so the normal way a new survivor
+        # gets noticed is a line appearing in a pull request's diff. This is the backstop
+        # for the ones that arrive without a diff — a dependency bump, a compiler change,
+        # or a merge that nobody re-swept. A warning, not a failure: the count is a report.
+        if: always()
+        run: |
+          if grep -qE '^ *\+ NEW ' mutation-sweep.log; then
+            n=$(grep -cE '^ *\+ NEW ' mutation-sweep.log)
+            echo "::warning::$n survivor(s) not in scripts/mutation_survivors.txt — regenerate with: python3 scripts/mutate_host.py --all --write-inventory"
+            grep -E '^ *\+ NEW ' mutation-sweep.log
+          fi
+
       - name: Summary
         if: always()
         run: |
           {
             echo "### Mutation sweep (advisory)"
             echo '```'
-            grep -E '^SCOPE|^ *not seen|unasserted survivor\(s\)|^ *canary|^ *killed ' mutation-sweep.log || true
+            grep -E '^SCOPE|^INVENTORY|^ *[+-] (NEW|was here)|^ *not seen|unasserted survivor\(s\)|^ *canary|^ *killed ' mutation-sweep.log || true
             echo '```'
             echo ""
             echo "UNASSERTED means the mutant ran and every test still passed."

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -31,6 +31,19 @@ jobs:
         # Same dependency the host tests need; without it the harness SKIPS the two suites
         # that cover the exporter and correctly reports VOID rather than a kill count.
         run: |
+          # ⚠️ DROP THE RUNNER'S THIRD-PARTY APT SOURCES FIRST. The ubuntu-latest image ships
+          # lists for Google Chrome, Microsoft and Azure that this project never installs from.
+          # When one of them serves a bad index, `apt-get update` exits 100 and every job that
+          # installs anything goes red before reaching a line of project code. Measured
+          # 2026-09-09: `Hash Sum mismatch` on dl.google.com/linux/chrome-stable reddened
+          # host-tests, lint and mutation together, and survived a re-run — it is an outage,
+          # not a flake, and retrying does not clear it.
+          #
+          # Removing the lists is the fix rather than `|| true`, which would hide a genuine
+          # failure to reach the Ubuntu archive — the one we do depend on.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
+                     /etc/apt/sources.list.d/microsoft-prod.list \
+                     /etc/apt/sources.list.d/azure-cli.list
           sudo apt-get update -q
           sudo apt-get install -y --no-install-recommends libcjson-dev
 

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -31,19 +31,26 @@ jobs:
         # Same dependency the host tests need; without it the harness SKIPS the two suites
         # that cover the exporter and correctly reports VOID rather than a kill count.
         run: |
-          # ⚠️ DROP THE RUNNER'S THIRD-PARTY APT SOURCES FIRST. The ubuntu-latest image ships
-          # lists for Google Chrome, Microsoft and Azure that this project never installs from.
-          # When one of them serves a bad index, `apt-get update` exits 100 and every job that
-          # installs anything goes red before reaching a line of project code. Measured
-          # 2026-09-09: `Hash Sum mismatch` on dl.google.com/linux/chrome-stable reddened
-          # host-tests, lint and mutation together, and survived a re-run — it is an outage,
-          # not a flake, and retrying does not clear it.
+          # ⚠️ DROP THE RUNNER'S UNRELATED APT SOURCES FIRST. The ubuntu-latest image ships
+          # apt sources for Google Chrome and Microsoft that this project never installs from.
+          # When one of them serves a bad index, `apt-get update` exits 100 and the job dies
+          # before reaching a line of project code. Measured 2026-09-09: `Hash Sum mismatch`
+          # on dl.google.com/linux/chrome-stable reddened host-tests, lint and mutation
+          # together, and survived a re-run — an outage, not a flake.
           #
-          # Removing the lists is the fix rather than `|| true`, which would hide a genuine
-          # failure to reach the Ubuntu archive — the one we do depend on.
-          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
-                     /etc/apt/sources.list.d/microsoft-prod.list \
-                     /etc/apt/sources.list.d/azure-cli.list
+          # MATCHED BY CONTENT, NOT BY FILENAME. The first version of this named
+          # /etc/apt/sources.list.d/google-chrome.list, removed nothing, and failed exactly as
+          # before: the image's file names differ between runner releases and between the
+          # .list and deb822 .sources formats. A guessed name fails silently, which is the
+          # worst way for a workaround to be wrong. Grepping for the host cannot miss.
+          #
+          # Removed rather than swallowed with `|| true`, which would also hide a genuine
+          # failure to reach the Ubuntu archive — the one repository these jobs depend on.
+          for f in $(grep -rlE 'dl\.google\.com|packages\.microsoft\.com' \
+                       /etc/apt/sources.list /etc/apt/sources.list.d/ 2>/dev/null || true); do
+              echo "removing apt source this project does not use: $f"
+              sudo rm -f "$f"
+          done
           sudo apt-get update -q
           sudo apt-get install -y --no-install-recommends libcjson-dev
 

--- a/scripts/edf_gen_test.c
+++ b/scripts/edf_gen_test.c
@@ -1043,6 +1043,246 @@ static void test_str_pressure_settings_exact(void)
     cJSON_Delete(settings);
 }
 
+/* ── Identification.json / Identification.crc ────────────────────────────────
+ * edf_generate_identification_files() was the largest untested function in the
+ * exporter. The mutation harness picks it as edf_header.c's canary, empties its
+ * body, and every test still passed — so the harness refused a verdict on all
+ * 456 lines of that file rather than report a clean sweep it had not earned.
+ *
+ * These exist to make that verdict possible, so they pin behaviour a mutant
+ * would change rather than merely reaching the function: the CRC's byte order
+ * and length, the number->string coercion, the defaults for absent keys, and
+ * the one input/output key name that differs on purpose.
+ */
+static void ident_write_file(const char *path, const char *text)
+{
+    FILE *f = fopen(path, "wb");
+    assert(f);
+    size_t n = strlen(text);
+    assert(fwrite(text, 1, n, f) == n);
+    assert(fclose(f) == 0);
+}
+
+static char *ident_slurp(const char *path, size_t *out_len)
+{
+    FILE *f = fopen(path, "rb");
+    if (!f) return NULL;
+    assert(fseek(f, 0, SEEK_END) == 0);
+    long n = ftell(f);
+    assert(n >= 0);
+    assert(fseek(f, 0, SEEK_SET) == 0);
+    char *buf = malloc((size_t)n + 1);
+    assert(buf);
+    assert(fread(buf, 1, (size_t)n, f) == (size_t)n);
+    buf[n] = '\0';
+    fclose(f);
+    if (out_len) *out_len = (size_t)n;
+    return buf;
+}
+
+static void ident_make_dir(char *dst, size_t cap, const char *name)
+{
+    snprintf(dst, cap, "%s/%s", g_root, name);
+    mkdir(dst, 0777);
+}
+
+/* The full profile the AS11 expects, so the shape is pinned rather than sampled. */
+static const char *IDENT_FULL =
+    "{"
+    "\"UniversalIdentifier\":\"UID-1\","
+    "\"SerialNumber\":\"SN-2\","
+    "\"ProductCode\":37001,"
+    "\"ProductName\":\"AirSense 11\","
+    "\"ProductGeographicIdentifier\":\"EUR\","
+    "\"HardwareIdentifier\":\"HW-3\","
+    "\"BootloaderIdentifier\":\"BL-4\","
+    "\"ApplicationIdentifier\":\"APP-5\","
+    "\"ConfigurationIdentifier\":\"CFG-6\","
+    "\"PlatformIdentifier\":12,"
+    "\"VariantIdentifier\":34,"
+    "\"RegionIdentifier\":56,"
+    "\"ProfileVariantIdentifier\":\"PV-7\","
+    "\"DataVersionIdentifier\":78,"
+    "\"DataModelVersionIdentifier\":\"DM-8\""
+    "}";
+
+static cJSON *ident_profile(cJSON *root, const char *which)
+{
+    cJSON *fg = cJSON_GetObjectItem(root, "FlowGenerator");
+    assert(fg);
+    cJSON *profiles = cJSON_GetObjectItem(fg, "IdentificationProfiles");
+    assert(profiles);
+    cJSON *p = cJSON_GetObjectItem(profiles, which);
+    assert(p);
+    return p;
+}
+
+static void ident_expect_str(cJSON *obj, const char *key, const char *want)
+{
+    cJSON *j = cJSON_GetObjectItem(obj, key);
+    assert(j);
+    assert(cJSON_IsString(j));
+    assert(strcmp(j->valuestring, want) == 0);
+}
+
+static void test_crc32_matches_the_published_check_vector(void)
+{
+    /* CRC-32/ISO-HDLC (IEEE 802.3) has a published check value: the CRC of the
+     * nine bytes "123456789" is 0xCBF43926.
+     *
+     * Asserting against the constant rather than against another call of the same
+     * function is the entire point of this test. The Identification.crc test below
+     * compares the file's four bytes to edf_crc32_ieee() — so a mutation INSIDE the
+     * CRC changes both sides equally and survives, which is exactly what the
+     * mutation harness reported when this test did not exist: the loop bounds at
+     * lines 50 and 52 and the shift at line 56 all survived a suite that looked
+     * like it covered them. A test whose oracle is the code under test defends the
+     * bug instead of catching it. */
+    assert(edf_crc32_ieee((const uint8_t *)"123456789", 9) == 0xCBF43926u);
+    assert(edf_crc32_ieee((const uint8_t *)"", 0) == 0u);
+    assert(edf_crc32_ieee((const uint8_t *)"a", 1) == 0xE8B7BE43u);
+    /* Length is honoured, not strlen: a CRC over a prefix differs. */
+    assert(edf_crc32_ieee((const uint8_t *)"123456789", 8) != 0xCBF43926u);
+}
+
+static void test_identification_profile_shape(void)
+{
+    char dir[300], ident[400], out_path[400];
+    ident_make_dir(dir, sizeof(dir), "ident_shape");
+    snprintf(ident, sizeof(ident), "%s/identification.json", dir);
+    ident_write_file(ident, IDENT_FULL);
+
+    assert(edf_generate_identification_files(dir, ident) == ESP_OK);
+
+    snprintf(out_path, sizeof(out_path), "%s/Identification.json", dir);
+    char *out = ident_slurp(out_path, NULL);
+    assert(out);
+    cJSON *root = cJSON_Parse(out);
+    assert(root);
+
+    cJSON *product = ident_profile(root, "Product");
+    ident_expect_str(product, "UniversalIdentifier", "UID-1");
+    ident_expect_str(product, "SerialNumber", "SN-2");
+    ident_expect_str(product, "ProductName", "AirSense 11");
+    ident_expect_str(product, "ProductGeographicIdentifier", "EUR");
+    /* A numeric ProductCode is rendered as a STRING. The AS11 writes it either
+     * way and the profile always carries a string, so the coercion is load-bearing. */
+    ident_expect_str(product, "ProductCode", "37001");
+    /* Always blank, never copied from the source, even when the source has them. */
+    ident_expect_str(product, "SerialNumberVerificationCode", "");
+    ident_expect_str(product, "FdaUniqueDeviceIdentifier", "");
+
+    ident_expect_str(ident_profile(root, "Hardware"), "HardwareIdentifier", "HW-3");
+
+    cJSON *software = ident_profile(root, "Software");
+    ident_expect_str(software, "BootloaderIdentifier", "BL-4");
+    ident_expect_str(software, "ApplicationIdentifier", "APP-5");
+    ident_expect_str(software, "ConfigurationIdentifier", "CFG-6");
+    ident_expect_str(software, "DataModelVersionIdentifier", "DM-8");
+    /* THE KEY NAME CHANGES ON PURPOSE: the source says ProfileVARIANTIdentifier,
+     * the profile says ProfileVARIATIONIdentifier. It reads like a typo and it is
+     * not — pinned here so that "fixing" it breaks a test instead of a device. */
+    ident_expect_str(software, "ProfileVariationIdentifier", "PV-7");
+    assert(cJSON_GetObjectItem(software, "ProfileVariantIdentifier") == NULL);
+
+    /* These four stay NUMBERS. */
+    cJSON *plat = cJSON_GetObjectItem(software, "PlatformIdentifier");
+    assert(plat && cJSON_IsNumber(plat) && plat->valuedouble == 12);
+    cJSON *var = cJSON_GetObjectItem(software, "VariantIdentifier");
+    assert(var && cJSON_IsNumber(var) && var->valuedouble == 34);
+    cJSON *reg = cJSON_GetObjectItem(software, "RegionIdentifier");
+    assert(reg && cJSON_IsNumber(reg) && reg->valuedouble == 56);
+    cJSON *dv = cJSON_GetObjectItem(software, "DataVersionIdentifier");
+    assert(dv && cJSON_IsNumber(dv) && dv->valuedouble == 78);
+
+    cJSON_Delete(root);
+    free(out);
+}
+
+static void test_identification_crc_is_le_crc32_of_the_json(void)
+{
+    char dir[300], ident[400], json_path[400], crc_path[400];
+    ident_make_dir(dir, sizeof(dir), "ident_crc");
+    snprintf(ident, sizeof(ident), "%s/identification.json", dir);
+    ident_write_file(ident, IDENT_FULL);
+
+    assert(edf_generate_identification_files(dir, ident) == ESP_OK);
+
+    snprintf(json_path, sizeof(json_path), "%s/Identification.json", dir);
+    snprintf(crc_path, sizeof(crc_path), "%s/Identification.crc", dir);
+
+    size_t json_len = 0, crc_len = 0;
+    char *json = ident_slurp(json_path, &json_len);
+    unsigned char *crc_file = (unsigned char *)ident_slurp(crc_path, &crc_len);
+    assert(json && crc_file);
+
+    /* Exactly four bytes — not a text rendering, not a trailing newline. */
+    assert(crc_len == 4);
+
+    /* Little-endian, over the WHOLE json as written. Both halves of that matter:
+     * a byte-order flip and an off-by-one on the length are the two mutations a
+     * CRC written this way invites. */
+    uint32_t want = edf_crc32_ieee((const uint8_t *)json, json_len);
+    uint32_t got = (uint32_t)crc_file[0]
+                 | ((uint32_t)crc_file[1] << 8)
+                 | ((uint32_t)crc_file[2] << 16)
+                 | ((uint32_t)crc_file[3] << 24);
+    assert(got == want);
+    assert(got != edf_crc32_ieee((const uint8_t *)json, json_len - 1));
+
+    free(json);
+    free(crc_file);
+}
+
+static void test_identification_absent_fields_are_empty_or_zero(void)
+{
+    char dir[300], ident[400], out_path[400];
+    ident_make_dir(dir, sizeof(dir), "ident_sparse");
+    snprintf(ident, sizeof(ident), "%s/identification.json", dir);
+    ident_write_file(ident, "{\"SerialNumber\":\"ONLY\"}");
+
+    assert(edf_generate_identification_files(dir, ident) == ESP_OK);
+
+    snprintf(out_path, sizeof(out_path), "%s/Identification.json", dir);
+    char *out = ident_slurp(out_path, NULL);
+    assert(out);
+    cJSON *root = cJSON_Parse(out);
+    assert(root);
+
+    cJSON *product = ident_profile(root, "Product");
+    ident_expect_str(product, "SerialNumber", "ONLY");
+    /* Absent strings are present-and-empty, not absent and not null: the profile
+     * always carries every key. */
+    ident_expect_str(product, "UniversalIdentifier", "");
+    ident_expect_str(product, "ProductCode", "");
+    ident_expect_str(product, "ProductName", "");
+
+    cJSON *software = ident_profile(root, "Software");
+    cJSON *plat = cJSON_GetObjectItem(software, "PlatformIdentifier");
+    assert(plat && cJSON_IsNumber(plat) && plat->valuedouble == 0);
+    cJSON *dv = cJSON_GetObjectItem(software, "DataVersionIdentifier");
+    assert(dv && cJSON_IsNumber(dv) && dv->valuedouble == 0);
+
+    cJSON_Delete(root);
+    free(out);
+}
+
+static void test_identification_missing_source_is_refused(void)
+{
+    char dir[300], ident[400], json_path[400], crc_path[400];
+    ident_make_dir(dir, sizeof(dir), "ident_missing");
+    snprintf(ident, sizeof(ident), "%s/does-not-exist.json", dir);
+
+    assert(edf_generate_identification_files(dir, ident) == ESP_FAIL);
+
+    /* And it writes nothing at all: a refused generation must not leave a
+     * half-made profile behind for the next reader to trust. */
+    snprintf(json_path, sizeof(json_path), "%s/Identification.json", dir);
+    snprintf(crc_path, sizeof(crc_path), "%s/Identification.crc", dir);
+    assert(ident_slurp(json_path, NULL) == NULL);
+    assert(ident_slurp(crc_path, NULL) == NULL);
+}
+
 int main(void)
 {
     snprintf(g_root, sizeof(g_root), "%s/snt_edf_test_XXXXXX",
@@ -1075,6 +1315,17 @@ int main(void)
     run("the session's AS11 offset beats the device timezone",
         test_as11_offset_beats_device_timezone, NULL);
     run("STR pressure settings are exact cmH2O x 50", test_str_pressure_settings_exact, NULL);
+
+    run("crc32 matches the published CRC-32/ISO-HDLC check vector",
+        test_crc32_matches_the_published_check_vector, NULL);
+    run("Identification profile carries every key, with the deliberate rename",
+        test_identification_profile_shape, NULL);
+    run("Identification.crc is four bytes, little-endian crc32 of the json",
+        test_identification_crc_is_le_crc32_of_the_json, NULL);
+    run("absent identification fields become empty strings and zeroes",
+        test_identification_absent_fields_are_empty_or_zero, NULL);
+    run("a missing identification.json is refused and writes nothing",
+        test_identification_missing_source_is_refused, NULL);
 
     if (!getenv("KEEP_TEST_TREE")) rmtree(g_root);
     else printf("test tree kept at %s\n", g_root);

--- a/scripts/mutate_host.py
+++ b/scripts/mutate_host.py
@@ -93,6 +93,65 @@ def target_path(entry: str) -> str:
     return entry[1:] if entry.startswith("#") else entry
 
 EQUIV_FILE = os.path.join(HERE, "mutate_equivalent.txt")
+SURVIVOR_FILE = os.path.join(HERE, "mutation_survivors.txt")
+
+
+def environment_is_complete() -> tuple[bool, str]:
+    """(may this run rewrite the inventory, and if not why not).
+
+    ⚠️ A NARROWER ENVIRONMENT SEES FEWER SURVIVORS. Without cJSON the two EDF suites are
+    skipped and this harness reports SCOPE 2 of 80 instead of 8; every survivor in the five
+    EDF modules simply is not found. Writing the inventory from that run would DELETE those
+    entries, and the diff would read exactly like someone had fixed them.
+
+    So the inventory may only be written where the whole suite builds. Refusing is the
+    feature: an inventory that quietly narrows is worse than no inventory, because it is
+    trusted."""
+    skipped = sorted(t for t in TESTS if sources_for(t) is None)
+    if skipped:
+        return False, "these suites could not be built: " + ", ".join(skipped)
+    if not shutil.which("gcov"):
+        return False, ("gcov is absent, so reach is unknown and every mutant is run and "
+                       "classified UNASSERTED rather than UNREACHED")
+    return True, ""
+
+
+def load_inventory() -> dict[str, str]:
+    out = {}
+    if os.path.exists(SURVIVOR_FILE):
+        for line in open(SURVIVOR_FILE, encoding="utf-8"):
+            key = line.split("#", 1)[0].strip()
+            if key:
+                out[key] = line.split("#", 1)[1].strip() if "#" in line else ""
+    return out
+
+
+def write_inventory(entries: dict[str, str]) -> None:
+    with open(SURVIVOR_FILE, "w", encoding="utf-8", newline="\n") as f:
+        f.write(
+            "# UNASSERTED survivors: mutants that RAN and that every host test still passed.\n"
+            "# Committed on purpose. A gitignored copy would exist only on the machine that\n"
+            "# produced it, and the useful property of this file is that a pull request which\n"
+            "# weakens an assertion ADDS A LINE HERE, next to the change that caused it —\n"
+            "# visible in review without anyone running the sweep.\n"
+            "#\n"
+            "# NOT a list of bugs, and not a to-do list. A survivor means the suite does not\n"
+            "# distinguish this mutant from the original; whether that matters is a judgement\n"
+            "# each one needs on its own. A mutant no input can kill belongs in\n"
+            "# mutate_equivalent.txt instead, with the argument written down.\n"
+            "#\n"
+            "# Regenerate with:  python3 scripts/mutate_host.py --all --write-inventory\n"
+            "# It REFUSES on a machine where any suite is skipped — see environment_is_complete().\n"
+            "#\n"
+            "# Format:  <path>:<line>:<operator>      # the line as it stands today\n"
+            "\n")
+        # path:line:operator — and the OPERATOR CONTAINS COLONS ("arithmetic:+→-"), so this
+        # splits from the left with maxsplit=2. rsplit here silently sorted by the wrong
+        # field and then crashed on int().
+        for key in sorted(entries, key=lambda k: (k.split(":", 2)[0], int(k.split(":", 2)[1]))):
+            src = entries[key]
+            f.write(f"{key}\n" if not src else f"{key:<52} # {src}\n")
+
 
 
 def find_cjson() -> str | None:
@@ -552,6 +611,9 @@ def main() -> int:
     ap.add_argument("--limit", type=int, default=25, help="max mutants per file")
     ap.add_argument("--selftest", action="store_true")
     ap.add_argument("--cjson", help="path to cJSON.c when it is not beside the project")
+    ap.add_argument("--write-inventory", action="store_true",
+                    help="rewrite scripts/mutation_survivors.txt from this run; needs --all, "
+                         "and refuses where any suite is skipped")
     a = ap.parse_args()
 
     global CJSON
@@ -597,6 +659,7 @@ def main() -> int:
 
     equivs = load_equivalents()
     total_surv = 0
+    all_surv: dict[str, str] = {}
     for t in targets:
         if not os.path.exists(t):
             print(f"\n{t}: not found"); return 3
@@ -627,10 +690,43 @@ def main() -> int:
             print(f"     ·  UNREACHED   {r['file']}:{ln}  {op}   {src}")
         if len(r["unreached"]) > 10:
             print(f"     ·  … and {len(r['unreached']) - 10} more unreached")
+        for ln, op, src in r["unasserted"]:
+            all_surv[f"{r['file']}:{ln}:{op}"] = src.strip()
         total_surv += len(r["unasserted"])
 
     print(f"\n{total_surv} unasserted survivor(s)")
     print("UNREACHED lines need a test that reaches them; UNASSERTED need a stronger assertion.")
+
+    complete, why = environment_is_complete()
+    if a.write_inventory:
+        if not a.all:
+            print("\nREFUSED: --write-inventory needs --all. A single file cannot rewrite the "
+                  "whole inventory\n         without deleting every entry it did not look at.")
+            return 4
+        if not complete:
+            print(f"\nREFUSED to write {os.path.relpath(SURVIVOR_FILE, ROOT)}: {why}")
+            print("         This run saw less than the full suite, so writing would delete "
+                  "entries it never\n         looked for — a diff that reads exactly like "
+                  "someone had fixed them.")
+            return 4
+        write_inventory(all_surv)
+        print(f"\nwrote {os.path.relpath(SURVIVOR_FILE, ROOT)} — {len(all_surv)} survivor(s)")
+    elif a.all and os.path.exists(SURVIVOR_FILE):
+        known = load_inventory()
+        added = sorted(set(all_surv) - set(known))
+        gone = sorted(set(known) - set(all_surv))
+        print(f"\nINVENTORY  {len(known)} known, {len(added)} new, {len(gone)} no longer found")
+        if not complete:
+            print(f"           ⚠️ comparison is UNRELIABLE here: {why}")
+            print("           Entries under 'no longer found' may simply not have been looked for.")
+        for k in added:
+            print(f"     + NEW       {k}   {all_surv[k]}")
+        for k in gone:
+            print(f"     - was here  {k}")
+        if added:
+            print("           A new survivor is an assertion that stopped distinguishing "
+                  "something.\n           Regenerate with --all --write-inventory once it is "
+                  "understood, not before.")
     return 1 if total_surv else 0
 
 

--- a/scripts/mutation_survivors.txt
+++ b/scripts/mutation_survivors.txt
@@ -1,0 +1,56 @@
+# UNASSERTED survivors: mutants that RAN and that every host test still passed.
+# Committed on purpose. A gitignored copy would exist only on the machine that
+# produced it, and the useful property of this file is that a pull request which
+# weakens an assertion ADDS A LINE HERE, next to the change that caused it —
+# visible in review without anyone running the sweep.
+#
+# NOT a list of bugs, and not a to-do list. A survivor means the suite does not
+# distinguish this mutant from the original; whether that matters is a judgement
+# each one needs on its own. A mutant no input can kill belongs in
+# mutate_equivalent.txt instead, with the argument written down.
+#
+# Regenerate with:  python3 scripts/mutate_host.py --all --write-inventory
+# It REFUSES on a machine where any suite is skipped — see environment_is_complete().
+#
+# Format:  <path>:<line>:<operator>      # the line as it stands today
+
+main/edf_annotations.c:63:arithmetic:-→+             # strncpy(path, edf_path, sizeof(path) - 1);
+main/edf_annotations.c:64:arithmetic:-→+             # path[sizeof(path) - 1] = '\0';
+main/edf_annotations.c:68:arithmetic:*→/             # snt_event_t *ev_list = malloc(capacity * sizeof(snt_event_t));
+main/edf_annotations.c:83:logical:&&→||              # if (data_id && cJSON_IsString(data_id)) {
+main/edf_annotations.c:151:relational:<→<=           # for (size_t i = 0; i + 1 < count; i++) {
+main/edf_gen.c:111:logical:||→&&                     # if (!session_dir || !session_id || !out_root) return ESP_ERR_INVALID_A
+main/edf_gen.c:126:relational:<→<=                   # if (start_epoch_ms < 946684800000LL) {  /* < 2000-01-01T00:00:00Z */
+main/edf_gen.c:161:arithmetic:-→+                    # as11_time_noon_day(start_epoch_ms - clock_drift_ms, day_folder, sizeof
+main/edf_gen.c:245:relational:<→<=                   # if (zle_ntp > 0 && zle_ntp > start_epoch_ms && zle_ntp < end_epoch_ms)
+main/edf_gen.c:258:relational:>→>=                   # if (zle_ntp > 0) {
+main/edf_gen.c:269:relational:>→>=                   # if (maskon_as11 > 0) {
+main/edf_gen.c:270:arithmetic:+→-                    # int64_t maskon_ntp = maskon_as11 + clock_drift_ms;
+main/edf_gen.c:271:relational:<→<=                   # if (maskon_ntp > start_epoch_ms && maskon_ntp < end_epoch_ms) {
+main/edf_gen.c:309:relational:<=→<                   # if (end_ntp <= 0) {
+main/edf_gen.c:311:relational:>→>=                   # if (maskoff_as11 > 0) {
+main/edf_gen.c:312:arithmetic:+→-                    # end_ntp = maskoff_as11 + clock_drift_ms;
+main/edf_gen.c:316:relational:>→>=                   # if (end_ntp > 0) {
+main/edf_header.c:71:relational:>→>=                 # if (len > width) len = width;
+main/edf_header.c:84:relational:<→<=                 # if (written < 0 || (size_t)written >= tmp_path_len) {
+main/edf_header.c:125:arithmetic:+→-                 # char *buf = malloc(fsize + 1);
+main/edf_header.c:188:arithmetic:+→-                 # edf_write_field(hdr + 88, 80, recording_id);         /* recording ID *
+main/edf_header.c:189:arithmetic:+→-                 # edf_write_field(hdr + 168, 8, start_date);           /* start date */
+main/edf_waveform.c:32:relational:<=→<               # if (!f || channels_in_file <= 0) return UINT32_MAX;
+main/edf_waveform.c:35:relational:<→<=               # if (cur < 0) return UINT32_MAX;
+main/edf_waveform.c:38:relational:<→<=               # if (fseek(f, cur, SEEK_SET) != 0 || end < 0) return UINT32_MAX;
+main/edf_waveform.c:40:relational:<=→<               # if (end <= (long)sizeof(snt_header_t)) return 0;
+main/edf_waveform.c:61:logical:&&→||                 # if (events && cJSON_IsArray(events)) {
+main/edf_waveform.c:63:relational:<→<=               # for (int i = 0; i < n; i++) {
+main/edf_waveform.c:67:logical:||→&&                 # if (!label || !cJSON_IsString(label)) continue;
+main/edf_waveform.c:70:logical:&&→||                 # if (rt && cJSON_IsString(rt)) {
+main/edf_waveform.c:99:logical:&&→||                 # if (events && cJSON_IsArray(events)) {
+main/edf_waveform.c:101:relational:<→<=              # for (int i = 0; i < n; i++) {
+main/edf_waveform.c:105:logical:||→&&                # if (!label || !cJSON_IsString(label)) continue;
+main/edf_waveform.c:108:logical:&&→||                # if (rt && cJSON_IsString(rt)) {
+main/edf_waveform.c:135:logical:&&→||                # if (data_id && cJSON_IsString(data_id) &&
+main/edf_waveform.c:138:logical:&&→||                # if (events && cJSON_IsArray(events)) {
+main/edf_waveform.c:140:relational:<→<=              # for (int i = 0; i < n; i++) {
+main/edf_waveform.c:144:logical:&&→||                # if (val && cJSON_IsNumber(val) &&
+main/edf_waveform.c:148:logical:&&→||                # if (rt && cJSON_IsString(rt)) {
+main/edf_waveform.c:151:relational:>→>=              # if (as11_ms > 0)


### PR DESCRIPTION
Three things, in the order they were found. The first is the reason for the other two.

## 1. `edf_generate_identification_files()` had no test at all

After #254 the harness could finally see `edf_header.c`, and its verdict was `VOID`: the canary lands on `edf_generate_identification_files()`, no test called it, so emptying the whole function body changed nothing and the harness refused a verdict on all 456 lines rather than report a clean sweep it had not earned. That is fail-closed working — but the file it was protecting us from is the one that writes the profile the AS11 reads back.

Five tests, written to pin what a mutant would change rather than to reach the function:

- the profile carries every key, including the two that are deliberately always blank
- a numeric `ProductCode` is coerced to a string, because the source writes it either way and the profile always carries a string
- **`ProfileVariantIdentifier` in the source becomes `ProfileVariationIdentifier` in the output.** It reads like a typo and is not. Pinned so that "fixing" it breaks a test instead of a device
- absent fields are present-and-empty or zero, never missing
- `Identification.crc` is exactly four bytes, little-endian, over the whole json
- a missing `identification.json` is refused **and writes nothing**

`edf_header.c` now produces a real verdict:

```
canary: edf_generate_identification_files() body emptied → killed
killed 15   stillborn 3   unasserted 5   unreached 2
```

**One note on the CRC test, because the first version of it was wrong in an instructive way.** It asserted that the four bytes on disk matched `edf_crc32_ieee()` over the json — which is self-referential: a mutation inside the CRC moves both sides of the comparison equally. The harness said so immediately, reporting the loop bounds at lines 50 and 52 and the shift at line 56 as surviving a test that appeared to cover them. The fix is an oracle the code cannot move: CRC-32/ISO-HDLC publishes a check value, `0xCBF43926` for `"123456789"`. With that added those three mutants die, and the count goes from 12 killed / 8 unasserted to 15 / 5.

The five that remain are in other functions and left for a separate pass: `edf_write_field`'s truncation at :71, the atomic-path guard at :84, `edf_read_bin_file`'s malloc at :125, and the two header offsets at :188 and :189.

## 2. The searching harness runs nowhere, so: weekly

`scripts/mutate_host.py` has been in the repo since #232 with nothing invoking it — the same gap #221 closed for `mutants.py` — and #254 only made it *able* to run on a runner. The two halves are not interchangeable, which is why this is a second workflow and not a step in `mutation.yml`:

| | | |
|---|---|---|
| `mutants.py` | **pins** | a fixed set that must all die, 15/15 today. Red means someone broke a working test. 30s, belongs on every push, and is where it already is |
| `mutate_host.py` | **searches** | generates mutants it has never seen. 40 unasserted survivors on a green tree, so as a gate it is permanently red |

A permanently red gate teaches people to ignore CI, which is the reasoning that already made lint's style tier advisory. So this reports and does not block. The one thing it **does** fail on is `VOID` — a surviving canary or a failing baseline means the harness could not detect a change it made on purpose, and every number in the log is then worthless. Reporting that as a quiet success is how a mutation score becomes a comfort.

**Why weekly and not on push, measured rather than assumed:** 391s for `--all` against 30s for `mutants.py`. The slowest per-push job here is the IDF build at about 200s and the jobs run concurrently, so a 391s job becomes the critical path and roughly doubles the wait on every pull request — to deliver a report nobody must act on before merging. Saturday 20:00 UTC puts the result in place for Sunday.

## 3. The survivor inventory is committed, not generated

A weekly report saying "40 survivors" is a number people read twice and then stop reading, and it carries no memory: nobody can tell whether this week's 40 are last week's 40.

`scripts/mutation_survivors.txt` is that memory, and it is **checked in**. The property worth having is not the trend — it is that a pull request weakening an assertion **adds a line here, in the diff, next to the change that caused it**, seen by a reviewer who never ran the sweep. A gitignored copy would exist only on the machine that made it, and two developers would hold different baselines without knowing. It is the argument `scripts/mutate_equivalent.txt` already won, applied to the open questions instead of the closed ones.

Verified deterministic before committing anything: two runs over the same tree give an identical classification, and the format carries no paths, timings or counts — the same `path:line:operator` convention as `mutate_equivalent.txt`, so there is one format rather than two.

**The refusal is the point.** A narrower environment finds fewer survivors: without cJSON the two EDF suites are skipped, `SCOPE` drops from 8 of 80 to 2 of 80, and every survivor in the five EDF modules is simply not looked for. Writing the inventory from that run would *delete* those entries, and the diff would read exactly like someone had fixed them. So `--write-inventory` requires `--all` and refuses where any suite is skipped or gcov is missing:

```
with cJSON      may write inventory: True
without cJSON   may write inventory: False — these suites could not be built:
                as11_events_test, edf_gen_test, edf_properties_test
```

Without the flag it compares instead, and when the environment is degraded it says the comparison is unreliable rather than presenting absences as fixes. Two runs on a clean tree: `INVENTORY 40 known, 0 new, 0 no longer found`.

## Also here: an apt fix, because CI went red today for none of these reasons

Every job that installs a package runs `sudo apt-get update`, and the `ubuntu-latest` image ships apt sources for Google Chrome and Microsoft that this project never installs from. Today one served a bad index and `apt-get update` exited 100:

```
E: Failed to fetch https://dl.google.com/linux/chrome-stable/.../Packages.gz  Hash Sum mismatch
##[error]Process completed with exit code 100
```

`host-tests`, `lint` and `mutation` went red together, at step 3 with step 4 skipped — a third-party repository reddening a firmware gate before any project code ran. It survived a re-run, so an outage rather than a flake.

The sources are **matched by content, not by filename**. My first attempt named `google-chrome.list`, removed nothing, and failed identically; the image actually uses `google-chrome.sources`, deb822 format. A workaround that silently matches nothing is the worst kind of wrong, so the loop echoes what it removes:

```
removing apt source this project does not use: /etc/apt/sources.list.d/microsoft-prod.list
removing apt source this project does not use: /etc/apt/sources.list.d/google-chrome.sources
```

Removed rather than swallowed with `|| true`, which would also hide a genuine failure to reach the Ubuntu archive — the one repository these jobs do depend on.

**Overlap worth knowing before you merge:** the identical fix is on #249 too, in `host-tests.yml` and `mutation.yml`, because that PR's own runs were failing the same way. Same text in both, and neither branch otherwise modifies those two files, so they merge in either order. `lint.yml` is hardened only on #249, where it is already being rewritten.

## What I could not test

`workflow_dispatch` requires the workflow file on the default branch, so the fork refused to dispatch the sweep:

```
HTTP 404: workflow mutation-sweep.yml not found on the default branch
```

The command it runs is verified (391s, real log, both guard conditions dry-run against a real and a simulated VOID log) and the YAML parses, but the job wiring itself is unexercised until it lands somewhere. If you would rather see it run before trusting the schedule, `workflow_dispatch` is on it, so one manual run after merge will tell you.

Host suite 5 run, 0 failed, 0 skipped; `edf_gen_test` 16 → 21 passing. Merges clean onto `3e8d371`.
