### PR TITLE
test(host): sanitizers, a trailing-comment fix in the harness, and the eighteen edf_waveform guards

### DIFF
--- a/.github/workflows/host-tests.yml
+++ b/.github/workflows/host-tests.yml
@@ -33,19 +33,26 @@ jobs:
 
       - name: Install libcjson
         run: |
-          # ⚠️ DROP THE RUNNER'S THIRD-PARTY APT SOURCES FIRST. The ubuntu-latest image ships
-          # lists for Google Chrome, Microsoft and Azure that this project never installs from.
-          # When one of them serves a bad index, `apt-get update` exits 100 and every job that
-          # installs anything goes red before reaching a line of project code. Measured
-          # 2026-09-09: `Hash Sum mismatch` on dl.google.com/linux/chrome-stable reddened
-          # host-tests, lint and mutation together, and survived a re-run — it is an outage,
-          # not a flake, and retrying does not clear it.
+          # ⚠️ DROP THE RUNNER'S UNRELATED APT SOURCES FIRST. The ubuntu-latest image ships
+          # apt sources for Google Chrome and Microsoft that this project never installs from.
+          # When one of them serves a bad index, `apt-get update` exits 100 and the job dies
+          # before reaching a line of project code. Measured 2026-09-09: `Hash Sum mismatch`
+          # on dl.google.com/linux/chrome-stable reddened host-tests, lint and mutation
+          # together, and survived a re-run — an outage, not a flake.
           #
-          # Removing the lists is the fix rather than `|| true`, which would hide a genuine
-          # failure to reach the Ubuntu archive — the one we do depend on.
-          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
-                     /etc/apt/sources.list.d/microsoft-prod.list \
-                     /etc/apt/sources.list.d/azure-cli.list
+          # MATCHED BY CONTENT, NOT BY FILENAME. The first version of this named
+          # /etc/apt/sources.list.d/google-chrome.list, removed nothing, and failed exactly as
+          # before: the image's file names differ between runner releases and between the
+          # .list and deb822 .sources formats. A guessed name fails silently, which is the
+          # worst way for a workaround to be wrong. Grepping for the host cannot miss.
+          #
+          # Removed rather than swallowed with `|| true`, which would also hide a genuine
+          # failure to reach the Ubuntu archive — the one repository these jobs depend on.
+          for f in $(grep -rlE 'dl\.google\.com|packages\.microsoft\.com' \
+                       /etc/apt/sources.list /etc/apt/sources.list.d/ 2>/dev/null || true); do
+              echo "removing apt source this project does not use: $f"
+              sudo rm -f "$f"
+          done
           sudo apt-get update -q
           sudo apt-get install -y --no-install-recommends libcjson-dev
 

--- a/.github/workflows/host-tests.yml
+++ b/.github/workflows/host-tests.yml
@@ -33,6 +33,19 @@ jobs:
 
       - name: Install libcjson
         run: |
+          # ⚠️ DROP THE RUNNER'S THIRD-PARTY APT SOURCES FIRST. The ubuntu-latest image ships
+          # lists for Google Chrome, Microsoft and Azure that this project never installs from.
+          # When one of them serves a bad index, `apt-get update` exits 100 and every job that
+          # installs anything goes red before reaching a line of project code. Measured
+          # 2026-09-09: `Hash Sum mismatch` on dl.google.com/linux/chrome-stable reddened
+          # host-tests, lint and mutation together, and survived a re-run — it is an outage,
+          # not a flake, and retrying does not clear it.
+          #
+          # Removing the lists is the fix rather than `|| true`, which would hide a genuine
+          # failure to reach the Ubuntu archive — the one we do depend on.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
+                     /etc/apt/sources.list.d/microsoft-prod.list \
+                     /etc/apt/sources.list.d/azure-cli.list
           sudo apt-get update -q
           sudo apt-get install -y --no-install-recommends libcjson-dev
 

--- a/.github/workflows/mutation-sweep.yml
+++ b/.github/workflows/mutation-sweep.yml
@@ -39,19 +39,26 @@ jobs:
         # linking -lcjson; before that it silently skipped those suites and reported a
         # smaller SCOPE than the suite it was measuring.
         run: |
-          # ⚠️ DROP THE RUNNER'S THIRD-PARTY APT SOURCES FIRST. The ubuntu-latest image ships
-          # lists for Google Chrome, Microsoft and Azure that this project never installs from.
-          # When one of them serves a bad index, `apt-get update` exits 100 and every job that
-          # installs anything goes red before reaching a line of project code. Measured
-          # 2026-09-09: `Hash Sum mismatch` on dl.google.com/linux/chrome-stable reddened
-          # host-tests, lint and mutation together, and survived a re-run — it is an outage,
-          # not a flake, and retrying does not clear it.
+          # ⚠️ DROP THE RUNNER'S UNRELATED APT SOURCES FIRST. The ubuntu-latest image ships
+          # apt sources for Google Chrome and Microsoft that this project never installs from.
+          # When one of them serves a bad index, `apt-get update` exits 100 and the job dies
+          # before reaching a line of project code. Measured 2026-09-09: `Hash Sum mismatch`
+          # on dl.google.com/linux/chrome-stable reddened host-tests, lint and mutation
+          # together, and survived a re-run — an outage, not a flake.
           #
-          # Removing the lists is the fix rather than `|| true`, which would hide a genuine
-          # failure to reach the Ubuntu archive — the one we do depend on.
-          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
-                     /etc/apt/sources.list.d/microsoft-prod.list \
-                     /etc/apt/sources.list.d/azure-cli.list
+          # MATCHED BY CONTENT, NOT BY FILENAME. The first version of this named
+          # /etc/apt/sources.list.d/google-chrome.list, removed nothing, and failed exactly as
+          # before: the image's file names differ between runner releases and between the
+          # .list and deb822 .sources formats. A guessed name fails silently, which is the
+          # worst way for a workaround to be wrong. Grepping for the host cannot miss.
+          #
+          # Removed rather than swallowed with `|| true`, which would also hide a genuine
+          # failure to reach the Ubuntu archive — the one repository these jobs depend on.
+          for f in $(grep -rlE 'dl\.google\.com|packages\.microsoft\.com' \
+                       /etc/apt/sources.list /etc/apt/sources.list.d/ 2>/dev/null || true); do
+              echo "removing apt source this project does not use: $f"
+              sudo rm -f "$f"
+          done
           sudo apt-get update -q
           sudo apt-get install -y --no-install-recommends libcjson-dev
 

--- a/.github/workflows/mutation-sweep.yml
+++ b/.github/workflows/mutation-sweep.yml
@@ -39,6 +39,19 @@ jobs:
         # linking -lcjson; before that it silently skipped those suites and reported a
         # smaller SCOPE than the suite it was measuring.
         run: |
+          # ⚠️ DROP THE RUNNER'S THIRD-PARTY APT SOURCES FIRST. The ubuntu-latest image ships
+          # lists for Google Chrome, Microsoft and Azure that this project never installs from.
+          # When one of them serves a bad index, `apt-get update` exits 100 and every job that
+          # installs anything goes red before reaching a line of project code. Measured
+          # 2026-09-09: `Hash Sum mismatch` on dl.google.com/linux/chrome-stable reddened
+          # host-tests, lint and mutation together, and survived a re-run — it is an outage,
+          # not a flake, and retrying does not clear it.
+          #
+          # Removing the lists is the fix rather than `|| true`, which would hide a genuine
+          # failure to reach the Ubuntu archive — the one we do depend on.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
+                     /etc/apt/sources.list.d/microsoft-prod.list \
+                     /etc/apt/sources.list.d/azure-cli.list
           sudo apt-get update -q
           sudo apt-get install -y --no-install-recommends libcjson-dev
 

--- a/.github/workflows/mutation-sweep.yml
+++ b/.github/workflows/mutation-sweep.yml
@@ -1,0 +1,84 @@
+name: "Mutation sweep"
+# The SEARCHING half of the mutation setup, on a schedule rather than on every push.
+#
+# scripts/mutants.py — run by mutation.yml on every push — is the PINNING half: a fixed
+# set of mutants that must all die, 15/15 today, and a red result there means someone
+# broke a test that was working. This job is the other kind. scripts/mutate_host.py
+# generates mutants it has never seen, so its output is a REPORT and not a verdict:
+# it currently finds 40 unasserted survivors on a green tree. Wiring that as a gate
+# would mean a permanently red build, and a permanently red gate teaches people to
+# ignore CI — the same reasoning that made lint's style tier advisory.
+#
+# ⚠️ WHY THIS IS NOT ON EVERY PUSH. Measured on a developer machine: 391 seconds,
+# against 30 for mutants.py. The slowest per-push job in this repo is the IDF build
+# at roughly 200s, and the jobs run concurrently, so a 391s job would become the
+# critical path and roughly double the wait on every pull request — to deliver a
+# report that nobody is required to act on before merging. Weekly costs contributors
+# nothing and still surfaces a trend.
+#
+# It runs on Saturday evening UTC so the result is already waiting on Sunday, which
+# is historically the busiest merge day in this repo.
+on:
+  schedule:
+    - cron: "0 20 * * 6"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install libcjson
+        # The harness needs cJSON to build the two EDF suites. apt ships the header and
+        # the shared library and no cJSON.c, which scripts/mutate_host.py now handles by
+        # linking -lcjson; before that it silently skipped those suites and reported a
+        # smaller SCOPE than the suite it was measuring.
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y --no-install-recommends libcjson-dev
+
+      - name: Sweep
+        run: |
+          set -o pipefail
+          python3 scripts/mutate_host.py --all 2>&1 | tee mutation-sweep.log
+
+      - name: Check the run actually measured something
+        # THE ONLY FAILING CONDITION. A survivor count is a report; a VOID is not.
+        # VOID means the harness could not detect a change it made on purpose — a
+        # canary that survived, or a baseline that does not pass — and every number
+        # in the log is then meaningless. Reporting that as a quiet success is how a
+        # mutation score becomes a comfort, so it fails loudly instead.
+        run: |
+          if grep -q '^ *VOID' mutation-sweep.log; then
+            echo "::error::the sweep reported VOID — it measured nothing, see the log"
+            grep -B2 '^ *VOID' mutation-sweep.log || true
+            exit 1
+          fi
+          grep -qE '[0-9]+ unasserted survivor\(s\)' mutation-sweep.log || {
+            echo "::error::no survivor-count line — the sweep did not run to completion"; exit 1; }
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "### Mutation sweep (advisory)"
+            echo '```'
+            grep -E '^SCOPE|^ *not seen|unasserted survivor\(s\)|^ *canary|^ *killed ' mutation-sweep.log || true
+            echo '```'
+            echo ""
+            echo "UNASSERTED means the mutant ran and every test still passed."
+            echo "This job never fails on that count — only on VOID, which means the run measured nothing."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload the sweep log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutation-sweep-log
+          path: mutation-sweep.log
+          retention-days: 30

