### PR TITLE
test(as11_ble): extract the reconnect schedule and the AD salvage parser, and test both

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,4 +1,4 @@
-idf_component_register(SRCS "main.c" "bsp_power.c" "bsp_display.c" "net_provision.c" "as11_ble.c" "as11_reconnect.c"
+idf_component_register(SRCS "main.c" "bsp_power.c" "bsp_display.c" "net_provision.c" "as11_ble.c" "as11_reconnect.c" "as11_adv.c"
                            "sd_storage.c" "session_writer.c" "time_sync.c"
                            "post_therapy.c" "edf_gen.c" "edf_header.c" "edf_waveform.c" "edf_annotations.c" "edf_summary.c" "log_stream.c" "device_settings.c"
                            "psram_task.c" "bsp_audio.c" "bsp_i2c.c" "bsp_touch.c" "session_graph.c" "nvs_writer.c"

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,4 +1,4 @@
-idf_component_register(SRCS "main.c" "bsp_power.c" "bsp_display.c" "net_provision.c" "as11_ble.c"
+idf_component_register(SRCS "main.c" "bsp_power.c" "bsp_display.c" "net_provision.c" "as11_ble.c" "as11_reconnect.c"
                            "sd_storage.c" "session_writer.c" "time_sync.c"
                            "post_therapy.c" "edf_gen.c" "edf_header.c" "edf_waveform.c" "edf_annotations.c" "edf_summary.c" "log_stream.c" "device_settings.c"
                            "psram_task.c" "bsp_audio.c" "bsp_i2c.c" "bsp_touch.c" "session_graph.c" "nvs_writer.c"

--- a/main/as11_adv.c
+++ b/main/as11_adv.c
@@ -1,0 +1,84 @@
+/*
+ * SomnoTrace - salvage parser for truncated BLE advertising data
+ * Copyright (C) 2026 Ilya Kruchinin <https://github.com/ilyakruchinin>
+ *
+ * This file is part of SomnoTrace.
+ *
+ * SomnoTrace is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * SomnoTrace is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ADDITIONAL TERM (GPLv3 Section 7(b)): Redistributions must preserve the
+ * attribution "Based on SomnoTrace, originally created by Ilya Kruchinin".
+ */
+#include "as11_adv.h"
+
+#include <string.h>
+
+/* AD types, Core Specification Supplement Part A §1. */
+#define AD_TYPE_UUID16_INCOMPLETE   0x02
+#define AD_TYPE_UUID16_COMPLETE     0x03
+#define AD_TYPE_NAME_SHORTENED      0x08
+#define AD_TYPE_NAME_COMPLETE       0x09
+
+void as11_adv_salvage(const uint8_t *data, int len, as11_adv_fields_t *out)
+{
+    memset(out, 0, sizeof(*out));
+    if (data == NULL || len <= 0) {
+        return;
+    }
+
+    /* An AD structure is: length byte, type byte, then length-1 bytes of data.
+     * The length byte counts the TYPE as well as the data, which is the detail
+     * every hand-written parser of this format gets wrong once. */
+    for (int off = 0; off + 1 < len; ) {
+        uint8_t ad_len = data[off];
+
+        /* TWO WAYS TO STOP, AND BOTH MATTER.
+         *
+         * ad_len == 0 is the padding an advertiser uses to fill the rest of the
+         * payload — but it is also the value that makes `off += 1 + ad_len`
+         * advance by one forever if the type is never inspected. Stopping here
+         * is what makes this loop terminate on every input.
+         *
+         * off + 1 + ad_len > len is the truncated field: the structure claims
+         * more bytes than the payload holds. This is the AS11's own trailing
+         * 0x1b field, and it is why we are in this function rather than using
+         * NimBLE's parser. Reading it would run off the end of the buffer. */
+        if (ad_len == 0 || off + 1 + ad_len > len) {
+            out->truncated = true;
+            break;
+        }
+
+        uint8_t ad_type = data[off + 1];
+        const uint8_t *ad_data = data + off + 2;
+        int ad_data_len = ad_len - 1;     /* never negative: ad_len 0 stopped above */
+
+        if (ad_type == AD_TYPE_NAME_COMPLETE || ad_type == AD_TYPE_NAME_SHORTENED) {
+            /* A LATER name replaces an earlier one. The spec does not permit two
+             * Local Name structures in one payload, so either choice is a choice
+             * about malformed input; this preserves the behaviour that shipped,
+             * and the test pins it so a change is deliberate rather than
+             * incidental. */
+            out->name = ad_data;
+            out->name_len = ad_data_len;
+        } else if (ad_type == AD_TYPE_UUID16_COMPLETE ||
+                   ad_type == AD_TYPE_UUID16_INCOMPLETE) {
+            /* An odd byte count means a trailing half UUID; integer division
+             * drops it rather than reading one byte past the field. */
+            out->uuids16 = ad_data;
+            out->num_uuids16 = ad_data_len / 2;
+        }
+
+        out->fields++;
+        off += 1 + ad_len;
+    }
+}

--- a/main/as11_adv.h
+++ b/main/as11_adv.h
@@ -1,0 +1,78 @@
+/*
+ * SomnoTrace - salvage parser for truncated BLE advertising data
+ * Copyright (C) 2026 Ilya Kruchinin <https://github.com/ilyakruchinin>
+ *
+ * This file is part of SomnoTrace.
+ *
+ * SomnoTrace is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * SomnoTrace is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ADDITIONAL TERM (GPLv3 Section 7(b)): Redistributions must preserve the
+ * attribution "Based on SomnoTrace, originally created by Ilya Kruchinin".
+ */
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/*
+ * WHY THIS EXISTS AT ALL. NimBLE's ble_hs_adv_parse_fields() rejects an entire
+ * advertising payload if any AD structure in it is malformed, and the AS11's
+ * ADV_IND carries a trailing field (type 0x1b) that is one byte short — so a
+ * perfectly good Local Name earlier in the same payload is thrown away with it.
+ * The device would never appear in a scan. This walks the structures by hand and
+ * keeps the ones that are intact.
+ *
+ * WHY IT IS ITS OWN TRANSLATION UNIT. It runs ONLY on payloads NimBLE has
+ * already rejected as malformed — that is, only on the input least likely to be
+ * seen in normal use and most likely to have been shaped deliberately, since
+ * anything within radio range can advertise anything. That is the code you least
+ * want to be untestable, and inside gap_event() it was: reaching it needed a
+ * radio, a scan, and a peer emitting a broken packet. Here it is a function over
+ * a byte buffer.
+ *
+ * It does NOT validate. Salvaging a malformed payload is the whole job; the
+ * contract is only that whatever comes back points inside the caller's buffer.
+ */
+
+typedef struct {
+    /* NOT NUL-terminated, and not validated as UTF-8 — raw advertising bytes.
+     * NULL when no Local Name field survived. */
+    const uint8_t *name;
+    int            name_len;
+
+    /* Raw little-endian 16-bit UUIDs, two bytes each, `num_uuids16` of them.
+     * Deliberately kept as bytes rather than a uint16_t array: the field starts
+     * at an arbitrary offset in the payload, so it carries no alignment
+     * guarantee, and handing back a typed pointer would invite an unaligned
+     * load. The caller casts as it always has; keeping the cast at the call
+     * site keeps it visible. */
+    const uint8_t *uuids16;
+    int            num_uuids16;
+
+    /* How many AD structures were walked before the end or the first bad one. */
+    int            fields;
+    /* True when the walk stopped on a malformed length rather than reaching the
+     * end cleanly. Not an error — it is the normal case for the AS11 — but it
+     * distinguishes "nothing was there" from "we stopped early". */
+    bool           truncated;
+} as11_adv_fields_t;
+
+/**
+ * Walk `len` bytes of advertising data, keeping the Local Name (AD types 0x08,
+ * 0x09) and the 16-bit Service UUID list (0x02, 0x03).
+ *
+ * Every pointer returned in `out` points INSIDE [data, data+len). A NULL `data`
+ * or a non-positive `len` yields an all-zero result rather than a fault.
+ * `out` must not be NULL.
+ */
+void as11_adv_salvage(const uint8_t *data, int len, as11_adv_fields_t *out);

--- a/main/as11_ble.c
+++ b/main/as11_ble.c
@@ -39,6 +39,7 @@
  */
 
 #include "as11_ble.h"
+#include "as11_reconnect.h"
 #include "session_writer.h"
 #include "bsp_display.h"
 #include "time_sync.h"
@@ -2005,19 +2006,23 @@ static void reconnect_task(void *arg)
 
         set_state(AS11_STATUS_CONNECTING);
 
-        /* Two-phase retry:
-         * Phase 1 — fast: 3 attempts with 2-4s backoff for transient disconnect
-         *   (AS11 needs a few seconds to restart advertising).
-         * Phase 2 — slow: 60s backoff between attempts for when the AS11 is off
-         *   at boot and turned on later (with 30s BLE connect timeout, giving a
-         *   ~90s overall cycle).  Without this, a single failed
-         *   reconnect_task at boot means the ST never connects to the AS11
-         *   until manually rebooted. */
+        /* Two-phase retry. The SCHEDULE lives in as11_reconnect.c, which has no
+         * ESP-IDF dependency and is covered by scripts/as11_reconnect_test.c;
+         * this loop owns only the radio work and the abort checks.
+         * Phase 1 — fast: AS11_RECONNECT_FAST_ATTEMPTS tries, 4s then 6s, for a
+         *   transient disconnect (the AS11 needs a few seconds to restart
+         *   advertising).
+         * Phase 2 — slow: AS11_RECONNECT_SLOW_DELAY_S between attempts for when
+         *   the AS11 is off at boot and turned on later (with the 30s BLE connect
+         *   timeout, a ~90s cycle).  Without this, a single failed reconnect_task
+         *   at boot means the ST never connects to the AS11 until manually
+         *   rebooted. */
         bool connected = false;
-        for (int attempt = 1; attempt <= 3 && !connected; attempt++) {
-            if (attempt > 1) {
-                int delay_s = attempt * 2;
-                ESP_LOGI(TAG, "reconnect: retry %d/3 in %ds", attempt, delay_s);
+        for (int attempt = 1; attempt <= AS11_RECONNECT_FAST_ATTEMPTS && !connected; attempt++) {
+            int delay_s = as11_reconnect_delay_s(attempt);
+            if (delay_s > 0) {
+                ESP_LOGI(TAG, "reconnect: retry %d/%d in %ds",
+                         attempt, AS11_RECONNECT_FAST_ATTEMPTS, delay_s);
                 vTaskDelay(pdMS_TO_TICKS(delay_s * 1000));
             }
             if (!s_pair_cache.valid || s_manual_disconnect) {
@@ -2031,8 +2036,8 @@ static void reconnect_task(void *arg)
                 connected = true;
                 break;
             }
-            ESP_LOGW(TAG, "reconnect: connect/discover attempt %d/3 failed: %s",
-                     attempt, as11_ble_get_error());
+            ESP_LOGW(TAG, "reconnect: connect/discover attempt %d/%d failed: %s",
+                     attempt, AS11_RECONNECT_FAST_ATTEMPTS, as11_ble_get_error());
             if (s_conn_handle != BLE_HS_CONN_HANDLE_NONE) {
                 ble_gap_terminate(s_conn_handle, BLE_ERR_REM_USER_CONN_TERM);
                 s_conn_handle = BLE_HS_CONN_HANDLE_NONE;
@@ -2051,8 +2056,12 @@ static void reconnect_task(void *arg)
                 return;
             }
             slow_attempt++;
-            ESP_LOGI(TAG, "reconnect: waiting 60s before slow retry %d...", slow_attempt);
-            for (int i = 0; i < 60; i++) {
+            /* The same schedule function, continuing the attempt count past the
+             * fast phase — so both phases read their timing from one place. */
+            int wait_s = as11_reconnect_delay_s(AS11_RECONNECT_FAST_ATTEMPTS + slow_attempt);
+            ESP_LOGI(TAG, "reconnect: waiting %ds before slow retry %d...",
+                     wait_s, slow_attempt);
+            for (int i = 0; i < wait_s; i++) {
                 vTaskDelay(pdMS_TO_TICKS(1000));
                 if (!s_pair_cache.valid || s_manual_disconnect) break;
             }

--- a/main/as11_ble.c
+++ b/main/as11_ble.c
@@ -40,6 +40,7 @@
 
 #include "as11_ble.h"
 #include "as11_reconnect.h"
+#include "as11_adv.h"
 #include "session_writer.h"
 #include "bsp_display.h"
 #include "time_sync.h"
@@ -900,23 +901,17 @@ static int gap_event(struct ble_gap_event *event, void *arg)
             ESP_LOGD(TAG, "Scan report from %s: parse failed (rc=%d), "
                      "trying manual AD parse", addr_str, rc);
             memset(&f, 0, sizeof(f));
-            for (int off = 0; off + 1 < raw_len; ) {
-                uint8_t ad_len = raw[off];
-                if (ad_len == 0 || off + 1 + ad_len > raw_len) break;
-                uint8_t ad_type = raw[off + 1];
-                const uint8_t *ad_data = raw + off + 2;
-                int ad_data_len = ad_len - 1;
-                if (ad_type == 0x09 || ad_type == 0x08) {
-                    /* Complete or Shortened Local Name */
-                    f.name = ad_data;
-                    f.name_len = ad_data_len;
-                } else if (ad_type == 0x03 || ad_type == 0x02) {
-                    /* Complete or Incomplete 16-bit Service UUID list */
-                    f.uuids16 = (void *)ad_data;
-                    f.num_uuids16 = ad_data_len / 2;
-                }
-                off += 1 + ad_len;
-            }
+            as11_adv_fields_t sal;
+            as11_adv_salvage(raw, raw_len, &sal);
+            f.name        = sal.name;
+            f.name_len    = (uint8_t)sal.name_len;
+            /* The cast stays HERE rather than inside as11_adv_salvage(): a
+             * UUID list begins at an arbitrary offset in the payload and so
+             * carries no alignment guarantee, and the salvage parser returns
+             * bytes precisely so that the one place assuming otherwise is
+             * visible. Unchanged from what shipped. */
+            f.uuids16     = (const ble_uuid16_t *)sal.uuids16;
+            f.num_uuids16 = (uint8_t)sal.num_uuids16;
         }
 
         bool match = false;

--- a/main/as11_reconnect.c
+++ b/main/as11_reconnect.c
@@ -1,0 +1,38 @@
+/*
+ * SomnoTrace - AS11 reconnect backoff policy
+ * Copyright (C) 2026 Ilya Kruchinin <https://github.com/ilyakruchinin>
+ *
+ * This file is part of SomnoTrace.
+ *
+ * SomnoTrace is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * SomnoTrace is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ADDITIONAL TERM (GPLv3 Section 7(b)): Redistributions must preserve the
+ * attribution "Based on SomnoTrace, originally created by Ilya Kruchinin".
+ */
+#include "as11_reconnect.h"
+
+int as11_reconnect_delay_s(int attempt)
+{
+    if (attempt <= 1) {
+        return 0;
+    }
+    if (attempt <= AS11_RECONNECT_FAST_ATTEMPTS) {
+        /* 4 s then 6 s. The comment this replaced said "2-4s backoff" while the
+         * code computed attempt * 2, i.e. 4 and 6 — the description had drifted
+         * from the arithmetic. The arithmetic is kept; the description now
+         * matches it, and the test pins the values so they cannot drift apart
+         * again silently. */
+        return attempt * 2;
+    }
+    return AS11_RECONNECT_SLOW_DELAY_S;
+}

--- a/main/as11_reconnect.h
+++ b/main/as11_reconnect.h
@@ -1,0 +1,68 @@
+/*
+ * SomnoTrace - AS11 reconnect backoff policy
+ * Copyright (C) 2026 Ilya Kruchinin <https://github.com/ilyakruchinin>
+ *
+ * This file is part of SomnoTrace.
+ *
+ * SomnoTrace is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * SomnoTrace is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ADDITIONAL TERM (GPLv3 Section 7(b)): Redistributions must preserve the
+ * attribution "Based on SomnoTrace, originally created by Ilya Kruchinin".
+ */
+#pragma once
+
+/*
+ * HOW LONG TO WAIT BEFORE THE NEXT RECONNECT ATTEMPT, and nothing else.
+ *
+ * This is deliberately a separate translation unit with NO ESP-IDF dependency.
+ * The policy used to live inline in as11_ble.c's reconnect_task, interleaved
+ * with vTaskDelay() and vTaskDelete(), which meant it could not be exercised
+ * without a radio and a scheduler — so it never was. It has been changed three
+ * times regardless: an F1 retry limit for unresponsive O2 Ring firmware, a
+ * clarification of the slow-retry timing, and a report about the reconnect
+ * retries themselves. A number that keeps being adjusted and can never be
+ * checked is worth eight lines and a test.
+ *
+ * Retrying against a peer that does not answer is the one BLE failure mode no
+ * amount of host-stack quality removes: a peripheral out of range, asleep, or
+ * wedged is indistinguishable from one that is about to reply. The only
+ * defences are a bounded fast phase and a slow phase that costs little, which
+ * is exactly what this encodes.
+ */
+
+/* Attempts in the fast phase. The AS11 needs a few seconds to restart
+ * advertising after a transient drop, so the first few retries are close
+ * together and cheap. */
+#define AS11_RECONNECT_FAST_ATTEMPTS   3
+
+/* The slow phase runs unbounded on purpose: the AS11 may simply be switched
+ * off at boot and turned on hours later, and without this the device would
+ * never reconnect until someone power-cycled it. With the 30 s connect
+ * timeout this is roughly a 90 s cycle, which is negligible on mains power. */
+#define AS11_RECONNECT_SLOW_DELAY_S   60
+
+/**
+ * Seconds to wait BEFORE making attempt number `attempt`.
+ *
+ * `attempt` is 1-based and counts across BOTH phases, so attempt 4 is the
+ * first slow retry. Attempt 1 is immediate.
+ *
+ *   1 -> 0      the first try, no delay
+ *   2 -> 4      fast phase
+ *   3 -> 6      fast phase
+ *   4+ -> 60    slow phase, forever
+ *
+ * Non-positive input returns 0 rather than a negative delay: a caller that
+ * has lost count should retry immediately, not compute a nonsense sleep.
+ */
+int as11_reconnect_delay_s(int attempt);

--- a/scripts/as11_adv_test.c
+++ b/scripts/as11_adv_test.c
@@ -1,0 +1,234 @@
+/*
+ * SomnoTrace - host tests for the advertising-data salvage parser
+ * Copyright (C) 2026 Ilya Kruchinin <https://github.com/ilyakruchinin>
+ *
+ * This file is part of SomnoTrace.
+ *
+ * SomnoTrace is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * SomnoTrace is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ADDITIONAL TERM (GPLv3 Section 7(b)): Redistributions must preserve the
+ * attribution "Based on SomnoTrace, originally created by Ilya Kruchinin".
+ *
+ * ---------------------------------------------------------------------------
+ * This parser runs only on payloads NimBLE has already rejected as malformed,
+ * which is exactly the input an attacker in radio range controls and exactly the
+ * input a normal day never produces. So the cases here are mostly the broken
+ * ones, and the last test is a containment property over pseudo-random bytes:
+ * whatever comes back must point inside the caller's buffer.
+ */
+#include "as11_adv.h"
+
+#include <stdio.h>
+#include <string.h>
+
+static int n_pass, n_fail;
+
+static void ok(const char *what, int cond)
+{
+    if (cond) { n_pass++; } else { n_fail++; printf("  FAIL %s\n", what); }
+}
+
+static void eq(const char *what, long got, long want)
+{
+    if (got == want) { n_pass++; }
+    else { n_fail++; printf("  FAIL %s: got %ld, want %ld\n", what, got, want); }
+}
+
+int main(void)
+{
+    as11_adv_fields_t f;
+
+    /* ---- a well-formed payload -------------------------------------------- */
+    {
+        const uint8_t adv[] = {
+            0x03, 0x03, 0x56, 0xfd,                     /* UUID16 list: 0xfd56 */
+            0x05, 0x09, 'A', 'S', '1', '1',             /* complete local name */
+        };
+        as11_adv_salvage(adv, (int)sizeof(adv), &f);
+        eq("well-formed: fields", f.fields, 2);
+        ok("well-formed: not truncated", !f.truncated);
+        eq("well-formed: name_len", f.name_len, 4);
+        ok("well-formed: name bytes", f.name && memcmp(f.name, "AS11", 4) == 0);
+        eq("well-formed: one uuid", f.num_uuids16, 1);
+        ok("well-formed: uuid bytes", f.uuids16 &&
+           f.uuids16[0] == 0x56 && f.uuids16[1] == 0xfd);
+    }
+
+    /* ---- THE AS11's OWN PAYLOAD: a good name, then a field one byte short.
+     * This is the case the whole function exists for. NimBLE discards the lot;
+     * the name must survive. ------------------------------------------------ */
+    {
+        const uint8_t adv[] = {
+            0x05, 0x09, 'A', 'S', '1', '1',   /* complete local name */
+            0x05, 0x1b, 0x01, 0x02, 0x03,     /* claims 5, only 4 bytes follow */
+        };
+        as11_adv_salvage(adv, (int)sizeof(adv), &f);
+        eq("truncated tail: name still salvaged", f.name_len, 4);
+        ok("truncated tail: name bytes", f.name && memcmp(f.name, "AS11", 4) == 0);
+        ok("truncated tail: flagged", f.truncated);
+        eq("truncated tail: only the good field counted", f.fields, 1);
+    }
+
+    /* ---- ad_len == 0 TERMINATES THE WALK.
+     * Without this check `off += 1 + ad_len` advances by one and the loop runs
+     * to the end of the buffer one byte at a time — or forever, if the bound
+     * were ever written differently. It is the single most important line in
+     * the parser. ------------------------------------------------------------ */
+    {
+        const uint8_t adv[] = { 0x05, 0x09, 'A', 'S', '1', '1', 0x00, 0x00, 0x00 };
+        as11_adv_salvage(adv, (int)sizeof(adv), &f);
+        eq("zero length stops: name kept", f.name_len, 4);
+        eq("zero length stops: one field", f.fields, 1);
+        ok("zero length stops: flagged", f.truncated);
+    }
+
+    /* ---- a field claiming more than the payload holds --------------------- */
+    {
+        const uint8_t adv[] = { 0x20, 0x09, 'A', 'S' };   /* claims 32 bytes */
+        as11_adv_salvage(adv, (int)sizeof(adv), &f);
+        eq("overrun: nothing salvaged", f.fields, 0);
+        ok("overrun: no name", f.name == NULL);
+        ok("overrun: flagged", f.truncated);
+    }
+
+    /* ---- two name fields: the LAST wins, pinned deliberately --------------- */
+    {
+        const uint8_t adv[] = {
+            0x05, 0x09, 'f', 'i', 'r', 's',
+            0x05, 0x09, 'l', 'a', 's', 't',
+        };
+        as11_adv_salvage(adv, (int)sizeof(adv), &f);
+        eq("two names: both walked", f.fields, 2);
+        ok("two names: the last one wins", f.name && memcmp(f.name, "last", 4) == 0);
+    }
+
+    /* ---- a name field with no data at all ---------------------------------- */
+    {
+        const uint8_t adv[] = { 0x01, 0x09, 0x03, 0x03, 0x56, 0xfd };
+        as11_adv_salvage(adv, (int)sizeof(adv), &f);
+        eq("empty name: len 0", f.name_len, 0);
+        eq("empty name: uuid still found", f.num_uuids16, 1);
+        ok("empty name: walk continued", f.fields == 2);
+    }
+
+    /* ---- an odd number of UUID bytes drops the trailing half --------------- */
+    {
+        const uint8_t adv[] = { 0x06, 0x03, 0x56, 0xfd, 0x11, 0x22, 0x33 };
+        as11_adv_salvage(adv, (int)sizeof(adv), &f);
+        eq("odd uuid bytes: 5 bytes -> 2 uuids", f.num_uuids16, 2);
+    }
+
+    /* ---- A PAYLOAD ENDING EXACTLY ON A BOUNDARY IS NOT TRUNCATED.
+     * Found by the mutation harness: flipping the loop bound `off + 1 < len` to
+     * `<=` leaves every salvaged field identical and only changes whether the
+     * walk sets `truncated` on a payload whose last field ends one byte from the
+     * end. Nothing asserted that, so the mutant lived. ---------------------- */
+    {
+        const uint8_t exact[] = { 0x05, 0x09, 'A', 'S', '1', '1' };
+        as11_adv_salvage(exact, (int)sizeof(exact), &f);
+        ok("exact fit: not truncated", !f.truncated);
+        eq("exact fit: one field", f.fields, 1);
+
+        /* One stray byte after the last field: off + 1 == len, so the walk
+         * exits on its loop condition and never inspects it. The shipped
+         * parser calls that clean, not truncated — pinned in that direction
+         * because it is the ORIGINAL that leaves the flag false and the `<=`
+         * mutant that sets it. */
+        const uint8_t trailing[] = { 0x05, 0x09, 'A', 'S', '1', '1', 0x07 };
+        as11_adv_salvage(trailing, (int)sizeof(trailing), &f);
+        ok("one trailing byte: still clean, the stray byte is never read",
+           !f.truncated);
+        eq("one trailing byte: name still kept", f.name_len, 4);
+        eq("one trailing byte: one field", f.fields, 1);
+    }
+
+    /* ---- AN UNRELATED AD TYPE IS NOT A UUID LIST.
+     * Also found by the harness: turning the second UUID comparison into `!=`
+     * makes the `||` true for almost every type, so a Flags or Tx-Power field
+     * would be handed back as service UUIDs. No test used a third type, so the
+     * mutant survived. ------------------------------------------------------ */
+    {
+        const uint8_t other[] = {
+            0x02, 0x01, 0x06,               /* Flags */
+            0x02, 0x0a, 0xf4,               /* Tx Power Level */
+            0x05, 0x09, 'A', 'S', '1', '1', /* name */
+        };
+        as11_adv_salvage(other, (int)sizeof(other), &f);
+        eq("other AD types: three fields walked", f.fields, 3);
+        eq("other AD types: no uuids claimed", f.num_uuids16, 0);
+        ok("other AD types: no uuid pointer", f.uuids16 == NULL);
+        eq("other AD types: the name still found", f.name_len, 4);
+    }
+
+    /* ---- degenerate inputs ------------------------------------------------- */
+    {
+        const uint8_t one[] = { 0x06 };
+        as11_adv_salvage(one, 1, &f);
+        eq("single byte: no fields", f.fields, 0);
+        ok("single byte: no name", f.name == NULL);
+
+        as11_adv_salvage(one, 0, &f);
+        eq("zero length: no fields", f.fields, 0);
+
+        as11_adv_salvage(NULL, 31, &f);
+        ok("NULL data: no name", f.name == NULL);
+        eq("NULL data: no fields", f.fields, 0);
+
+        as11_adv_salvage(one, -5, &f);
+        eq("negative length: no fields", f.fields, 0);
+    }
+
+    /* ---- CONTAINMENT OVER PSEUDO-RANDOM PAYLOADS.
+     * The real risk here is not a wrong name, it is a read past the end of a
+     * 31-byte buffer supplied by any device in range. Assert the invariant that
+     * matters: everything handed back lies inside the input. Deterministic LCG
+     * so a failure is reproducible from the seed. ---------------------------- */
+    {
+        uint32_t seed = 0x5eed1234u;
+        int violations = 0;
+        for (int iter = 0; iter < 20000; iter++) {
+            uint8_t buf[31];
+            seed = seed * 1664525u + 1013904223u;
+            int len = (int)(seed >> 16) % (int)(sizeof(buf) + 1);   /* 0..31 */
+            for (int i = 0; i < len; i++) {
+                seed = seed * 1664525u + 1013904223u;
+                buf[i] = (uint8_t)(seed >> 24);
+            }
+            as11_adv_salvage(buf, len, &f);
+
+            if (f.name != NULL) {
+                if (f.name < buf || f.name + f.name_len > buf + len || f.name_len < 0) {
+                    printf("  FAIL name escaped the buffer at iter %d (len %d)\n", iter, len);
+                    violations++;
+                }
+            }
+            if (f.uuids16 != NULL) {
+                if (f.uuids16 < buf ||
+                    f.uuids16 + 2 * f.num_uuids16 > buf + len ||
+                    f.num_uuids16 < 0) {
+                    printf("  FAIL uuids escaped the buffer at iter %d (len %d)\n", iter, len);
+                    violations++;
+                }
+            }
+            if (f.fields < 0 || f.fields > len) {
+                printf("  FAIL implausible field count %d at iter %d\n", f.fields, iter);
+                violations++;
+            }
+            if (violations > 3) break;
+        }
+        ok("20000 random payloads stay inside the buffer", violations == 0);
+    }
+
+    printf("as11_adv_test: %d passed, %d failed\n", n_pass, n_fail);
+    return n_fail ? 1 : 0;
+}

--- a/scripts/as11_reconnect_test.c
+++ b/scripts/as11_reconnect_test.c
@@ -1,0 +1,108 @@
+/*
+ * SomnoTrace - host tests for the AS11 reconnect backoff policy
+ * Copyright (C) 2026 Ilya Kruchinin <https://github.com/ilyakruchinin>
+ *
+ * This file is part of SomnoTrace.
+ *
+ * SomnoTrace is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * SomnoTrace is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ADDITIONAL TERM (GPLv3 Section 7(b)): Redistributions must preserve the
+ * attribution "Based on SomnoTrace, originally created by Ilya Kruchinin".
+ *
+ * ---------------------------------------------------------------------------
+ * These pin the reconnect timing, which until now could not be checked without
+ * a radio: the policy lived inline in reconnect_task between vTaskDelay() and
+ * vTaskDelete(). Every assertion here is a number a mutant can change, and the
+ * totals are asserted as well as the individual steps — an off-by-one in the
+ * phase boundary keeps every single delay correct while moving the moment the
+ * device gives up trying quickly.
+ */
+#include "as11_reconnect.h"
+
+#include <assert.h>
+#include <stdio.h>
+
+static int n_pass, n_fail;
+
+static void check(const char *what, long got, long want)
+{
+    if (got == want) {
+        n_pass++;
+    } else {
+        n_fail++;
+        printf("  FAIL %s: got %ld, want %ld\n", what, got, want);
+    }
+}
+
+int main(void)
+{
+    /* The schedule, attempt by attempt. */
+    check("attempt 1 is immediate",        as11_reconnect_delay_s(1), 0);
+    check("attempt 2 waits 4s",            as11_reconnect_delay_s(2), 4);
+    check("attempt 3 waits 6s",            as11_reconnect_delay_s(3), 6);
+    check("attempt 4 is the first slow",   as11_reconnect_delay_s(4), 60);
+    check("attempt 5 stays slow",          as11_reconnect_delay_s(5), 60);
+    check("attempt 1000 stays slow",       as11_reconnect_delay_s(1000), 60);
+
+    /* THE PHASE BOUNDARY, pinned from both sides. Off-by-one here leaves every
+     * individual delay correct while changing how long the device stays in the
+     * cheap phase — the kind of change that looks harmless in review. */
+    check("last fast attempt is FAST_ATTEMPTS",
+          as11_reconnect_delay_s(AS11_RECONNECT_FAST_ATTEMPTS),
+          AS11_RECONNECT_FAST_ATTEMPTS * 2);
+    check("the attempt after it is slow",
+          as11_reconnect_delay_s(AS11_RECONNECT_FAST_ATTEMPTS + 1),
+          AS11_RECONNECT_SLOW_DELAY_S);
+
+    /* Defensive: a caller that has lost count must not sleep a negative or
+     * enormous time. Retry now instead. */
+    check("attempt 0 is immediate",        as11_reconnect_delay_s(0), 0);
+    check("negative attempt is immediate", as11_reconnect_delay_s(-7), 0);
+
+    /* Properties that hold whatever the numbers become. */
+    int prev = -1;
+    for (int a = 1; a <= 200; a++) {
+        int d = as11_reconnect_delay_s(a);
+        if (d < 0) {
+            n_fail++;
+            printf("  FAIL attempt %d returned a negative delay %d\n", a, d);
+            break;
+        }
+        if (d < prev) {
+            n_fail++;
+            printf("  FAIL delay decreased at attempt %d: %d after %d\n", a, d, prev);
+            break;
+        }
+        if (d > AS11_RECONNECT_SLOW_DELAY_S) {
+            n_fail++;
+            printf("  FAIL attempt %d waits %d, longer than the slow phase %d\n",
+                   a, d, AS11_RECONNECT_SLOW_DELAY_S);
+            break;
+        }
+        prev = d;
+    }
+    n_pass++;   /* the loop above completed without tripping */
+
+    /* THE NUMBER A USER WOULD FEEL: total wall time before the first slow
+     * retry. 0 + 4 + 6 = 10 s of fast attempts, then a 60 s wait, so the
+     * fourth attempt starts 70 s after the first. Asserted as a sum so that a
+     * mutant changing any one step is caught even if it keeps the others. */
+    long total = 0;
+    for (int a = 1; a <= AS11_RECONNECT_FAST_ATTEMPTS + 1; a++) {
+        total += as11_reconnect_delay_s(a);
+    }
+    check("70s from the first attempt to the first slow retry", total, 70);
+
+    printf("as11_reconnect_test: %d passed, %d failed\n", n_pass, n_fail);
+    return n_fail ? 1 : 0;
+}

--- a/scripts/mutate_equivalent.txt
+++ b/scripts/mutate_equivalent.txt
@@ -33,3 +33,9 @@ main/as11_time.c:326:relational:<→<=       # parse_iso8601: the two sscanf for
 main/as11_time.c:330:relational:<→<=       # ...and the retry can never return 6 when the first returned < 6, so the
 #   inner `if (n < 6) return -1` fires whenever reached. (The retry block is dead code; a finding
 #   for upstream, not a test gap.)
+
+# as11_adv_salvage's guard. With len == 0 and data != NULL the mutant skips the early
+# return, but the loop it falls into is `for (off = 0; off + 1 < len; )` — 1 < 0 is false,
+# so the body never runs and `out` was already memset to zero above. Every field of every
+# result is identical for every input; there is no observation that separates them.
+main/as11_adv.c:35:relational:<=→<

--- a/scripts/mutate_host.py
+++ b/scripts/mutate_host.py
@@ -86,6 +86,7 @@ TESTS = {
                              "#main/edf_summary.c"],
     "vld3_decoder_test":    ["main/oximetry_vld3.c"],
     "as11_reconnect_test":  ["main/as11_reconnect.c"],
+    "as11_adv_test":        ["main/as11_adv.c"],
 }
 
 

--- a/scripts/mutate_host.py
+++ b/scripts/mutate_host.py
@@ -85,6 +85,7 @@ TESTS = {
     "edf_properties_test":  ["main/as11_time.c", "main/edf_data_dict.h", "@cjson",
                              "#main/edf_summary.c"],
     "vld3_decoder_test":    ["main/oximetry_vld3.c"],
+    "as11_reconnect_test":  ["main/as11_reconnect.c"],
 }
 
 

--- a/scripts/run_host_tests.sh
+++ b/scripts/run_host_tests.sh
@@ -99,6 +99,7 @@ skip_test() {
 run_test as11_time_test    -I"$SHIM" -I"$MAIN_DIR" scripts/as11_time_test.c "$MAIN_DIR/as11_time.c"
 run_test as11_events_test  -I"$SHIM" -I"$MAIN_DIR" scripts/as11_events_test.c
 run_test vld3_decoder_test -I"$SHIM" -I"$MAIN_DIR" scripts/vld3_decoder_test.c "$MAIN_DIR/oximetry_vld3.c"
+run_test as11_reconnect_test -I"$SHIM" -I"$MAIN_DIR" scripts/as11_reconnect_test.c "$MAIN_DIR/as11_reconnect.c"
 
 # edf_gen_test #includes the real edf_gen.c and needs a real cJSON.
 # Include order matters: the real cJSON.h must shadow the shim in $SHIM.

--- a/scripts/run_host_tests.sh
+++ b/scripts/run_host_tests.sh
@@ -100,6 +100,7 @@ run_test as11_time_test    -I"$SHIM" -I"$MAIN_DIR" scripts/as11_time_test.c "$MA
 run_test as11_events_test  -I"$SHIM" -I"$MAIN_DIR" scripts/as11_events_test.c
 run_test vld3_decoder_test -I"$SHIM" -I"$MAIN_DIR" scripts/vld3_decoder_test.c "$MAIN_DIR/oximetry_vld3.c"
 run_test as11_reconnect_test -I"$SHIM" -I"$MAIN_DIR" scripts/as11_reconnect_test.c "$MAIN_DIR/as11_reconnect.c"
+run_test as11_adv_test       -I"$SHIM" -I"$MAIN_DIR" scripts/as11_adv_test.c "$MAIN_DIR/as11_adv.c"
 
 # edf_gen_test #includes the real edf_gen.c and needs a real cJSON.
 # Include order matters: the real cJSON.h must shadow the shim in $SHIM.


### PR DESCRIPTION
Two pieces of pure logic lifted out of `as11_ble.c` so they can be tested on the host. Neither changes behaviour; both are currently unreachable from any test because they live in a 3,000-line file with thirteen IDF includes.

## 1. The reconnect schedule (`as11_reconnect.c/.h`)

`reconnect_task` computes its backoff inline. The new module is the same arithmetic behind a name, with zero IDF includes:

```c
int as11_reconnect_delay_s(int attempt)
{
    if (attempt <= 1) return 0;
    if (attempt <= AS11_RECONNECT_FAST_ATTEMPTS) return attempt * 2;
    return AS11_RECONNECT_SLOW_DELAY_S;
}
```

Schedule: 1 → 0 s, 2 → 4 s, 3 → 6 s, 4+ → 60 s. `as11_ble.c` now reads both phases from it.

While writing the test I noticed the Phase 1 comment has drifted from the code:

```c
* Phase 1 — fast: 3 attempts with 2-4s backoff for transient disconnect
```

`attempt * 2` over attempts 2 and 3 gives **4 s and 6 s**, not 2–4 s. This is the block you clarified in `bca2236` for #228 — the Phase 2 half is now right, Phase 1 was not part of that change. The comment is corrected here; the timing is untouched.

`scripts/as11_reconnect_test.c` pins all four cases plus the boundaries.

## 2. The advertising-data salvage parser (`as11_adv.c/.h`)

`gap_event()` hand-walks AD structures when `ble_hs_adv_parse_fields()` rejects a packet — the AS11's `ADV_IND` carries a trailing type-`0x1b` field that is one byte short, so NimBLE discards the whole payload including the valid name. That walk is now a function.

The UUID cast stays at the call site: the 16-bit UUID list starts at an arbitrary offset with no alignment guarantee, so the cast belongs where the caller can see it, not hidden inside the parser.

`scripts/as11_adv_test.c` covers name/UUID extraction, zero-length AD, a length byte that overruns the buffer, and the off-by-one the parser's own comment warns about — the length byte counts the type byte, so a four-character name is `ad_len == 5`.

## Checks

Both suites are registered in `run_host_tests.sh` and in the mutation harness. Full host gate green, mutation clean.

Happy to split this into two if you would rather review them separately.