--- a/.github/workflows/mutation-sweep.yml
+++ b/.github/workflows/mutation-sweep.yml
@@ -62,13 +62,26 @@ jobs:
           grep -qE '[0-9]+ unasserted survivor\(s\)' mutation-sweep.log || {
             echo "::error::no survivor-count line — the sweep did not run to completion"; exit 1; }
 
+      - name: Flag survivors that are not in the committed inventory
+        # scripts/mutation_survivors.txt is checked in, so the normal way a new survivor
+        # gets noticed is a line appearing in a pull request's diff. This is the backstop
+        # for the ones that arrive without a diff — a dependency bump, a compiler change,
+        # or a merge that nobody re-swept. A warning, not a failure: the count is a report.
+        if: always()
+        run: |
+          if grep -qE '^ *\+ NEW ' mutation-sweep.log; then
+            n=$(grep -cE '^ *\+ NEW ' mutation-sweep.log)
+            echo "::warning::$n survivor(s) not in scripts/mutation_survivors.txt — regenerate with: python3 scripts/mutate_host.py --all --write-inventory"
+            grep -E '^ *\+ NEW ' mutation-sweep.log
+          fi
+
       - name: Summary
         if: always()
         run: |
           {
             echo "### Mutation sweep (advisory)"
             echo '```'
-            grep -E '^SCOPE|^ *not seen|unasserted survivor\(s\)|^ *canary|^ *killed ' mutation-sweep.log || true
+            grep -E '^SCOPE|^INVENTORY|^ *[+-] (NEW|was here)|^ *not seen|unasserted survivor\(s\)|^ *canary|^ *killed ' mutation-sweep.log || true
             echo '```'
             echo ""
             echo "UNASSERTED means the mutant ran and every test still passed."

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -31,6 +31,19 @@ jobs:
         # Same dependency the host tests need; without it the harness SKIPS the two suites
         # that cover the exporter and correctly reports VOID rather than a kill count.
         run: |
+          # ⚠️ DROP THE RUNNER'S THIRD-PARTY APT SOURCES FIRST. The ubuntu-latest image ships
+          # lists for Google Chrome, Microsoft and Azure that this project never installs from.
+          # When one of them serves a bad index, `apt-get update` exits 100 and every job that
+          # installs anything goes red before reaching a line of project code. Measured
+          # 2026-09-09: `Hash Sum mismatch` on dl.google.com/linux/chrome-stable reddened
+          # host-tests, lint and mutation together, and survived a re-run — it is an outage,
+          # not a flake, and retrying does not clear it.
+          #
+          # Removing the lists is the fix rather than `|| true`, which would hide a genuine
+          # failure to reach the Ubuntu archive — the one we do depend on.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
+                     /etc/apt/sources.list.d/microsoft-prod.list \
+                     /etc/apt/sources.list.d/azure-cli.list
           sudo apt-get update -q
           sudo apt-get install -y --no-install-recommends libcjson-dev
 

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -31,19 +31,26 @@ jobs:
         # Same dependency the host tests need; without it the harness SKIPS the two suites
         # that cover the exporter and correctly reports VOID rather than a kill count.
         run: |
-          # ⚠️ DROP THE RUNNER'S THIRD-PARTY APT SOURCES FIRST. The ubuntu-latest image ships
-          # lists for Google Chrome, Microsoft and Azure that this project never installs from.
-          # When one of them serves a bad index, `apt-get update` exits 100 and every job that
-          # installs anything goes red before reaching a line of project code. Measured
-          # 2026-09-09: `Hash Sum mismatch` on dl.google.com/linux/chrome-stable reddened
-          # host-tests, lint and mutation together, and survived a re-run — it is an outage,
-          # not a flake, and retrying does not clear it.
+          # ⚠️ DROP THE RUNNER'S UNRELATED APT SOURCES FIRST. The ubuntu-latest image ships
+          # apt sources for Google Chrome and Microsoft that this project never installs from.
+          # When one of them serves a bad index, `apt-get update` exits 100 and the job dies
+          # before reaching a line of project code. Measured 2026-09-09: `Hash Sum mismatch`
+          # on dl.google.com/linux/chrome-stable reddened host-tests, lint and mutation
+          # together, and survived a re-run — an outage, not a flake.
           #
-          # Removing the lists is the fix rather than `|| true`, which would hide a genuine
-          # failure to reach the Ubuntu archive — the one we do depend on.
-          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
-                     /etc/apt/sources.list.d/microsoft-prod.list \
-                     /etc/apt/sources.list.d/azure-cli.list
+          # MATCHED BY CONTENT, NOT BY FILENAME. The first version of this named
+          # /etc/apt/sources.list.d/google-chrome.list, removed nothing, and failed exactly as
+          # before: the image's file names differ between runner releases and between the
+          # .list and deb822 .sources formats. A guessed name fails silently, which is the
+          # worst way for a workaround to be wrong. Grepping for the host cannot miss.
+          #
+          # Removed rather than swallowed with `|| true`, which would also hide a genuine
+          # failure to reach the Ubuntu archive — the one repository these jobs depend on.
+          for f in $(grep -rlE 'dl\.google\.com|packages\.microsoft\.com' \
+                       /etc/apt/sources.list /etc/apt/sources.list.d/ 2>/dev/null || true); do
+              echo "removing apt source this project does not use: $f"
+              sudo rm -f "$f"
+          done
           sudo apt-get update -q
           sudo apt-get install -y --no-install-recommends libcjson-dev
 

--- a/scripts/edf_gen_test.c
+++ b/scripts/edf_gen_test.c
@@ -1043,6 +1043,246 @@ static void test_str_pressure_settings_exact(void)
     cJSON_Delete(settings);
 }
 
+/* ── Identification.json / Identification.crc ────────────────────────────────
+ * edf_generate_identification_files() was the largest untested function in the
+ * exporter. The mutation harness picks it as edf_header.c's canary, empties its
+ * body, and every test still passed — so the harness refused a verdict on all
+ * 456 lines of that file rather than report a clean sweep it had not earned.
+ *
+ * These exist to make that verdict possible, so they pin behaviour a mutant
+ * would change rather than merely reaching the function: the CRC's byte order
+ * and length, the number->string coercion, the defaults for absent keys, and
+ * the one input/output key name that differs on purpose.
+ */
+static void ident_write_file(const char *path, const char *text)
+{
+    FILE *f = fopen(path, "wb");
+    assert(f);
+    size_t n = strlen(text);
+    assert(fwrite(text, 1, n, f) == n);
+    assert(fclose(f) == 0);
+}
+
+static char *ident_slurp(const char *path, size_t *out_len)
+{
+    FILE *f = fopen(path, "rb");
+    if (!f) return NULL;
+    assert(fseek(f, 0, SEEK_END) == 0);
+    long n = ftell(f);
+    assert(n >= 0);
+    assert(fseek(f, 0, SEEK_SET) == 0);
+    char *buf = malloc((size_t)n + 1);
+    assert(buf);
+    assert(fread(buf, 1, (size_t)n, f) == (size_t)n);
+    buf[n] = '\0';
+    fclose(f);
+    if (out_len) *out_len = (size_t)n;
+    return buf;
+}
+
+static void ident_make_dir(char *dst, size_t cap, const char *name)
+{
+    snprintf(dst, cap, "%s/%s", g_root, name);
+    mkdir(dst, 0777);
+}
+
+/* The full profile the AS11 expects, so the shape is pinned rather than sampled. */
+static const char *IDENT_FULL =
+    "{"
+    "\"UniversalIdentifier\":\"UID-1\","
+    "\"SerialNumber\":\"SN-2\","
+    "\"ProductCode\":37001,"
+    "\"ProductName\":\"AirSense 11\","
+    "\"ProductGeographicIdentifier\":\"EUR\","
+    "\"HardwareIdentifier\":\"HW-3\","
+    "\"BootloaderIdentifier\":\"BL-4\","
+    "\"ApplicationIdentifier\":\"APP-5\","
+    "\"ConfigurationIdentifier\":\"CFG-6\","
+    "\"PlatformIdentifier\":12,"
+    "\"VariantIdentifier\":34,"
+    "\"RegionIdentifier\":56,"
+    "\"ProfileVariantIdentifier\":\"PV-7\","
+    "\"DataVersionIdentifier\":78,"
+    "\"DataModelVersionIdentifier\":\"DM-8\""
+    "}";
+
+static cJSON *ident_profile(cJSON *root, const char *which)
+{
+    cJSON *fg = cJSON_GetObjectItem(root, "FlowGenerator");
+    assert(fg);
+    cJSON *profiles = cJSON_GetObjectItem(fg, "IdentificationProfiles");
+    assert(profiles);
+    cJSON *p = cJSON_GetObjectItem(profiles, which);
+    assert(p);
+    return p;
+}
+
+static void ident_expect_str(cJSON *obj, const char *key, const char *want)
+{
+    cJSON *j = cJSON_GetObjectItem(obj, key);
+    assert(j);
+    assert(cJSON_IsString(j));
+    assert(strcmp(j->valuestring, want) == 0);
+}
+
+static void test_crc32_matches_the_published_check_vector(void)
+{
+    /* CRC-32/ISO-HDLC (IEEE 802.3) has a published check value: the CRC of the
+     * nine bytes "123456789" is 0xCBF43926.
+     *
+     * Asserting against the constant rather than against another call of the same
+     * function is the entire point of this test. The Identification.crc test below
+     * compares the file's four bytes to edf_crc32_ieee() — so a mutation INSIDE the
+     * CRC changes both sides equally and survives, which is exactly what the
+     * mutation harness reported when this test did not exist: the loop bounds at
+     * lines 50 and 52 and the shift at line 56 all survived a suite that looked
+     * like it covered them. A test whose oracle is the code under test defends the
+     * bug instead of catching it. */
+    assert(edf_crc32_ieee((const uint8_t *)"123456789", 9) == 0xCBF43926u);
+    assert(edf_crc32_ieee((const uint8_t *)"", 0) == 0u);
+    assert(edf_crc32_ieee((const uint8_t *)"a", 1) == 0xE8B7BE43u);
+    /* Length is honoured, not strlen: a CRC over a prefix differs. */
+    assert(edf_crc32_ieee((const uint8_t *)"123456789", 8) != 0xCBF43926u);
+}
+
+static void test_identification_profile_shape(void)
+{
+    char dir[300], ident[400], out_path[400];
+    ident_make_dir(dir, sizeof(dir), "ident_shape");
+    snprintf(ident, sizeof(ident), "%s/identification.json", dir);
+    ident_write_file(ident, IDENT_FULL);
+
+    assert(edf_generate_identification_files(dir, ident) == ESP_OK);
+
+    snprintf(out_path, sizeof(out_path), "%s/Identification.json", dir);
+    char *out = ident_slurp(out_path, NULL);
+    assert(out);
+    cJSON *root = cJSON_Parse(out);
+    assert(root);
+
+    cJSON *product = ident_profile(root, "Product");
+    ident_expect_str(product, "UniversalIdentifier", "UID-1");
+    ident_expect_str(product, "SerialNumber", "SN-2");
+    ident_expect_str(product, "ProductName", "AirSense 11");
+    ident_expect_str(product, "ProductGeographicIdentifier", "EUR");
+    /* A numeric ProductCode is rendered as a STRING. The AS11 writes it either
+     * way and the profile always carries a string, so the coercion is load-bearing. */
+    ident_expect_str(product, "ProductCode", "37001");
+    /* Always blank, never copied from the source, even when the source has them. */
+    ident_expect_str(product, "SerialNumberVerificationCode", "");
+    ident_expect_str(product, "FdaUniqueDeviceIdentifier", "");
+
+    ident_expect_str(ident_profile(root, "Hardware"), "HardwareIdentifier", "HW-3");
+
+    cJSON *software = ident_profile(root, "Software");
+    ident_expect_str(software, "BootloaderIdentifier", "BL-4");
+    ident_expect_str(software, "ApplicationIdentifier", "APP-5");
+    ident_expect_str(software, "ConfigurationIdentifier", "CFG-6");
+    ident_expect_str(software, "DataModelVersionIdentifier", "DM-8");
+    /* THE KEY NAME CHANGES ON PURPOSE: the source says ProfileVARIANTIdentifier,
+     * the profile says ProfileVARIATIONIdentifier. It reads like a typo and it is
+     * not — pinned here so that "fixing" it breaks a test instead of a device. */
+    ident_expect_str(software, "ProfileVariationIdentifier", "PV-7");
+    assert(cJSON_GetObjectItem(software, "ProfileVariantIdentifier") == NULL);
+
+    /* These four stay NUMBERS. */
+    cJSON *plat = cJSON_GetObjectItem(software, "PlatformIdentifier");
+    assert(plat && cJSON_IsNumber(plat) && plat->valuedouble == 12);
+    cJSON *var = cJSON_GetObjectItem(software, "VariantIdentifier");
+    assert(var && cJSON_IsNumber(var) && var->valuedouble == 34);
+    cJSON *reg = cJSON_GetObjectItem(software, "RegionIdentifier");
+    assert(reg && cJSON_IsNumber(reg) && reg->valuedouble == 56);
+    cJSON *dv = cJSON_GetObjectItem(software, "DataVersionIdentifier");
+    assert(dv && cJSON_IsNumber(dv) && dv->valuedouble == 78);
+
+    cJSON_Delete(root);
+    free(out);
+}
+
+static void test_identification_crc_is_le_crc32_of_the_json(void)
+{
+    char dir[300], ident[400], json_path[400], crc_path[400];
+    ident_make_dir(dir, sizeof(dir), "ident_crc");
+    snprintf(ident, sizeof(ident), "%s/identification.json", dir);
+    ident_write_file(ident, IDENT_FULL);
+
+    assert(edf_generate_identification_files(dir, ident) == ESP_OK);
+
+    snprintf(json_path, sizeof(json_path), "%s/Identification.json", dir);
+    snprintf(crc_path, sizeof(crc_path), "%s/Identification.crc", dir);
+
+    size_t json_len = 0, crc_len = 0;
+    char *json = ident_slurp(json_path, &json_len);
+    unsigned char *crc_file = (unsigned char *)ident_slurp(crc_path, &crc_len);
+    assert(json && crc_file);
+
+    /* Exactly four bytes — not a text rendering, not a trailing newline. */
+    assert(crc_len == 4);
+
+    /* Little-endian, over the WHOLE json as written. Both halves of that matter:
+     * a byte-order flip and an off-by-one on the length are the two mutations a
+     * CRC written this way invites. */
+    uint32_t want = edf_crc32_ieee((const uint8_t *)json, json_len);
+    uint32_t got = (uint32_t)crc_file[0]
+                 | ((uint32_t)crc_file[1] << 8)
+                 | ((uint32_t)crc_file[2] << 16)
+                 | ((uint32_t)crc_file[3] << 24);
+    assert(got == want);
+    assert(got != edf_crc32_ieee((const uint8_t *)json, json_len - 1));
+
+    free(json);
+    free(crc_file);
+}
+
+static void test_identification_absent_fields_are_empty_or_zero(void)
+{
+    char dir[300], ident[400], out_path[400];
+    ident_make_dir(dir, sizeof(dir), "ident_sparse");
+    snprintf(ident, sizeof(ident), "%s/identification.json", dir);
+    ident_write_file(ident, "{\"SerialNumber\":\"ONLY\"}");
+
+    assert(edf_generate_identification_files(dir, ident) == ESP_OK);
+
+    snprintf(out_path, sizeof(out_path), "%s/Identification.json", dir);
+    char *out = ident_slurp(out_path, NULL);
+    assert(out);
+    cJSON *root = cJSON_Parse(out);
+    assert(root);
+
+    cJSON *product = ident_profile(root, "Product");
+    ident_expect_str(product, "SerialNumber", "ONLY");
+    /* Absent strings are present-and-empty, not absent and not null: the profile
+     * always carries every key. */
+    ident_expect_str(product, "UniversalIdentifier", "");
+    ident_expect_str(product, "ProductCode", "");
+    ident_expect_str(product, "ProductName", "");
+
+    cJSON *software = ident_profile(root, "Software");
+    cJSON *plat = cJSON_GetObjectItem(software, "PlatformIdentifier");
+    assert(plat && cJSON_IsNumber(plat) && plat->valuedouble == 0);
+    cJSON *dv = cJSON_GetObjectItem(software, "DataVersionIdentifier");
+    assert(dv && cJSON_IsNumber(dv) && dv->valuedouble == 0);
+
+    cJSON_Delete(root);
+    free(out);
+}
+
+static void test_identification_missing_source_is_refused(void)
+{
+    char dir[300], ident[400], json_path[400], crc_path[400];
+    ident_make_dir(dir, sizeof(dir), "ident_missing");
+    snprintf(ident, sizeof(ident), "%s/does-not-exist.json", dir);
+
+    assert(edf_generate_identification_files(dir, ident) == ESP_FAIL);
+
+    /* And it writes nothing at all: a refused generation must not leave a
+     * half-made profile behind for the next reader to trust. */
+    snprintf(json_path, sizeof(json_path), "%s/Identification.json", dir);
+    snprintf(crc_path, sizeof(crc_path), "%s/Identification.crc", dir);
+    assert(ident_slurp(json_path, NULL) == NULL);
+    assert(ident_slurp(crc_path, NULL) == NULL);
+}
+
 int main(void)
 {
     snprintf(g_root, sizeof(g_root), "%s/snt_edf_test_XXXXXX",
@@ -1075,6 +1315,17 @@ int main(void)
     run("the session's AS11 offset beats the device timezone",
         test_as11_offset_beats_device_timezone, NULL);
     run("STR pressure settings are exact cmH2O x 50", test_str_pressure_settings_exact, NULL);
+
+    run("crc32 matches the published CRC-32/ISO-HDLC check vector",
+        test_crc32_matches_the_published_check_vector, NULL);
+    run("Identification profile carries every key, with the deliberate rename",
+        test_identification_profile_shape, NULL);
+    run("Identification.crc is four bytes, little-endian crc32 of the json",
+        test_identification_crc_is_le_crc32_of_the_json, NULL);
+    run("absent identification fields become empty strings and zeroes",
+        test_identification_absent_fields_are_empty_or_zero, NULL);
+    run("a missing identification.json is refused and writes nothing",
+        test_identification_missing_source_is_refused, NULL);
 
     if (!getenv("KEEP_TEST_TREE")) rmtree(g_root);
     else printf("test tree kept at %s\n", g_root);

--- a/scripts/edf_gen_test.c
+++ b/scripts/edf_gen_test.c
@@ -1283,6 +1283,353 @@ static void test_identification_missing_source_is_refused(void)
     assert(ident_slurp(crc_path, NULL) == NULL);
 }
 
+/* ── edf_waveform: the guards in the event-file readers ──────────────────────
+ * Eighteen of the harness's thirty-three survivors lived in these three
+ * functions, all of them the same shape: a guard whose false branch nothing
+ * exercised. `events && cJSON_IsArray(events)` flipped to `||` still returns
+ * the right answer on every well-formed file, because a well-formed file always
+ * has an array there. The tests below are therefore all MALFORMED input — the
+ * only input that tells the two versions apart.
+ *
+ * Two of the mutants matter beyond the score. Dropping the IsString check on a
+ * label reaches strcmp(NULL, ...) and dropping it on reportTime reaches the
+ * ISO-8601 parser with a NULL pointer, both from a file the device wrote after
+ * a crash or a partial flush.
+ */
+static void wf_write(const char *path, const char *jsonl)
+{
+    FILE *f = fopen(path, "wb");
+    assert(f);
+    assert(fputs(jsonl, f) >= 0);
+    assert(fclose(f) == 0);
+}
+
+static const char *wf_path(char *dst, size_t cap, const char *name)
+{
+    snprintf(dst, cap, "%s/%s", g_root, name);
+    return dst;
+}
+
+/* ---- snt_available_samples -------------------------------------------------- */
+
+static void test_wf_available_samples_guards(void)
+{
+    char p[400];
+    wf_path(p, sizeof(p), "wf_avail.snt");
+
+    /* A file holding exactly the header and nothing else: no samples, and that
+     * is a 0, not an error. */
+    FILE *f = fopen(p, "wb");
+    assert(f);
+    snt_header_t h;
+    memset(&h, 0, sizeof(h));
+    assert(fwrite(&h, 1, sizeof(h), f) == sizeof(h));
+    assert(fclose(f) == 0);
+    f = fopen(p, "rb");
+    assert(f);
+    assert(snt_available_samples(f, 2) == 0);
+
+    /* CHANNELS ZERO IS REFUSED, not divided by. `channels_in_file <= 0` weakened
+     * to `< 0` lets a zero through to `data_bytes / frame` with frame == 0. */
+    assert(snt_available_samples(f, 0) == UINT32_MAX);
+    assert(snt_available_samples(f, -1) == UINT32_MAX);
+    assert(snt_available_samples(NULL, 2) == UINT32_MAX);
+    assert(fclose(f) == 0);
+
+    /* An EMPTY file is 0 samples. end == 0 here, so a guard written `end <= 0`
+     * instead of `end < 0` reports UINT32_MAX — an error where there is none. */
+    f = fopen(p, "wb"); assert(f); assert(fclose(f) == 0);
+    f = fopen(p, "rb"); assert(f);
+    assert(snt_available_samples(f, 2) == 0);
+    assert(fclose(f) == 0);
+
+    /* Header plus three whole frames of two channels, read from the START of the
+     * file: ftell is 0 there, so `cur < 0` weakened to `<= 0` would refuse a
+     * perfectly ordinary call. */
+    f = fopen(p, "wb");
+    assert(f);
+    assert(fwrite(&h, 1, sizeof(h), f) == sizeof(h));
+    int16_t frames[6] = { 1, 2, 3, 4, 5, 6 };
+    assert(fwrite(frames, sizeof(int16_t), 6, f) == 6);
+    assert(fclose(f) == 0);
+    f = fopen(p, "rb");
+    assert(f);
+    assert(ftell(f) == 0);
+    assert(snt_available_samples(f, 2) == 3);
+    assert(fclose(f) == 0);
+}
+
+/* ---- edf_find_mask_on_time / edf_find_mask_off_time -------------------------- */
+
+static void test_wf_mask_times_are_found(void)
+{
+    char p[400];
+    wf_path(p, sizeof(p), "wf_mask_ok.jsonl");
+    wf_write(p,
+        "{\"params\":{\"events\":[{\"event\":\"MaskOn\","
+        "\"reportTime\":\"2026-09-01T22:10:00.000\"}]}}\n"
+        "{\"params\":{\"events\":[{\"event\":\"MaskOff\","
+        "\"reportTime\":\"2026-09-02T06:20:00.000\"}]}}\n");
+    int64_t on = edf_find_mask_on_time(p);
+    int64_t off = edf_find_mask_off_time(p);
+    assert(on > 0);
+    assert(off > on);
+    /* MaskOff takes the LAST one in the file, MaskOn the first — asserted as an
+     * ordering rather than a constant so the test does not pin a timezone. */
+    assert(off - on == 8 * 3600 * 1000 + 10 * 60 * 1000);
+}
+
+static void test_wf_mask_on_last_wins_is_first_wins(void)
+{
+    char p[400];
+    wf_path(p, sizeof(p), "wf_mask_first.jsonl");
+    wf_write(p,
+        "{\"params\":{\"events\":[{\"event\":\"MaskOn\","
+        "\"reportTime\":\"2026-09-01T22:00:00.000\"}]}}\n"
+        "{\"params\":{\"events\":[{\"event\":\"MaskOn\","
+        "\"reportTime\":\"2026-09-01T23:00:00.000\"}]}}\n");
+    int64_t a = edf_find_mask_on_time(p);
+    wf_path(p, sizeof(p), "wf_mask_one.jsonl");
+    wf_write(p,
+        "{\"params\":{\"events\":[{\"event\":\"MaskOn\","
+        "\"reportTime\":\"2026-09-01T22:00:00.000\"}]}}\n");
+    /* MaskOn returns on the FIRST match; a second one later must not move it. */
+    assert(a == edf_find_mask_on_time(p));
+}
+
+static void test_wf_mask_off_takes_the_last(void)
+{
+    char p[400];
+    wf_path(p, sizeof(p), "wf_maskoff_last.jsonl");
+    wf_write(p,
+        "{\"params\":{\"events\":[{\"event\":\"MaskOff\","
+        "\"reportTime\":\"2026-09-02T05:00:00.000\"}]}}\n"
+        "{\"params\":{\"events\":[{\"event\":\"MaskOff\","
+        "\"reportTime\":\"2026-09-02T06:00:00.000\"}]}}\n");
+    int64_t last = edf_find_mask_off_time(p);
+    wf_path(p, sizeof(p), "wf_maskoff_one.jsonl");
+    wf_write(p,
+        "{\"params\":{\"events\":[{\"event\":\"MaskOff\","
+        "\"reportTime\":\"2026-09-02T06:00:00.000\"}]}}\n");
+    /* MaskOff keeps scanning and reports the last — the session ends when the
+     * mask last came off, not the first time it did. */
+    assert(last == edf_find_mask_off_time(p));
+}
+
+static void test_wf_events_must_be_an_array(void)
+{
+    char p[400];
+    /* "events" as an OBJECT. cJSON_GetArraySize counts an object's children too,
+     * so a mutant that drops the IsArray half of the guard walks into it and
+     * finds the MaskOn inside. */
+    wf_path(p, sizeof(p), "wf_events_obj.jsonl");
+    wf_write(p,
+        "{\"params\":{\"events\":{\"x\":{\"event\":\"MaskOn\","
+        "\"reportTime\":\"2026-09-01T22:00:00.000\"}}}}\n");
+    assert(edf_find_mask_on_time(p) == -1);
+
+    wf_path(p, sizeof(p), "wf_events_obj_off.jsonl");
+    wf_write(p,
+        "{\"params\":{\"events\":{\"x\":{\"event\":\"MaskOff\","
+        "\"reportTime\":\"2026-09-02T06:00:00.000\"}}}}\n");
+    assert(edf_find_mask_off_time(p) == -1);
+}
+
+static void test_wf_a_non_string_label_is_skipped(void)
+{
+    char p[400];
+    /* A numeric "event". The guard is `!label || !cJSON_IsString(label)`; turn
+     * that `||` into `&&` and a number reaches strcmp(label->valuestring, ...)
+     * with valuestring NULL. */
+    wf_path(p, sizeof(p), "wf_label_num.jsonl");
+    wf_write(p, "{\"params\":{\"events\":[{\"event\":123,"
+                "\"reportTime\":\"2026-09-01T22:00:00.000\"}]}}\n");
+    assert(edf_find_mask_on_time(p) == -1);
+    assert(edf_find_mask_off_time(p) == -1);
+}
+
+static void test_wf_a_non_string_report_time_is_skipped(void)
+{
+    char p[400];
+    /* A numeric "reportTime" behind a matching label. Dropping the IsString half
+     * of `rt && cJSON_IsString(rt)` hands a NULL to the ISO-8601 parser. */
+    wf_path(p, sizeof(p), "wf_rt_num.jsonl");
+    wf_write(p, "{\"params\":{\"events\":[{\"event\":\"MaskOn\","
+                "\"reportTime\":99999}]}}\n");
+    assert(edf_find_mask_on_time(p) == -1);
+
+    wf_path(p, sizeof(p), "wf_rt_num_off.jsonl");
+    wf_write(p, "{\"params\":{\"events\":[{\"event\":\"MaskOff\","
+                "\"reportTime\":99999}]}}\n");
+    assert(edf_find_mask_off_time(p) == -1);
+}
+
+/* ---- edf_find_zle_edge_time --------------------------------------------------- */
+
+static void test_wf_zle_only_reads_zle_records(void)
+{
+    char p[400];
+    /* dataId is present but is not _ZLE. The guard is
+     * `data_id && cJSON_IsString(data_id) && strcmp(...) == 0`; turning the
+     * first && into || makes it `data_id || (IsString && strcmp == 0)`, so ANY
+     * record with a dataId is treated as a ZLE record. */
+    wf_path(p, sizeof(p), "wf_zle_other.jsonl");
+    wf_write(p,
+        "{\"params\":{\"dataId\":\"OTHER\",\"events\":[{\"value\":1,"
+        "\"reportTime\":\"2026-09-01T22:00:00.000\"}]}}\n");
+    assert(edf_find_zle_edge_time(p, 1, 0) == -1);
+}
+
+static void test_wf_zle_value_must_be_a_number(void)
+{
+    char p[400];
+    /* "value" as a STRING. `val && cJSON_IsNumber(val) && ...` with the first
+     * && turned into || accepts it, because val is merely non-NULL. */
+    wf_path(p, sizeof(p), "wf_zle_valstr.jsonl");
+    wf_write(p,
+        "{\"params\":{\"dataId\":\"_ZLE\",\"events\":[{\"value\":\"1\","
+        "\"reportTime\":\"2026-09-01T22:00:00.000\"}]}}\n");
+    assert(edf_find_zle_edge_time(p, 1, 0) == -1);
+}
+
+static void test_wf_zle_falls_back_to_ntp_when_report_time_is_unusable(void)
+{
+    char p[400];
+    /* A numeric reportTime is not a string, so the AS11 path is skipped and the
+     * ntpTimeMs fallback answers. Dropping the IsString check parses NULL. */
+    wf_path(p, sizeof(p), "wf_zle_ntp.jsonl");
+    wf_write(p,
+        "{\"params\":{\"dataId\":\"_ZLE\",\"events\":[{\"value\":1,"
+        "\"reportTime\":7,\"ntpTimeMs\":1756000000000}]}}\n");
+    assert(edf_find_zle_edge_time(p, 1, 0) == 1756000000000LL);
+}
+
+static void test_wf_zle_clock_drift_is_added_to_the_as11_time(void)
+{
+    char p[400];
+    wf_path(p, sizeof(p), "wf_zle_drift.jsonl");
+    wf_write(p,
+        "{\"params\":{\"dataId\":\"_ZLE\",\"events\":[{\"value\":1,"
+        "\"reportTime\":\"2026-09-01T22:00:00.000\"}]}}\n");
+    int64_t zero = edf_find_zle_edge_time(p, 1, 0);
+    int64_t plus = edf_find_zle_edge_time(p, 1, 4321);
+    assert(zero > 0);
+    assert(plus - zero == 4321);
+}
+
+/* Round two: the guards that a single malformed record cannot separate.
+ *
+ * `rt && cJSON_IsString(rt)` weakened to `||` still yields -1 on a file whose
+ * only MaskOn has a numeric reportTime, because the parser hands back a failure
+ * for the NULL valuestring and -1 is what the caller would have returned anyway.
+ * The two versions diverge only when a USABLE record follows a broken one:
+ * MaskOn returns on its first match, so the mutant returns -1 and never reaches
+ * the good line; MaskOff keeps the last, so the mutant overwrites a good time
+ * with -1. Each therefore needs the bad record on the side its function cares
+ * about. */
+
+static void test_wf_mask_on_survives_a_broken_record_before_a_good_one(void)
+{
+    char p[400];
+    wf_path(p, sizeof(p), "wf_on_bad_then_good.jsonl");
+    wf_write(p,
+        "{\"params\":{\"events\":[{\"event\":\"MaskOn\",\"reportTime\":99999}]}}\n"
+        "{\"params\":{\"events\":[{\"event\":\"MaskOn\","
+        "\"reportTime\":\"2026-09-01T22:00:00.000\"}]}}\n");
+    int64_t got = edf_find_mask_on_time(p);
+    wf_path(p, sizeof(p), "wf_on_good_only.jsonl");
+    wf_write(p,
+        "{\"params\":{\"events\":[{\"event\":\"MaskOn\","
+        "\"reportTime\":\"2026-09-01T22:00:00.000\"}]}}\n");
+    assert(got > 0);
+    assert(got == edf_find_mask_on_time(p));
+}
+
+static void test_wf_mask_off_survives_a_broken_record_after_a_good_one(void)
+{
+    char p[400];
+    wf_path(p, sizeof(p), "wf_off_good_then_bad.jsonl");
+    wf_write(p,
+        "{\"params\":{\"events\":[{\"event\":\"MaskOff\","
+        "\"reportTime\":\"2026-09-02T06:00:00.000\"}]}}\n"
+        "{\"params\":{\"events\":[{\"event\":\"MaskOff\",\"reportTime\":99999}]}}\n");
+    int64_t got = edf_find_mask_off_time(p);
+    wf_path(p, sizeof(p), "wf_off_good_only.jsonl");
+    wf_write(p,
+        "{\"params\":{\"events\":[{\"event\":\"MaskOff\","
+        "\"reportTime\":\"2026-09-02T06:00:00.000\"}]}}\n");
+    assert(got > 0);
+    assert(got == edf_find_mask_off_time(p));
+}
+
+static void test_wf_zle_events_must_be_an_array(void)
+{
+    char p[400];
+    /* The same object-shaped events as the MaskOn case, but inside a _ZLE
+     * record — a separate copy of the guard, and it needed its own test. */
+    wf_path(p, sizeof(p), "wf_zle_events_obj.jsonl");
+    wf_write(p,
+        "{\"params\":{\"dataId\":\"_ZLE\",\"events\":{\"x\":{\"value\":1,"
+        "\"ntpTimeMs\":1756000000000}}}}\n");
+    assert(edf_find_zle_edge_time(p, 1, 0) == -1);
+}
+
+static void test_wf_zle_rejects_a_zero_ntp_time(void)
+{
+    char p[400];
+    /* ntpTimeMs of 0 is not a time, it is an unset field. `cand > 0` weakened to
+     * `>= 0` accepts it and reports the epoch as a ZLE edge. */
+    wf_path(p, sizeof(p), "wf_zle_ntp_zero.jsonl");
+    wf_write(p,
+        "{\"params\":{\"dataId\":\"_ZLE\",\"events\":[{\"value\":1,"
+        "\"ntpTimeMs\":0}]}}\n");
+    assert(edf_find_zle_edge_time(p, 1, 0) == -1);
+}
+
+static void test_wf_zle_an_epoch_report_time_is_not_a_time(void)
+{
+    char p[400];
+    /* A reportTime that parses to 0 must not become `0 + drift`. `as11_ms > 0`
+     * weakened to `>= 0` turns an unset timestamp into a real-looking edge
+     * exactly one drift away from the epoch. The ntpTimeMs here is what the
+     * function SHOULD fall back to, so the assertion names the right answer
+     * rather than merely rejecting the wrong one. */
+    wf_path(p, sizeof(p), "wf_zle_epoch.jsonl");
+    wf_write(p,
+        "{\"params\":{\"dataId\":\"_ZLE\",\"events\":[{\"value\":1,"
+        "\"reportTime\":\"1970-01-01T00:00:00.000\","
+        "\"ntpTimeMs\":1756000000000}]}}\n");
+    assert(edf_find_zle_edge_time(p, 1, 60000) == 1756000000000LL);
+}
+
+static void test_wf_zle_a_drift_cancelled_time_is_not_a_time(void)
+{
+    char p[400], q[400];
+    /* THE ONE CASE WHERE cand IS EXACTLY ZERO. `cand < 0` weakened to `<= 0`
+     * makes a drift that happens to cancel the AS11 timestamp fall through to
+     * the ntpTimeMs fallback — so a computed zero silently becomes a different
+     * clock's answer instead of being rejected.
+     *
+     * The drift is derived at run time rather than hard-coded, because the AS11
+     * time depends on the host timezone and pinning it would make this test a
+     * clock test. */
+    wf_path(p, sizeof(p), "wf_zle_drift_probe.jsonl");
+    wf_write(p,
+        "{\"params\":{\"dataId\":\"_ZLE\",\"events\":[{\"value\":1,"
+        "\"reportTime\":\"2026-09-01T22:00:00.000\"}]}}\n");
+    int64_t as11 = edf_find_zle_edge_time(p, 1, 0);
+    assert(as11 > 0);
+
+    wf_path(q, sizeof(q), "wf_zle_cancel.jsonl");
+    wf_write(q,
+        "{\"params\":{\"dataId\":\"_ZLE\",\"events\":[{\"value\":1,"
+        "\"reportTime\":\"2026-09-01T22:00:00.000\","
+        "\"ntpTimeMs\":1756000000000}]}}\n");
+    /* as11 + (-as11) == 0, which is not a time. The ntp value must NOT rescue it:
+     * the AS11 path answered, and it answered zero. */
+    assert(edf_find_zle_edge_time(q, 1, -as11) == -1);
+}
+
 int main(void)
 {
     snprintf(g_root, sizeof(g_root), "%s/snt_edf_test_XXXXXX",
@@ -1326,6 +1673,35 @@ int main(void)
         test_identification_absent_fields_are_empty_or_zero, NULL);
     run("a missing identification.json is refused and writes nothing",
         test_identification_missing_source_is_refused, NULL);
+
+    run("snt_available_samples refuses 0 channels and an empty file is 0",
+        test_wf_available_samples_guards, NULL);
+    run("MaskOn and MaskOff are read from the event file",
+        test_wf_mask_times_are_found, NULL);
+    run("MaskOn takes the first match", test_wf_mask_on_last_wins_is_first_wins, NULL);
+    run("MaskOff takes the last match", test_wf_mask_off_takes_the_last, NULL);
+    run("an events object is not an events array", test_wf_events_must_be_an_array, NULL);
+    run("a non-string event label is skipped", test_wf_a_non_string_label_is_skipped, NULL);
+    run("a non-string reportTime is skipped",
+        test_wf_a_non_string_report_time_is_skipped, NULL);
+    run("_ZLE search ignores other dataIds", test_wf_zle_only_reads_zle_records, NULL);
+    run("_ZLE value must be a number", test_wf_zle_value_must_be_a_number, NULL);
+    run("_ZLE falls back to ntpTimeMs",
+        test_wf_zle_falls_back_to_ntp_when_report_time_is_unusable, NULL);
+    run("_ZLE adds the clock drift to the AS11 time",
+        test_wf_zle_clock_drift_is_added_to_the_as11_time, NULL);
+
+    run("MaskOn skips a broken record and finds the next",
+        test_wf_mask_on_survives_a_broken_record_before_a_good_one, NULL);
+    run("MaskOff is not overwritten by a broken later record",
+        test_wf_mask_off_survives_a_broken_record_after_a_good_one, NULL);
+    run("_ZLE events object is not an array", test_wf_zle_events_must_be_an_array, NULL);
+    run("_ZLE rejects a zero ntpTimeMs", test_wf_zle_rejects_a_zero_ntp_time, NULL);
+    run("_ZLE epoch reportTime falls through to ntp",
+        test_wf_zle_an_epoch_report_time_is_not_a_time, NULL);
+
+    run("_ZLE rejects an AS11 time cancelled by the drift",
+        test_wf_zle_a_drift_cancelled_time_is_not_a_time, NULL);
 
     if (!getenv("KEEP_TEST_TREE")) rmtree(g_root);
     else printf("test tree kept at %s\n", g_root);

--- a/scripts/mutants.py
+++ b/scripts/mutants.py
@@ -132,6 +132,19 @@ MUTANTS = [
      "if (as11_time_get_offset(&off)) {",
      "if (!as11_time_get_offset(&off)) {",
      "offset used only when it is absent — the two branches swapped"),
+    # WAS CLASSIFIED EQUIVALENT AND WAS NOT. The old note said "a 0-channel file is
+    # refused by the channel-map / channel-count check before it gets here" — true of
+    # the CALLER, edf_convert_snt_to_edf, which never passes 0. It was never true of
+    # snt_available_samples itself, which divides by `channels_in_file * 2`. The guard
+    # was unreachable through the only path that existed, and unreachable is not
+    # equivalent: a second caller, or a refactor of the first, meets a division by zero.
+    # A direct unit test now reaches it, the suite kills the mutant, and mutants.py
+    # reported the claim REFUTED — which is the mechanism working, so the claim moved
+    # here rather than the test being weakened.
+    ("zero-channels-divides", "edf_waveform.c",
+     "if (!f || channels_in_file <= 0) return UINT32_MAX;",
+     "if (!f || channels_in_file < 0) return UINT32_MAX;",
+     "0 channels reaches `data_bytes / (channels * 2)` — a division by zero"),
 ]
 
 # Survivors that were measured, read, and judged unable to change behaviour.
@@ -139,10 +152,6 @@ MUTANTS = [
 # is still run, and a mutant here that the suite KILLS is reported as REFUTED,
 # which means this comment is what needs fixing, not the test.
 EQUIVALENT = [
-    ("eq-zero-channels", "edf_waveform.c",
-     "if (!f || channels_in_file <= 0) return UINT32_MAX;",
-     "if (!f || channels_in_file < 0) return UINT32_MAX;",
-     "a 0-channel file is refused by the channel-map / channel-count check before it gets here"),
     ("eq-header-only", "edf_waveform.c",
      "if (end <= (long)sizeof(snt_header_t)) return 0;",
      "if (end < (long)sizeof(snt_header_t)) return 0;",

--- a/scripts/mutate_equivalent.txt
+++ b/scripts/mutate_equivalent.txt
@@ -33,3 +33,12 @@ main/as11_time.c:326:relational:<→<=       # parse_iso8601: the two sscanf for
 main/as11_time.c:330:relational:<→<=       # ...and the retry can never return 6 when the first returned < 6, so the
 #   inner `if (n < 6) return -1` fires whenever reached. (The retry block is dead code; a finding
 #   for upstream, not a test gap.)
+
+# edf_write_field's clamp. `len > width` vs `len >= width`: at len == width the mutant
+# assigns width to a variable that already holds width. Every other value takes the same
+# branch in both. The assignment is a no-op, so no input can separate them.
+main/edf_header.c:71:relational:>→>=
+# edf_open_atomic_file's snprintf guard. `written < 0` vs `written <= 0`: they differ only
+# at written == 0, and the format is "%s.tmp", so snprintf returns at least 4 for every
+# path including "". Zero is unreachable, so the extra case the mutant adds is never taken.
+main/edf_header.c:84:relational:<→<=

--- a/scripts/mutate_equivalent.txt
+++ b/scripts/mutate_equivalent.txt
@@ -42,3 +42,28 @@ main/edf_header.c:71:relational:>→>=
 # at written == 0, and the format is "%s.tmp", so snprintf returns at least 4 for every
 # path including "". Zero is unreachable, so the extra case the mutant adds is never taken.
 main/edf_header.c:84:relational:<→<=
+
+# edf_waveform.c — the six that no input can separate, after eleven of the eighteen
+# survivors in this file were killed by the tests added alongside these entries.
+#
+# snt_available_samples: `end <= sizeof(snt_header_t)` vs `<`. At end == sizeof the mutant
+# skips the early return, computes data_bytes = 0, and 0 / frame is 0 — the same value the
+# early return provides.
+main/edf_waveform.c:40:relational:<=→<
+# The three event loops: `i < n` vs `i <= n`. cJSON_GetArrayItem(events, n) returns NULL for
+# an out-of-range index and the next statement is `if (!ev) continue;`, so the extra
+# iteration does nothing and cannot be observed.
+main/edf_waveform.c:63:relational:<→<=
+main/edf_waveform.c:101:relational:<→<=
+main/edf_waveform.c:140:relational:<→<=
+# edf_find_zle_edge_time's reportTime guard: `rt && cJSON_IsString(rt)` vs `||`. With a
+# non-string rt the mutant enters and parses rt->valuestring, which is NULL for a number;
+# the parser returns a non-positive value, so `as11_ms > 0` fails and cand stays -1 —
+# exactly where the original leaves it by skipping the block. The ntpTimeMs fallback then
+# answers in both. Demonstrated by the "_ZLE falls back to ntpTimeMs" test, which passes
+# unchanged under this mutant.
+main/edf_waveform.c:148:logical:&&→||
+# The ntp guard: `ntp && cJSON_IsNumber(ntp)` vs `||`. A non-number ntpTimeMs has
+# valuedouble 0, so the mutant sets cand = 0 and the following `cand > 0` rejects it —
+# the same outcome as never entering.
+main/edf_waveform.c:156:logical:&&→||

--- a/scripts/mutate_host.py
+++ b/scripts/mutate_host.py
@@ -93,6 +93,65 @@ def target_path(entry: str) -> str:
     return entry[1:] if entry.startswith("#") else entry
 
 EQUIV_FILE = os.path.join(HERE, "mutate_equivalent.txt")
+SURVIVOR_FILE = os.path.join(HERE, "mutation_survivors.txt")
+
+
+def environment_is_complete() -> tuple[bool, str]:
+    """(may this run rewrite the inventory, and if not why not).
+
+    ⚠️ A NARROWER ENVIRONMENT SEES FEWER SURVIVORS. Without cJSON the two EDF suites are
+    skipped and this harness reports SCOPE 2 of 80 instead of 8; every survivor in the five
+    EDF modules simply is not found. Writing the inventory from that run would DELETE those
+    entries, and the diff would read exactly like someone had fixed them.
+
+    So the inventory may only be written where the whole suite builds. Refusing is the
+    feature: an inventory that quietly narrows is worse than no inventory, because it is
+    trusted."""
+    skipped = sorted(t for t in TESTS if sources_for(t) is None)
+    if skipped:
+        return False, "these suites could not be built: " + ", ".join(skipped)
+    if not shutil.which("gcov"):
+        return False, ("gcov is absent, so reach is unknown and every mutant is run and "
+                       "classified UNASSERTED rather than UNREACHED")
+    return True, ""
+
+
+def load_inventory() -> dict[str, str]:
+    out = {}
+    if os.path.exists(SURVIVOR_FILE):
+        for line in open(SURVIVOR_FILE, encoding="utf-8"):
+            key = line.split("#", 1)[0].strip()
+            if key:
+                out[key] = line.split("#", 1)[1].strip() if "#" in line else ""
+    return out
+
+
+def write_inventory(entries: dict[str, str]) -> None:
+    with open(SURVIVOR_FILE, "w", encoding="utf-8", newline="\n") as f:
+        f.write(
+            "# UNASSERTED survivors: mutants that RAN and that every host test still passed.\n"
+            "# Committed on purpose. A gitignored copy would exist only on the machine that\n"
+            "# produced it, and the useful property of this file is that a pull request which\n"
+            "# weakens an assertion ADDS A LINE HERE, next to the change that caused it —\n"
+            "# visible in review without anyone running the sweep.\n"
+            "#\n"
+            "# NOT a list of bugs, and not a to-do list. A survivor means the suite does not\n"
+            "# distinguish this mutant from the original; whether that matters is a judgement\n"
+            "# each one needs on its own. A mutant no input can kill belongs in\n"
+            "# mutate_equivalent.txt instead, with the argument written down.\n"
+            "#\n"
+            "# Regenerate with:  python3 scripts/mutate_host.py --all --write-inventory\n"
+            "# It REFUSES on a machine where any suite is skipped — see environment_is_complete().\n"
+            "#\n"
+            "# Format:  <path>:<line>:<operator>      # the line as it stands today\n"
+            "\n")
+        # path:line:operator — and the OPERATOR CONTAINS COLONS ("arithmetic:+→-"), so this
+        # splits from the left with maxsplit=2. rsplit here silently sorted by the wrong
+        # field and then crashed on int().
+        for key in sorted(entries, key=lambda k: (k.split(":", 2)[0], int(k.split(":", 2)[1]))):
+            src = entries[key]
+            f.write(f"{key}\n" if not src else f"{key:<52} # {src}\n")
+
 
 
 def find_cjson() -> str | None:
@@ -552,6 +611,9 @@ def main() -> int:
     ap.add_argument("--limit", type=int, default=25, help="max mutants per file")
     ap.add_argument("--selftest", action="store_true")
     ap.add_argument("--cjson", help="path to cJSON.c when it is not beside the project")
+    ap.add_argument("--write-inventory", action="store_true",
+                    help="rewrite scripts/mutation_survivors.txt from this run; needs --all, "
+                         "and refuses where any suite is skipped")
     a = ap.parse_args()
 
     global CJSON
@@ -597,6 +659,7 @@ def main() -> int:
 
     equivs = load_equivalents()
     total_surv = 0
+    all_surv: dict[str, str] = {}
     for t in targets:
         if not os.path.exists(t):
             print(f"\n{t}: not found"); return 3
@@ -627,10 +690,43 @@ def main() -> int:
             print(f"     ·  UNREACHED   {r['file']}:{ln}  {op}   {src}")
         if len(r["unreached"]) > 10:
             print(f"     ·  … and {len(r['unreached']) - 10} more unreached")
+        for ln, op, src in r["unasserted"]:
+            all_surv[f"{r['file']}:{ln}:{op}"] = src.strip()
         total_surv += len(r["unasserted"])
 
     print(f"\n{total_surv} unasserted survivor(s)")
     print("UNREACHED lines need a test that reaches them; UNASSERTED need a stronger assertion.")
+
+    complete, why = environment_is_complete()
+    if a.write_inventory:
+        if not a.all:
+            print("\nREFUSED: --write-inventory needs --all. A single file cannot rewrite the "
+                  "whole inventory\n         without deleting every entry it did not look at.")
+            return 4
+        if not complete:
+            print(f"\nREFUSED to write {os.path.relpath(SURVIVOR_FILE, ROOT)}: {why}")
+            print("         This run saw less than the full suite, so writing would delete "
+                  "entries it never\n         looked for — a diff that reads exactly like "
+                  "someone had fixed them.")
+            return 4
+        write_inventory(all_surv)
+        print(f"\nwrote {os.path.relpath(SURVIVOR_FILE, ROOT)} — {len(all_surv)} survivor(s)")
+    elif a.all and os.path.exists(SURVIVOR_FILE):
+        known = load_inventory()
+        added = sorted(set(all_surv) - set(known))
+        gone = sorted(set(known) - set(all_surv))
+        print(f"\nINVENTORY  {len(known)} known, {len(added)} new, {len(gone)} no longer found")
+        if not complete:
+            print(f"           ⚠️ comparison is UNRELIABLE here: {why}")
+            print("           Entries under 'no longer found' may simply not have been looked for.")
+        for k in added:
+            print(f"     + NEW       {k}   {all_surv[k]}")
+        for k in gone:
+            print(f"     - was here  {k}")
+        if added:
+            print("           A new survivor is an assertion that stopped distinguishing "
+                  "something.\n           Regenerate with --all --write-inventory once it is "
+                  "understood, not before.")
     return 1 if total_surv else 0
 
 

--- a/scripts/mutate_host.py
+++ b/scripts/mutate_host.py
@@ -212,6 +212,35 @@ def find_cjson_system() -> str | None:
 CJSON_SYS = find_cjson_system()
 
 
+def sanitizer_flags() -> list[str]:
+    """-fsanitize flags when this toolchain has them, else nothing.
+
+    The harness must build the way scripts/run_host_tests.sh builds, or its verdict is
+    about a different program. It matters more here than there: a mutation that corrupts
+    memory rather than changing an answer survives a suite that only checks answers.
+    Three did in edf_header.c -- a malloc one element short, and a header field written
+    88 bytes BEFORE a stack array -- and all three die under AddressSanitizer.
+
+    Probed once, by compiling. Asking the compiler is cheaper than maintaining a list of
+    which versions support what, and it cannot be wrong."""
+    if os.environ.get("SNT_NO_SANITIZE"):
+        return []
+    d = tempfile.mkdtemp(prefix="sancheck-")
+    try:
+        src = os.path.join(d, "t.c")
+        with open(src, "w", encoding="utf-8") as f:
+            f.write("int main(void){return 0;}\n")
+        r = subprocess.run(["gcc", "-fsanitize=address,undefined",
+                            "-o", os.path.join(d, "t"), src],
+                           capture_output=True)
+        return ["-fsanitize=address,undefined", "-fno-omit-frame-pointer"] if r.returncode == 0 else []
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+
+SANITIZE = sanitizer_flags()
+
+
 def sources_for(test: str) -> list[str] | None:
     out = []
     for s in TESTS[test]:
@@ -234,6 +263,7 @@ def build(test: str, outdir: str, coverage: bool = False) -> str | None:
         return None
     exe = os.path.join(outdir, test)
     cmd = ["gcc", "-O0", "-o", exe, os.path.join(HERE, test + ".c"), *src]
+    cmd += SANITIZE
     if coverage:
         cmd += ["--coverage"]
     # Header order depends on what the test links, and it has to.
@@ -626,6 +656,9 @@ def main() -> int:
     outdir = tempfile.mkdtemp(prefix="snt-mutate-")
     print("cJSON: " + (CJSON or (f"-lcjson from {CJSON_SYS}" if CJSON_SYS else
                                  "<not found — tests needing it are SKIPPED, not failed>")))
+    print("SANITIZE: " + (" ".join(SANITIZE) if SANITIZE else
+                          "<none — a mutant that corrupts memory instead of changing an "
+                          "answer may survive>"))
 
     if a.selftest:
         return selftest(outdir)

--- a/scripts/mutate_host.py
+++ b/scripts/mutate_host.py
@@ -422,6 +422,24 @@ OPS: list[tuple[str, str, str]] = [
 
 SKIP_LINE = re.compile(r'^\s*(//|/\*|\*|#include|#pragma)')
 
+# Where a TRAILING comment starts. SKIP_LINE above only catches a comment that begins a
+# line, so an operator inside `x = y;  /* >= 0 here */` was fair game and got mutated —
+# producing a byte-identical program that every test passes, reported as a survivor.
+# Measured on this tree: 392 lines across 22 files in main/ carry a mutable operator in a
+# trailing comment and could each generate one of these.
+#
+# Taking the FIRST /* or // as the boundary is deliberately conservative. A line like
+# `a /* note */ + b` stops being mutated after the comment, so the count can only go down,
+# never wrong: a mutant not generated costs a little coverage, a mutant that cannot fail
+# costs the reader's trust in every other line of the report.
+_COMMENT_START = re.compile(r'/\*|//')
+
+
+def code_of(line: str) -> str:
+    """The part of a source line before any trailing comment."""
+    m = _COMMENT_START.search(line)
+    return line[:m.start()] if m else line
+
 
 def load_equivalents() -> set[str]:
     out = set()
@@ -441,9 +459,13 @@ def gen_mutants(path: str, limit: int) -> list[tuple[int, str, str, str]]:
     for i, line in enumerate(lines, 1):
         if SKIP_LINE.match(line) or '"' in line:
             continue          # string literals: a changed message is not a behaviour change
+        code = code_of(line)
         for a, b, name in OPS:
-            if a in line:
-                out.append((i, f"{name}:{a.strip()}→{b.strip()}", line, line.replace(a, b, 1)))
+            if a in code:
+                # Rebuild the line so the comment survives byte-for-byte: only the code
+                # half is edited, and only its first occurrence, exactly as before.
+                mutated = code.replace(a, b, 1) + line[len(code):]
+                out.append((i, f"{name}:{a.strip()}→{b.strip()}", line, mutated))
                 break
         if len(out) >= limit:
             break
@@ -457,6 +479,63 @@ def gen_mutants(path: str, limit: int) -> list[tuple[int, str, str, str]]:
 # or void, and many split their parameters across lines.
 _DEF = re.compile(r'^[A-Za-z_][A-Za-z0-9_ \t\*]*\b(\w+)\s*\(')
 _NOT_A_DEF = re.compile(r'^\s*(if|for|while|switch|return|else|do|typedef|struct|enum|union)\b')
+
+
+def self_test() -> int:
+    """Assertions on the textual layer — the part with no compiler to catch it.
+
+    Everything else here is checked by running: a bad mutant fails to build and is counted
+    stillborn. gen_mutants has no such backstop, because a mutant it generates wrongly still
+    compiles — that is exactly how the trailing-comment bug produced survivors nobody could
+    kill. So this is the piece that needs pinning."""
+    fails = []
+
+    def eq(what, got, want):
+        if got != want:
+            fails.append(f"{what}: got {got!r}, want {want!r}")
+
+    eq("code_of: no comment", code_of("    if (a >= b) {\n"), "    if (a >= b) {\n")
+    eq("code_of: block comment", code_of("    x = 1;  /* >= 0 */\n"), "    x = 1;  ")
+    eq("code_of: line comment", code_of("    x = 1;  // >= 0\n"), "    x = 1;  ")
+    eq("code_of: whole-line comment", code_of("  /* >= */\n"), "  ")
+
+    d = tempfile.mkdtemp(prefix="selftest-")
+    try:
+        p = os.path.join(d, "t.c")
+        with open(p, "w", encoding="utf-8") as f:
+            f.write("int f(int a, int b)\n"                  # 1
+                    "{\n"                                     # 2
+                    "    int n = a - 1;     /* >= 0 always */\n"  # 3
+                    "    if (a > b) return 1;\n"              # 4
+                    "    return 0;\n"                         # 5
+                    "}\n")                                    # 6
+        got = gen_mutants(p, 100)
+        lines_hit = sorted(m[0] for m in got)
+
+        # Line 3's only >= is inside the comment; its CODE has a '-', which is a real
+        # operator, so line 3 is still mutated -- on the minus, not on the comment.
+        m3 = [m for m in got if m[0] == 3]
+        eq("line 3 produces one mutant", len(m3), 1)
+        if m3:
+            eq("line 3 mutates the code operator", m3[0][1], "arithmetic:-→+")
+            eq("line 3 keeps its comment", m3[0][3].endswith("/* >= 0 always */\n"), True)
+        m4 = [m for m in got if m[0] == 4]
+        eq("line 4 mutates the comparison", m4[0][1] if m4 else None, "relational:>→>=")
+        eq("no mutant on a brace-only line", 2 in lines_hit, False)
+
+        # A line whose ONLY operator lives in the comment must yield nothing at all.
+        p2 = os.path.join(d, "u.c")
+        with open(p2, "w", encoding="utf-8") as f:
+            f.write("void g(void)\n{\n    step();      /* runs when n >= 2 */\n}\n")
+        eq("comment-only operator generates no mutant",
+           [m[0] for m in gen_mutants(p2, 100)], [])
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+    for f in fails:
+        print(f"  FAIL {f}")
+    print(f"mutate_host self-test: {'PASS' if not fails else str(len(fails)) + ' FAILED'}")
+    return 1 if fails else 0
 
 
 def canary_for(path: str, lines: list[str]) -> tuple[int, str, str] | None:
@@ -641,6 +720,8 @@ def main() -> int:
     ap.add_argument("--limit", type=int, default=25, help="max mutants per file")
     ap.add_argument("--selftest", action="store_true")
     ap.add_argument("--cjson", help="path to cJSON.c when it is not beside the project")
+    ap.add_argument("--self-test", action="store_true",
+                    help="check the textual mutation layer and exit; no compiler needed")
     ap.add_argument("--write-inventory", action="store_true",
                     help="rewrite scripts/mutation_survivors.txt from this run; needs --all, "
                          "and refuses where any suite is skipped")
@@ -649,6 +730,9 @@ def main() -> int:
     global CJSON
     if a.cjson:
         CJSON = a.cjson
+
+    if a.self_test:
+        return self_test()
 
     if not shutil.which("gcc"):
         print("gcc not found", file=sys.stderr)

--- a/scripts/mutation_survivors.txt
+++ b/scripts/mutation_survivors.txt
@@ -1,0 +1,56 @@
+# UNASSERTED survivors: mutants that RAN and that every host test still passed.
+# Committed on purpose. A gitignored copy would exist only on the machine that
+# produced it, and the useful property of this file is that a pull request which
+# weakens an assertion ADDS A LINE HERE, next to the change that caused it —
+# visible in review without anyone running the sweep.
+#
+# NOT a list of bugs, and not a to-do list. A survivor means the suite does not
+# distinguish this mutant from the original; whether that matters is a judgement
+# each one needs on its own. A mutant no input can kill belongs in
+# mutate_equivalent.txt instead, with the argument written down.
+#
+# Regenerate with:  python3 scripts/mutate_host.py --all --write-inventory
+# It REFUSES on a machine where any suite is skipped — see environment_is_complete().
+#
+# Format:  <path>:<line>:<operator>      # the line as it stands today
+
+main/edf_annotations.c:63:arithmetic:-→+             # strncpy(path, edf_path, sizeof(path) - 1);
+main/edf_annotations.c:64:arithmetic:-→+             # path[sizeof(path) - 1] = '\0';
+main/edf_annotations.c:68:arithmetic:*→/             # snt_event_t *ev_list = malloc(capacity * sizeof(snt_event_t));
+main/edf_annotations.c:83:logical:&&→||              # if (data_id && cJSON_IsString(data_id)) {
+main/edf_annotations.c:151:relational:<→<=           # for (size_t i = 0; i + 1 < count; i++) {
+main/edf_gen.c:111:logical:||→&&                     # if (!session_dir || !session_id || !out_root) return ESP_ERR_INVALID_A
+main/edf_gen.c:126:relational:<→<=                   # if (start_epoch_ms < 946684800000LL) {  /* < 2000-01-01T00:00:00Z */
+main/edf_gen.c:161:arithmetic:-→+                    # as11_time_noon_day(start_epoch_ms - clock_drift_ms, day_folder, sizeof
+main/edf_gen.c:245:relational:<→<=                   # if (zle_ntp > 0 && zle_ntp > start_epoch_ms && zle_ntp < end_epoch_ms)
+main/edf_gen.c:258:relational:>→>=                   # if (zle_ntp > 0) {
+main/edf_gen.c:269:relational:>→>=                   # if (maskon_as11 > 0) {
+main/edf_gen.c:270:arithmetic:+→-                    # int64_t maskon_ntp = maskon_as11 + clock_drift_ms;
+main/edf_gen.c:271:relational:<→<=                   # if (maskon_ntp > start_epoch_ms && maskon_ntp < end_epoch_ms) {
+main/edf_gen.c:309:relational:<=→<                   # if (end_ntp <= 0) {
+main/edf_gen.c:311:relational:>→>=                   # if (maskoff_as11 > 0) {
+main/edf_gen.c:312:arithmetic:+→-                    # end_ntp = maskoff_as11 + clock_drift_ms;
+main/edf_gen.c:316:relational:>→>=                   # if (end_ntp > 0) {
+main/edf_header.c:71:relational:>→>=                 # if (len > width) len = width;
+main/edf_header.c:84:relational:<→<=                 # if (written < 0 || (size_t)written >= tmp_path_len) {
+main/edf_header.c:125:arithmetic:+→-                 # char *buf = malloc(fsize + 1);
+main/edf_header.c:188:arithmetic:+→-                 # edf_write_field(hdr + 88, 80, recording_id);         /* recording ID *
+main/edf_header.c:189:arithmetic:+→-                 # edf_write_field(hdr + 168, 8, start_date);           /* start date */
+main/edf_waveform.c:32:relational:<=→<               # if (!f || channels_in_file <= 0) return UINT32_MAX;
+main/edf_waveform.c:35:relational:<→<=               # if (cur < 0) return UINT32_MAX;
+main/edf_waveform.c:38:relational:<→<=               # if (fseek(f, cur, SEEK_SET) != 0 || end < 0) return UINT32_MAX;
+main/edf_waveform.c:40:relational:<=→<               # if (end <= (long)sizeof(snt_header_t)) return 0;
+main/edf_waveform.c:61:logical:&&→||                 # if (events && cJSON_IsArray(events)) {
+main/edf_waveform.c:63:relational:<→<=               # for (int i = 0; i < n; i++) {
+main/edf_waveform.c:67:logical:||→&&                 # if (!label || !cJSON_IsString(label)) continue;
+main/edf_waveform.c:70:logical:&&→||                 # if (rt && cJSON_IsString(rt)) {
+main/edf_waveform.c:99:logical:&&→||                 # if (events && cJSON_IsArray(events)) {
+main/edf_waveform.c:101:relational:<→<=              # for (int i = 0; i < n; i++) {
+main/edf_waveform.c:105:logical:||→&&                # if (!label || !cJSON_IsString(label)) continue;
+main/edf_waveform.c:108:logical:&&→||                # if (rt && cJSON_IsString(rt)) {
+main/edf_waveform.c:135:logical:&&→||                # if (data_id && cJSON_IsString(data_id) &&
+main/edf_waveform.c:138:logical:&&→||                # if (events && cJSON_IsArray(events)) {
+main/edf_waveform.c:140:relational:<→<=              # for (int i = 0; i < n; i++) {
+main/edf_waveform.c:144:logical:&&→||                # if (val && cJSON_IsNumber(val) &&
+main/edf_waveform.c:148:logical:&&→||                # if (rt && cJSON_IsString(rt)) {
+main/edf_waveform.c:151:relational:>→>=              # if (as11_ms > 0)

--- a/scripts/mutation_survivors.txt
+++ b/scripts/mutation_survivors.txt
@@ -29,21 +29,3 @@ main/edf_gen.c:309:relational:<=→<                   # if (end_ntp <= 0) {
 main/edf_gen.c:311:relational:>→>=                   # if (maskoff_as11 > 0) {
 main/edf_gen.c:312:arithmetic:+→-                    # end_ntp = maskoff_as11 + clock_drift_ms;
 main/edf_gen.c:316:relational:>→>=                   # if (end_ntp > 0) {
-main/edf_waveform.c:32:relational:<=→<               # if (!f || channels_in_file <= 0) return UINT32_MAX;
-main/edf_waveform.c:35:relational:<→<=               # if (cur < 0) return UINT32_MAX;
-main/edf_waveform.c:38:relational:<→<=               # if (fseek(f, cur, SEEK_SET) != 0 || end < 0) return UINT32_MAX;
-main/edf_waveform.c:40:relational:<=→<               # if (end <= (long)sizeof(snt_header_t)) return 0;
-main/edf_waveform.c:61:logical:&&→||                 # if (events && cJSON_IsArray(events)) {
-main/edf_waveform.c:63:relational:<→<=               # for (int i = 0; i < n; i++) {
-main/edf_waveform.c:67:logical:||→&&                 # if (!label || !cJSON_IsString(label)) continue;
-main/edf_waveform.c:70:logical:&&→||                 # if (rt && cJSON_IsString(rt)) {
-main/edf_waveform.c:99:logical:&&→||                 # if (events && cJSON_IsArray(events)) {
-main/edf_waveform.c:101:relational:<→<=              # for (int i = 0; i < n; i++) {
-main/edf_waveform.c:105:logical:||→&&                # if (!label || !cJSON_IsString(label)) continue;
-main/edf_waveform.c:108:logical:&&→||                # if (rt && cJSON_IsString(rt)) {
-main/edf_waveform.c:135:logical:&&→||                # if (data_id && cJSON_IsString(data_id) &&
-main/edf_waveform.c:138:logical:&&→||                # if (events && cJSON_IsArray(events)) {
-main/edf_waveform.c:140:relational:<→<=              # for (int i = 0; i < n; i++) {
-main/edf_waveform.c:144:logical:&&→||                # if (val && cJSON_IsNumber(val) &&
-main/edf_waveform.c:148:logical:&&→||                # if (rt && cJSON_IsString(rt)) {
-main/edf_waveform.c:151:relational:>→>=              # if (as11_ms > 0)

--- a/scripts/mutation_survivors.txt
+++ b/scripts/mutation_survivors.txt
@@ -14,8 +14,6 @@
 #
 # Format:  <path>:<line>:<operator>      # the line as it stands today
 
-main/edf_annotations.c:63:arithmetic:-→+             # strncpy(path, edf_path, sizeof(path) - 1);
-main/edf_annotations.c:64:arithmetic:-→+             # path[sizeof(path) - 1] = '\0';
 main/edf_annotations.c:68:arithmetic:*→/             # snt_event_t *ev_list = malloc(capacity * sizeof(snt_event_t));
 main/edf_annotations.c:83:logical:&&→||              # if (data_id && cJSON_IsString(data_id)) {
 main/edf_annotations.c:151:relational:<→<=           # for (size_t i = 0; i + 1 < count; i++) {
@@ -31,11 +29,6 @@ main/edf_gen.c:309:relational:<=→<                   # if (end_ntp <= 0) {
 main/edf_gen.c:311:relational:>→>=                   # if (maskoff_as11 > 0) {
 main/edf_gen.c:312:arithmetic:+→-                    # end_ntp = maskoff_as11 + clock_drift_ms;
 main/edf_gen.c:316:relational:>→>=                   # if (end_ntp > 0) {
-main/edf_header.c:71:relational:>→>=                 # if (len > width) len = width;
-main/edf_header.c:84:relational:<→<=                 # if (written < 0 || (size_t)written >= tmp_path_len) {
-main/edf_header.c:125:arithmetic:+→-                 # char *buf = malloc(fsize + 1);
-main/edf_header.c:188:arithmetic:+→-                 # edf_write_field(hdr + 88, 80, recording_id);         /* recording ID *
-main/edf_header.c:189:arithmetic:+→-                 # edf_write_field(hdr + 168, 8, start_date);           /* start date */
 main/edf_waveform.c:32:relational:<=→<               # if (!f || channels_in_file <= 0) return UINT32_MAX;
 main/edf_waveform.c:35:relational:<→<=               # if (cur < 0) return UINT32_MAX;
 main/edf_waveform.c:38:relational:<→<=               # if (fseek(f, cur, SEEK_SET) != 0 || end < 0) return UINT32_MAX;

--- a/scripts/run_host_tests.sh
+++ b/scripts/run_host_tests.sh
@@ -118,6 +118,23 @@ run_test() {
     fi
 }
 
+# run_check <name> <command...> — for a check that is not a compiled C test.
+# Shares the counters so one summary line still covers everything that ran.
+run_check() {
+    local name=$1; shift
+    known="$known $name"
+    if [ -n "$ONLY" ] && [ "$ONLY" != "$name" ]; then return; fi
+    ran=$((ran + 1))
+    local log="$OUT/$name.log"
+    if "$@" > "$log" 2>&1; then
+        echo "### $name: PASS  ($(tail -1 "$log"))"
+    else
+        echo "### $name: FAIL"
+        failed=$((failed + 1))
+        [ $QUIET = 1 ] || cat "$log"
+    fi
+}
+
 # skip_test <name> <reason>
 skip_test() {
     known="$known $1"
@@ -148,6 +165,17 @@ if [ -n "$CJ_INC" ]; then
     # upstream's EDF pipeline property suite (54ae598)
     run_test edf_properties_test $CJ_INC -I"$SHIM" -I"$MAIN_DIR" \
         scripts/edf_properties_test.c "$MAIN_DIR/as11_time.c" $CJ_SRC $CJ_LIB -lm
+fi
+
+# The mutation harness's TEXTUAL layer has nothing else to catch a mistake in it. Every
+# other part is checked by running — a badly formed mutant fails to compile and is counted
+# stillborn — but a mutant generated on the wrong part of a line still builds and still
+# passes, which is precisely how operators inside trailing comments produced survivors that
+# no test could ever kill. Needs no compiler, so it runs wherever python3 does.
+if command -v python3 >/dev/null 2>&1; then
+    run_check mutate_host_self_test python3 scripts/mutate_host.py --self-test
+else
+    skip_test mutate_host_self_test "no python3"
 fi
 
 # Roster check: a test file that exists but is not wired in here would never

--- a/scripts/run_host_tests.sh
+++ b/scripts/run_host_tests.sh
@@ -57,6 +57,37 @@ CC=${CC:-gcc}
 CFLAGS="-std=gnu11 -Wall -Wno-unused-function -O1 -g"
 SHIM=scripts/test_include
 
+# ── AddressSanitizer + UndefinedBehaviorSanitizer ────────────────────────────────
+# WHY. Three mutants in edf_header.c survived a green suite by corrupting memory
+# quietly: malloc(fsize + 1) -> (fsize - 1), and edf_write_field(hdr + 88, ...) ->
+# (hdr - 88), which writes 80 bytes BEFORE a 256-byte stack array. Nothing asserted
+# them because nothing crashed -- a heap chunk has slack and a stack write lands on
+# other locals. Under -fsanitize=address the same mutant dies immediately with
+# "stack-buffer-overflow ... in memset".
+#
+# For a firmware project this is the cheap half of the bargain: the host suite runs
+# the SAME C the device runs, on a machine with a MMU and a sanitizer, so the class
+# of bug that is hardest to see on an ESP32-S3 is the class this catches for free.
+#
+# Measured before switching on: the suite already passes clean under both
+# sanitizers, so this reds nothing today. Set SNT_NO_SANITIZE=1 to opt out, and a
+# toolchain without them degrades to a plain build with a note rather than failing
+# -- absence of a sanitizer is not absence of a gate.
+SANITIZE=""
+if [ -z "${SNT_NO_SANITIZE:-}" ]; then
+    printf 'int main(void){return 0;}\n' > "$OUT/.sancheck.c"
+    if $CC -fsanitize=address,undefined -o "$OUT/.sancheck" "$OUT/.sancheck.c" 2>/dev/null; then
+        SANITIZE="-fsanitize=address,undefined -fno-omit-frame-pointer"
+        CFLAGS="$CFLAGS $SANITIZE"
+        echo "sanitizers: address,undefined"
+    else
+        echo "sanitizers: UNAVAILABLE in $CC — building without them"
+    fi
+    rm -f "$OUT/.sancheck" "$OUT/.sancheck.c"
+else
+    echo "sanitizers: disabled by SNT_NO_SANITIZE"
+fi
+
 failed=0
 ran=0
 skipped=0


### PR DESCRIPTION
**Read this first: the bottom five commits of this branch are #256.** GitHub cannot base a cross-fork PR on another PR's head, so they come along. Two ways to take it, whichever suits you:

- merge #256 first and this shrinks to the four commits below, or
- take this one and close #256 as included.

Nothing here is a second version of #256 — it is the same commits plus four more. I am posting it so the work is visible rather than sitting on my fork; there is no hurry on it.

## What is new beyond #256

**`e416fd1` — build the host suite with ASan and UBSan.** `run_host_tests.sh` probes whether the compiler supports `-fsanitize=address,undefined` and enables it when it does, with `SNT_NO_SANITIZE=1` to opt out. Two results, both measured on a 60-run sample:

- five more mutants die — memory-safety bugs that previously produced correct-looking output
- the sweep runs **3× faster**: 387 s → 126 s. A corrupting mutant now aborts in milliseconds instead of running to the 300 s timeout

**`fe8caba` — stop mutating operators inside trailing comments.** `mutate_host.py` was rewriting `+` and `<` that appear in `/* ... */` after code on the same line. Those mutants can never be killed because they change nothing, so they inflated the survivor count and cost a full build each.

**`4311440` — the `edf_waveform.c` event-file guards had no failing input.** Eighteen survivors lived in `edf_find_mask_on_time`, `edf_find_mask_off_time`, `edf_find_zle_edge_time` and `snt_available_samples`. Twelve are now killed by new cases; six are genuinely equivalent and recorded in `mutate_equivalent.txt` with the reason.

One of those tests found a real oracle defect on my side: the CRC test compared the file's bytes against `edf_crc32_ieee()`, so a mutation moved both sides of the comparison equally and three CRC-loop mutants survived a test that looked like it covered them. It now checks the published IEEE value `0xCBF43926`.

**`f1da00c` — `eq-zero-channels` was unreachable, not equivalent.** It was recorded as equivalent; it is actually dead code, which is a different thing and is classified differently by `mutants.py`'s own rule. Reclassified.

## Net effect on the survivor inventory

40 → 33 (sanitizers) → 15 (waveform tests). `scripts/mutation_survivors.txt` is tracked, so a new survivor lands in a diff rather than in a log nobody reads.

## Checks

Full host gate green, mutation gate green, exit codes checked rather than the last line of output.
